### PR TITLE
API 기동 시 DB AutoMigrate 및 기본 시드 자동

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,115 +440,104 @@ export CORS_ALLOW_ORIGINS=https://damoang.net
 
 ---
 
-## 🚀 운영 환경 배포
+## 🚀 운영 환경 배포 (Standalone)
 
-### Docker Compose 사용 (권장)
+전체 스택(MySQL, Redis, API, Gateway, Web, Admin)을 단일 compose로 실행합니다.
 
-1. **운영 서버에 코드 배포**
-   ```bash
-   git clone https://github.com/damoang/angple-backend.git
-   cd angple-backend
-   ```
-
-2. **환경 변수 설정**
-   ```bash
-   # .env.prod 파일 생성
-   cat > .env.prod << 'EOF'
-   APP_ENV=prod
-   DB_HOST=your-production-db-host
-   DB_PORT=3306
-   DB_USER=angple_user
-   DB_PASSWORD=your-secure-password
-   DB_NAME=angple_prod
-   REDIS_HOST=your-redis-host
-   REDIS_PORT=6379
-   JWT_SECRET=your-jwt-secret-key
-   DAMOANG_JWT_SECRET=your-damoang-jwt-secret
-   CORS_ALLOW_ORIGINS=https://damoang.net,https://www.damoang.net
-   EOF
-   ```
-
-3. **Docker Compose 실행**
-   ```bash
-   # 운영 환경 실행
-   docker-compose --env-file .env.prod up -d
-
-   # 로그 확인
-   docker-compose logs -f api
-   ```
-
-### 바이너리 직접 실행
+### 빠른 시작
 
 ```bash
-# 1. 빌드
-make build-api
+git clone https://github.com/damoang/angple-backend.git
+cd angple-backend
+cp .env.example .env   # 필수 값 수정
+docker compose -f docker-compose.standalone.yml up -d
+```
 
-# 2. 환경 변수 설정
-export APP_ENV=prod
-export DB_HOST=...
-export DB_PASSWORD=...
-# (기타 환경 변수)
+### 필수 환경 변수 (`.env`)
 
-# 3. 실행
-./bin/api
+| 변수 | 설명 | 필수 |
+|------|------|------|
+| `DB_PASSWORD` | MySQL 사용자 비밀번호 | O |
+| `MYSQL_ROOT_PASSWORD` | MySQL root 비밀번호 | O |
+| `JWT_SECRET` | JWT 서명 키 (32자 이상) | O |
+| `ANGPLE_VERSION` | Docker 이미지 태그 | - (기본: latest) |
+| `CORS_ALLOW_ORIGINS` | 허용 Origin 목록 | - |
+| `LARAVEL_BACKEND_URL` | 레거시 PHP 백엔드 URL | - |
+| `DAMOANG_JWT_SECRET` | 레거시 SSO 시크릿 | - |
+
+### 서비스 포트
+
+| 서비스 | 기본 포트 | 환경 변수 |
+|--------|----------|----------|
+| Gateway | 8080 | `GATEWAY_PORT` |
+| API | 8081 | `API_PORT` |
+| Web | 3010 | `WEB_PORT` |
+| Admin | 3011 | `ADMIN_PORT` |
+
+### 서버별 커스터마이징 (`docker-compose.override.yml`)
+
+리버스 프록시(Nginx Proxy Manager 등)나 레거시 DB 연동 등 **서버 고유 설정**은 `docker-compose.override.yml`을 사용합니다. 이 파일은 Docker Compose가 자동으로 merge합니다.
+
+```yaml
+# docker-compose.override.yml 예시
+services:
+  api:
+    networks:
+      - proxy-network
+      - legacy-db
+    environment:
+      DB_HOST: legacy-mysql
+      DB_NAME: legacy_db
+      DB_USER: root
+      DB_PASSWORD: legacy-password
+  gateway:
+    networks:
+      - proxy-network
+  web:
+    networks:
+      - proxy-network
+
+networks:
+  proxy-network:
+    external: true
+  legacy-db:
+    external: true
+    name: existing_mysql_network
 ```
 
 ### Health Check
 
 ```bash
-curl https://api.damoang.net/health
+curl http://localhost:8081/health   # API
+curl http://localhost:8080/health   # Gateway
+curl http://localhost:3010          # Web
+curl http://localhost:3011          # Admin
 ```
 
 ---
 
