### PR TITLE
fix: Load Test workflow를 docker-compose.dev.yml 사용하도록 수정

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -41,12 +41,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24'
-        cache: true
-
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -55,25 +49,22 @@ jobs:
     - name: Install locust
       run: pip install -r tests/load/requirements.txt
 
-    - name: Build and start services
-      run: |
-        docker compose up -d mysql redis
-        sleep 10  # Wait for MySQL to be healthy
-        go build -o bin/api cmd/api/main.go
-        ./bin/api &
-        sleep 5  # Wait for API to start
+    - name: Start all services
+      run: docker compose -f docker-compose.dev.yml up -d --build
 
-    - name: Wait for API health
+    - name: Wait for API to be healthy
       run: |
-        for i in {1..30}; do
+        echo "Waiting for all services to be ready..."
+        for i in {1..90}; do
           if curl -s http://localhost:8081/health | grep -q "ok"; then
-            echo "API is healthy"
+            echo "API is healthy!"
             exit 0
           fi
-          echo "Waiting for API... ($i/30)"
+          echo "Waiting for API... ($i/90)"
           sleep 2
         done
-        echo "API failed to start"
+        echo "Services failed to start"
+        docker compose -f docker-compose.dev.yml logs
         exit 1
 
     - name: Run load test
@@ -113,6 +104,4 @@ jobs:
 
     - name: Cleanup
       if: always()
-      run: |
-        pkill -f "./bin/api" || true
-        docker compose down -v || true
+      run: docker compose -f docker-compose.dev.yml down -v || true


### PR DESCRIPTION
변경 사항:
- docker-compose.dev.yml로 MySQL, Redis, API 전체 실행
- Go 빌드를 Docker 컨테이너 내부에서 수행 (setup-go 제거)
- depends_on: service_healthy로 의존성 대기 자동화
- 환경변수 설정을 docker-compose.dev.yml에 위임
- workflow 코드 간소화

이전 문제:
- config.local.yaml 사용으로 포트 불일치 (8083 vs 8081)
- MySQL 연결 실패 (127.0.0.1:3307)
- 수동 healthcheck 스크립트 불안정