### PR TITLE
chore: MySQL 8.0에서 8.4 LTS로 업그레이드

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # MySQL Database
   mysql:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: angple-mysql
     ports:
       - "3307:3306"  # 현세대(3306)와 포트 충돌 방지


### PR DESCRIPTION
- MySQL 8.4는 2032년까지 장기 지원 (8.0은 2026년 4월 EOL)
- 버퍼풀/I/O 성능 향상
- 테스트 완료: API 정상 연결 확인