-## 🔄 GitHub Actions 배포
+## 🔄 CI/CD (GitHub Actions)
 
-GitHub Actions를 통해 개발/운영 환경에 자동 또는 수동으로 배포할 수 있습니다.
+### 빌드 및 배포
 
-### 환경 구성
+`main` 브랜치에 push하면 자동으로:
 
-| 환경 | 서버 | 트리거 | 빌드 방식 | 이미지 저장 |
-|------|------|--------|----------|------------|
-| **개발 (DEV)** | OCI | `push to main` 자동 | docker compose | 로컬만 |
-| **운영 (PROD)** | EC2 | 수동 (workflow_dispatch) | docker build | ECR |
-
-### 개발 환경 배포 (OCI - 자동)
-
-main 브랜치에 push하면 자동으로 OCI 개발 서버에 배포됩니다.
+1. Go 테스트 실행
+2. API + Gateway Docker 이미지 빌드 (linux/amd64, linux/arm64)
+3. GHCR(ghcr.io)에 push
+4. SSH로 서버에 접속하여 이미지 pull & 재시작
 
 ```
-main push → GitHub Actions → SSH to OCI → git pull → docker compose up
+main push → test → build (multi-arch) → GHCR push → SSH deploy
 ```
 
-**워크플로우**: `.github/workflows/deploy-dev.yml`
+**워크플로우**: `.github/workflows/ghcr-deploy.yml`
 
-### 운영 환경 배포 (EC2 - 수동)
-
-GitHub Actions에서 수동으로 트리거하여 EC2 운영 서버에 배포합니다.
-
-```
-수동 트리거 → GitHub Actions → AWS SSM → git pull → docker build → ECR push → docker run
-```
+### 운영 환경 배포 (수동)
 
 **워크플로우**: `.github/workflows/deploy-prod.yml`
 
-**배포 방법:**
-1. GitHub → Actions → "Deploy to Prod (EC2)" 선택
-2. "Run workflow" 클릭
-3. (선택) Image tag 입력 또는 비워두면 자동 생성 (`main-{커밋SHA}`)
-
-**운영 포트:**
-- API: `8082`
-- Gateway: `8083`
-
-### 롤백
-
-ECR에 저장된 이전 이미지로 롤백할 수 있습니다:
-
-```bash
-# 이전 이미지 태그로 배포
-/home/damoang/deploy/rollback.sh angple-backend main-{이전커밋}
-```
+GitHub Actions에서 수동 트리거하여 운영 서버에 배포합니다.
 
 ---
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/damoang/angple-backend/docs" // swagger docs
 	"github.com/damoang/angple-backend/internal/config"
 	"github.com/damoang/angple-backend/internal/handler"
+	"github.com/damoang/angple-backend/internal/migration"
 	"github.com/damoang/angple-backend/internal/plugin"
 	"github.com/damoang/angple-backend/internal/plugins/commerce"
 	"github.com/damoang/angple-backend/internal/repository"
@@ -100,6 +101,9 @@ func main() {
 		db = nil
 	} else {
 		pkglogger.Info("✅ Connected to MySQL")
+		if err := migration.Run(db); err != nil {
+			pkglogger.Info("⚠️  Migration warning: %v", err)
+		}
 	}
 
 	// Redis 연결

--- a/docker-compose.standalone.yml
+++ b/docker-compose.standalone.yml
@@ -37,6 +37,8 @@ services:
   api:
     image: ghcr.io/damoang/angple-backend-api:${ANGPLE_VERSION:-latest}
     container_name: angple-api
+    ports:
+      - "${API_PORT:-8081}:8081"
     environment:
       APP_ENV: ${APP_ENV:-prod}
       DB_HOST: mysql
@@ -64,8 +66,12 @@ services:
     environment:
       LARAVEL_BACKEND_URL: ${LARAVEL_BACKEND_URL:-http://host.docker.internal:80}
       GO_API_URL: http://api:8081
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on: [api]
-    networks: [angple]
+    networks:
+      angple:
+        aliases: [gateway-internal]
     restart: unless-stopped
 
   web:
@@ -75,7 +81,8 @@ services:
       - "${WEB_PORT:-3010}:3000"
     environment:
       NODE_ENV: production
-      INTERNAL_API_URL: http://gateway:8080/api/v1
+      INTERNAL_API_URL: http://gateway-internal:8080/api/v2
+      BACKEND_URL: http://gateway-internal:8080
     depends_on: [gateway]
     volumes:
       - web-data:/app/data

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -1,0 +1,89 @@
+package migration
+
+import (
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// Run executes AutoMigrate for the menus table and seeds default data if empty.
+func Run(db *gorm.DB) error {
+	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
+	if err := db.AutoMigrate(&domain.Menu{}); err != nil {
+		return err
+	}
+
+	// 2. Seed - menus 테이블이 비어있을 때만 기본 메뉴 삽입
+	var count int64
+	db.Model(&domain.Menu{}).Count(&count)
+	if count == 0 {
+		return seedMenus(db)
+	}
+
+	return nil
+}
+
+func seedMenus(db *gorm.DB) error {
+	int64Ptr := func(v int64) *int64 { return &v }
+
+	menus := []domain.Menu{
+		// 1. 커뮤니티 (루트)
+		{ID: 1, ParentID: nil, Title: "커뮤니티", URL: "/community", Icon: "MessageSquare", Shortcut: "", Description: "커뮤니티", Depth: 1, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: true, ShowInSidebar: true},
+		// 1-1. 커뮤니티 하위
+		{ID: 2, ParentID: int64Ptr(1), Title: "자유게시판", URL: "/free", Icon: "CircleStar", Shortcut: "F", Description: "자유게시판", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 3, ParentID: int64Ptr(1), Title: "질문과 답변", URL: "/qa", Icon: "CircleHelp", Shortcut: "Q", Description: "질문과 답변", Depth: 2, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 4, ParentID: int64Ptr(1), Title: "갤러리", URL: "/gallery", Icon: "Images", Shortcut: "G", Description: "갤러리", Depth: 2, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 2. 소모임 (루트)
+		{ID: 10, ParentID: nil, Title: "소모임", URL: "/groups", Icon: "Users", Shortcut: "", Description: "소모임", Depth: 1, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: true, ShowInSidebar: true},
+		// 2-1. 소모임 하위
+		{ID: 11, ParentID: int64Ptr(10), Title: "소모임 모아보기", URL: "/groups/all", Icon: "", Shortcut: "", Description: "소모임 모아보기", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 12, ParentID: int64Ptr(10), Title: "소모임 목록", URL: "/groups/list", Icon: "Users", Shortcut: "", Description: "소모임 목록", Depth: 2, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		// 2-2. 소모임 하위 (주요 소모임)
+		{ID: 13, ParentID: int64Ptr(12), Title: "AI당", URL: "/groups/ai", Icon: "Cpu", Shortcut: "", Description: "AI당", Depth: 3, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 14, ParentID: int64Ptr(12), Title: "개발한당", URL: "/groups/development", Icon: "Code", Shortcut: "", Description: "개발한당", Depth: 3, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 15, ParentID: int64Ptr(12), Title: "게임한당", URL: "/groups/game", Icon: "Gamepad2", Shortcut: "", Description: "게임한당", Depth: 3, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 16, ParentID: int64Ptr(12), Title: "공부한당", URL: "/groups/study", Icon: "BookOpen", Shortcut: "", Description: "공부한당", Depth: 3, OrderNum: 4, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 17, ParentID: int64Ptr(12), Title: "애플모앙", URL: "/groups/apple", Icon: "Apple", Shortcut: "", Description: "애플모앙", Depth: 3, OrderNum: 5, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 3. 새로운 소식 (루트)
+		{ID: 20, ParentID: nil, Title: "새로운 소식", URL: "/news", Icon: "Newspaper", Shortcut: "N", Description: "새로운 소식", Depth: 1, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: true, ShowInSidebar: true},
+		// 3-1. 새로운 소식 하위
+		{ID: 21, ParentID: int64Ptr(20), Title: "사용기", URL: "/tutorial", Icon: "PenTool", Shortcut: "T", Description: "사용기", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 22, ParentID: int64Ptr(20), Title: "강좌/팁", URL: "/lecture", Icon: "Lightbulb", Shortcut: "L", Description: "강좌/팁", Depth: 2, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 23, ParentID: int64Ptr(20), Title: "자료실", URL: "/pds", Icon: "FolderOpen", Shortcut: "P", Description: "자료실", Depth: 2, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 4. 리뷰 (루트)
+		{ID: 30, ParentID: nil, Title: "리뷰", URL: "/reviews", Icon: "Gift", Shortcut: "", Description: "리뷰", Depth: 1, OrderNum: 4, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		// 4-1. 리뷰 하위
+		{ID: 31, ParentID: int64Ptr(30), Title: "앙지도", URL: "/reviews/map", Icon: "MapPin", Shortcut: "M", Description: "다모앙 지도", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 32, ParentID: int64Ptr(30), Title: "앙티티", URL: "/reviews/rating", Icon: "Star", Shortcut: "O", Description: "다모앙 평점", Depth: 2, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 33, ParentID: int64Ptr(30), Title: "수익링크", URL: "/reviews/referral", Icon: "TrendingUp", Shortcut: "", Description: "수익링크", Depth: 2, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 5. 알뜰구매 (루트)
+		{ID: 40, ParentID: nil, Title: "알뜰구매", URL: "/economy", Icon: "ShoppingCart", Shortcut: "E", Description: "알뜰구매", Depth: 1, OrderNum: 5, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		// 5-1. 알뜰구매 하위
+		{ID: 41, ParentID: int64Ptr(40), Title: "직접홍보", URL: "/economy/promotion", Icon: "Megaphone", Shortcut: "W", Description: "직접홍보", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 6. BETA (루트)
+		{ID: 50, ParentID: nil, Title: "BETA", URL: "/beta", Icon: "Sparkles", Shortcut: "", Description: "BETA 기능", Depth: 1, OrderNum: 6, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		// 6-1. BETA 하위
+		{ID: 51, ParentID: int64Ptr(50), Title: "다모앙 레시피", URL: "/beta/recipe", Icon: "Coffee", Shortcut: "", Description: "다모앙 레시피", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 52, ParentID: int64Ptr(50), Title: "다모앙 전문가", URL: "/beta/expert", Icon: "UserCheck", Shortcut: "", Description: "다모앙 전문가", Depth: 2, OrderNum: 2, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 53, ParentID: int64Ptr(50), Title: "다모앙 음악", URL: "/beta/music", Icon: "Music", Shortcut: "D", Description: "다모앙 음악", Depth: 2, OrderNum: 3, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+
+		// 7. 안내 (루트)
+		{ID: 60, ParentID: nil, Title: "안내", URL: "/info", Icon: "Info", Shortcut: "", Description: "안내", Depth: 1, OrderNum: 7, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		// 7-1. 안내 하위
+		{ID: 61, ParentID: int64Ptr(60), Title: "게시판 안내", URL: "/info/board", Icon: "HelpCircle", Shortcut: "", Description: "게시판 안내", Depth: 2, OrderNum: 1, IsActive: true, Target: "_self", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+		{ID: 62, ParentID: int64Ptr(60), Title: "위키앙", URL: "https://wikiang.wiki", Icon: "BookText", Shortcut: "", Description: "위키앙", Depth: 2, OrderNum: 2, IsActive: true, Target: "_blank", ViewLevel: 1, ShowInHeader: false, ShowInSidebar: true},
+	}
+
+	if err := db.Create(&menus).Error; err != nil {
+		return err
+	}
+
+	// AUTO_INCREMENT 재설정
+	db.Exec("ALTER TABLE `menus` AUTO_INCREMENT = 100")
+
+	return nil
+}

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // MockPlugin 테스트용 목 플러그인
@@ -16,6 +17,10 @@ type MockPlugin struct {
 
 func (m *MockPlugin) Name() string {
 	return m.name
+}
+
+func (m *MockPlugin) Migrate(_ *gorm.DB) error {
+	return nil
 }
 
 func (m *MockPlugin) Initialize(_ *PluginContext) error {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -137,6 +137,9 @@ type Plugin interface {
 	// Name 플러그인 이름 반환
 	Name() string
 
+	// Migrate DB 마이그레이션 실행 (테이블 생성/업데이트)
+	Migrate(db *gorm.DB) error
+
 	// Initialize 플러그인 초기화
 	Initialize(ctx *PluginContext) error
 

--- a/internal/plugins/commerce/plugin.go
+++ b/internal/plugins/commerce/plugin.go
@@ -3,6 +3,7 @@ package commerce
 import (
 	"github.com/damoang/angple-backend/internal/plugin"
 	"github.com/damoang/angple-backend/internal/plugins/commerce/carrier"
+	"github.com/damoang/angple-backend/internal/plugins/commerce/domain"
 	"github.com/damoang/angple-backend/internal/plugins/commerce/gateway"
 	"github.com/damoang/angple-backend/internal/plugins/commerce/handler"
 	"github.com/damoang/angple-backend/internal/plugins/commerce/middleware"
@@ -227,6 +228,24 @@ func New() *CommercePlugin {
 // Name 플러그인 이름 반환
 func (p *CommercePlugin) Name() string {
 	return "commerce"
+}
+
+// Migrate DB 마이그레이션 실행 — 커머스 테이블 생성/업데이트
+func (p *CommercePlugin) Migrate(db *gorm.DB) error {
+	return db.AutoMigrate(
+		&domain.Product{},
+		&domain.Cart{},
+		&domain.Order{},
+		&domain.OrderItem{},
+		&domain.Coupon{},
+		&domain.CouponUsage{},
+		&domain.Payment{},
+		&domain.Review{},
+		&domain.ReviewHelpful{},
+		&domain.ProductFile{},
+		&domain.Download{},
+		&domain.Settlement{},
+	)
 }
 
 // Initialize 플러그인 초기화


### PR DESCRIPTION
### Summary

API 기동 시 DB AutoMigrate 및 기본 시드 자동화와  
플러그인 단위 마이그레이션 구조 개선,  
Standalone 운영 배포 가이드 정리를 포함한 PR입니다.

### What’s Changed

#### API 마이그레이션 및 시드
- API 시작 시 `menus` 테이블 AutoMigrate 수행
- 테이블이 비어 있는 경우 기본 메뉴 데이터 자동 삽입

#### 플러그인 마이그레이션 구조 개선
- `Plugin` 인터페이스에 `Migrate(*gorm.DB)` 메서드 추가
- 플러그인 Enable 시 마이그레이션 → 초기화 → 라우트 등록 순으로 실행
- Commerce 플러그인 커머스 도메인 테이블 AutoMigrate 추가

#### Standalone 배포 개선
- Gateway 내부 통신용 alias(`gateway-internal`) 분리
- Web ↔ Gateway 내부 API 경로 명확화
- `host.docker.internal` 대응 추가

#### 문서 정비
- Standalone 운영 환경 기준 README 배포 가이드 정리
- 빠른 시작 및 Health Check 섹션 보완
- GitHub Actions 기반 DEV / PROD 배포 흐름 정리

### Why

- 신규 및 운영 환경에서 DB 초기 설정 수동 작업을 제거하기 위함
- 플러그인 확장 시 마이그레이션 누락을 방지하기 위함
- Standalone 배포 시 설정 혼동을 줄이기 위함

### Notes

- 기존 데이터가 존재하는 경우 시드는 자동으로 삽입되지 않습니다.
- 신규 플러그인은 `Migrate()` 구현이 필요합니다.
