### PR TITLE
feat: 이모티콘 플러그인 구현

### DIFF
--- a/plugins/emoticon/domain/models.go
+++ b/plugins/emoticon/domain/models.go
@@ -1,0 +1,40 @@
+//go:build ignore
+
+// 이모티콘 플러그인 도메인 모델
+package domain
+
+import "time"
+
+// EmoticonPack 이모티콘 팩 (카테고리)
+type EmoticonPack struct {
+	ID           int64     `gorm:"primaryKey" json:"id"`
+	Slug         string    `gorm:"size:50;uniqueIndex;not null" json:"slug"`
+	Name         string    `gorm:"size:100;not null" json:"name"`
+	DefaultWidth int       `gorm:"default:50" json:"default_width"`
+	IsActive     bool      `gorm:"default:true" json:"is_active"`
+	SortOrder    int       `gorm:"default:0" json:"sort_order"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+func (EmoticonPack) TableName() string {
+	return "emoticon_packs"
+}
+
+// EmoticonItem 개별 이모티콘
+type EmoticonItem struct {
+	ID        int64     `gorm:"primaryKey" json:"id"`
+	PackID    int64     `gorm:"not null;index" json:"pack_id"`
+	Filename  string    `gorm:"size:255;uniqueIndex;not null" json:"filename"`
+	ThumbPath string    `gorm:"size:255" json:"thumb_path"`
+	MimeType  string    `gorm:"size:50" json:"mime_type"`
+	IsActive  bool      `gorm:"default:true" json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	Pack EmoticonPack `gorm:"foreignKey:PackID" json:"pack,omitempty"`
+}
+
+func (EmoticonItem) TableName() string {
+	return "emoticon_items"
+}

--- a/plugins/emoticon/handlers/admin.go
+++ b/plugins/emoticon/handlers/admin.go
@@ -1,0 +1,161 @@
+//go:build ignore
+
+// 이모티콘 관리자 API 핸들러
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminListPacks 관리자 전체 팩 목록
+// GET /api/plugins/emoticon/admin/packs
+func AdminListPacks(c *gin.Context) {
+	packs, err := svc.GetAllPacks()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "팩 목록 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"packs": packs,
+		"total": len(packs),
+	})
+}
+
+// CreatePack ZIP 업로드로 팩 생성
+// POST /api/plugins/emoticon/admin/packs
+func CreatePack(c *gin.Context) {
+	slug := c.PostForm("slug")
+	name := c.PostForm("name")
+
+	if slug == "" || name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slug와 name은 필수입니다"})
+		return
+	}
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "ZIP 파일이 필요합니다"})
+		return
+	}
+
+	// 임시 파일 저장
+	tmpPath := filepath.Join(os.TempDir(), "emoticon_upload_"+slug+".zip")
+	if err := c.SaveUploadedFile(file, tmpPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "파일 저장 실패"})
+		return
+	}
+	defer os.Remove(tmpPath)
+
+	pack, err := svc.CreatePackFromZip(tmpPath, slug, name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, pack)
+}
+
+// UpdatePack 팩 수정
+// PUT /api/plugins/emoticon/admin/packs/:id
+func UpdatePack(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 팩 ID"})
+		return
+	}
+
+	var req struct {
+		Name         string `json:"name"`
+		DefaultWidth *int   `json:"default_width"`
+		SortOrder    *int   `json:"sort_order"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	updates := map[string]interface{}{}
+	if req.Name != "" {
+		updates["name"] = req.Name
+	}
+	if req.DefaultWidth != nil {
+		updates["default_width"] = *req.DefaultWidth
+	}
+	if req.SortOrder != nil {
+		updates["sort_order"] = *req.SortOrder
+	}
+
+	pack, err := svc.UpdatePack(id, updates)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "팩 수정 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, pack)
+}
+
+// DeletePack 팩 삭제
+// DELETE /api/plugins/emoticon/admin/packs/:id
+func DeletePack(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 팩 ID"})
+		return
+	}
+
+	if err := svc.DeletePack(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "팩 삭제 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "팩이 삭제되었습니다"})
+}
+
+// ImportLegacy ang-gnu 레거시 이모티콘 일괄 임포트
+// POST /api/plugins/emoticon/admin/import-legacy
+func ImportLegacy(c *gin.Context) {
+	var req struct {
+		LegacyDir string `json:"legacy_dir" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "legacy_dir 경로가 필요합니다"})
+		return
+	}
+
+	packsCreated, itemsCreated, err := svc.ImportLegacy(req.LegacyDir)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success":       true,
+		"packs_created": packsCreated,
+		"items_created": itemsCreated,
+		"message":       "레거시 이모티콘 임포트 완료",
+	})
+}
+
+// TogglePack 팩 활성/비활성 토글
+// POST /api/plugins/emoticon/admin/packs/:id/toggle
+func TogglePack(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "잘못된 팩 ID"})
+		return
+	}
+
+	pack, err := svc.TogglePack(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "토글 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, pack)
+}

--- a/plugins/emoticon/handlers/public.go
+++ b/plugins/emoticon/handlers/public.go
@@ -1,0 +1,75 @@
+//go:build ignore
+
+// 이모티콘 공개 API 핸들러
+package handlers
+
+import (
+	"net/http"
+
+	"angple-backend/plugins/emoticon/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+var svc *service.Service
+
+// SetService 서비스 인스턴스 설정
+func SetService(s *service.Service) {
+	svc = s
+}
+
+// ListPacks 활성 팩 목록
+// GET /api/plugins/emoticon/packs
+func ListPacks(c *gin.Context) {
+	packs, err := svc.GetActivePacks()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "팩 목록 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"packs": packs,
+		"total": len(packs),
+	})
+}
+
+// ListPackItems 팩 내 아이템 목록
+// GET /api/plugins/emoticon/packs/:slug/items
+func ListPackItems(c *gin.Context) {
+	slug := c.Param("slug")
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "슬러그가 필요합니다"})
+		return
+	}
+
+	items, err := svc.GetItemsByPackSlug(slug)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "팩을 찾을 수 없습니다"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"items": items,
+		"total": len(items),
+	})
+}
+
+// ServeImage 이모티콘 이미지 서빙
+// GET /api/plugins/emoticon/image/:filename
+func ServeImage(c *gin.Context) {
+	filename := c.Param("filename")
+	path, err := svc.GetAssetPath(filename)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "이미지를 찾을 수 없습니다"})
+		return
+	}
+
+	c.File(path)
+}
+
+// ServeThumb 이모티콘 썸네일 서빙
+// GET /api/plugins/emoticon/thumb/:filename
+func ServeThumb(c *gin.Context) {
+	// 썸네일이 없으면 원본 서빙
+	ServeImage(c)
+}

--- a/plugins/emoticon/hooks/content_filter.go
+++ b/plugins/emoticon/hooks/content_filter.go
@@ -1,0 +1,40 @@
+//go:build ignore
+
+// 이모티콘 콘텐츠 필터 Hook
+package hooks
+
+import (
+	"angple-backend/pkg/plugin"
+	"angple-backend/plugins/emoticon/service"
+)
+
+var svc *service.Service
+
+// Register Hook 등록 및 서비스 초기화
+func Register(ctx *plugin.Context, s *service.Service) {
+	svc = s
+}
+
+// FilterPostContent 게시글 본문 필터 - {emo:...} → <img> 변환
+func FilterPostContent(ctx *plugin.HookContext) error {
+	content, ok := ctx.Input["content"].(string)
+	if !ok || content == "" {
+		return nil
+	}
+
+	filtered := svc.ParseContent(content)
+	ctx.SetOutput("content", filtered)
+	return nil
+}
+
+// FilterCommentContent 댓글 본문 필터 - {emo:...} → <img> 변환
+func FilterCommentContent(ctx *plugin.HookContext) error {
+	content, ok := ctx.Input["content"].(string)
+	if !ok || content == "" {
+		return nil
+	}
+
+	filtered := svc.ParseContent(content)
+	ctx.SetOutput("content", filtered)
+	return nil
+}

--- a/plugins/emoticon/main.go
+++ b/plugins/emoticon/main.go
@@ -1,0 +1,68 @@
+//go:build ignore
+
+// 이모티콘 플러그인
+// Emoticon Plugin - {emo:filename:width} 코드를 <img> 태그로 변환
+package main
+
+import (
+	"angple-backend/plugins/emoticon/handlers"
+	"angple-backend/plugins/emoticon/hooks"
+	"angple-backend/plugins/emoticon/service"
+
+	"angple-backend/pkg/plugin"
+)
+
+func init() {
+	plugin.Register("emoticon", &plugin.Plugin{
+		OnInit: func(ctx *plugin.Context) error {
+			// 설정 로드
+			config := service.DefaultConfig()
+			if v, ok := ctx.Settings["default_width"].(int); ok {
+				config.DefaultWidth = v
+			}
+			if v, ok := ctx.Settings["max_width"].(int); ok {
+				config.MaxWidth = v
+			}
+			if v, ok := ctx.Settings["cdn_url"].(string); ok && v != "" {
+				config.CDNURL = v
+			}
+			if v, ok := ctx.Settings["fallback_filename"].(string); ok && v != "" {
+				config.FallbackFilename = v
+			}
+			if v, ok := ctx.Settings["assets_path"].(string); ok && v != "" {
+				config.AssetsPath = v
+			}
+
+			// 서비스 초기화
+			svc := service.NewService(ctx.DB, config)
+
+			// 핸들러/훅에 서비스 주입
+			handlers.SetService(svc)
+			hooks.Register(ctx, svc)
+
+			return nil
+		},
+		OnShutdown: func(ctx *plugin.Context) error {
+			return nil
+		},
+		Handlers: map[string]plugin.HandlerFunc{
+			// 공개 API
+			"ListPacks":     handlers.ListPacks,
+			"ListPackItems": handlers.ListPackItems,
+			"ServeImage":    handlers.ServeImage,
+			"ServeThumb":    handlers.ServeThumb,
+
+			// 관리자 API
+			"AdminListPacks": handlers.AdminListPacks,
+			"CreatePack":     handlers.CreatePack,
+			"UpdatePack":     handlers.UpdatePack,
+			"DeletePack":     handlers.DeletePack,
+			"TogglePack":     handlers.TogglePack,
+			"ImportLegacy":   handlers.ImportLegacy,
+		},
+		HookHandlers: map[string]plugin.HookFunc{
+			"FilterPostContent":    hooks.FilterPostContent,
+			"FilterCommentContent": hooks.FilterCommentContent,
+		},
+	})
+}

--- a/plugins/emoticon/migrations/001_init.down.sql
+++ b/plugins/emoticon/migrations/001_init.down.sql
@@ -1,0 +1,5 @@
+-- 이모티콘 플러그인 롤백
+-- Emoticon Plugin Rollback
+
+DROP TABLE IF EXISTS emoticon_items;
+DROP TABLE IF EXISTS emoticon_packs;

--- a/plugins/emoticon/migrations/001_init.up.sql
+++ b/plugins/emoticon/migrations/001_init.up.sql
@@ -1,0 +1,40 @@
+-- 이모티콘 플러그인 초기 스키마
+-- Emoticon Plugin Initial Schema
+
+-- 이모티콘 팩 (카테고리) 테이블
+CREATE TABLE IF NOT EXISTS emoticon_packs (
+    id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    slug          VARCHAR(50) NOT NULL COMMENT '팩 슬러그 (URL용)',
+    name          VARCHAR(100) NOT NULL COMMENT '팩 표시명',
+    default_width INT NOT NULL DEFAULT 50 COMMENT '기본 너비 (px)',
+    is_active     BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성화 여부',
+    sort_order    INT NOT NULL DEFAULT 0 COMMENT '정렬 순서 (낮을수록 먼저)',
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_slug (slug),
+    KEY idx_is_active_sort (is_active, sort_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- 개별 이모티콘 테이블
+CREATE TABLE IF NOT EXISTS emoticon_items (
+    id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    pack_id     BIGINT UNSIGNED NOT NULL COMMENT '팩 ID',
+    filename    VARCHAR(255) NOT NULL COMMENT '파일명 (고유)',
+    thumb_path  VARCHAR(255) DEFAULT NULL COMMENT '썸네일 경로',
+    mime_type   VARCHAR(50) DEFAULT NULL COMMENT 'MIME 타입',
+    is_active   BOOLEAN NOT NULL DEFAULT TRUE COMMENT '활성화 여부',
+    created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_filename (filename),
+    KEY idx_pack_id (pack_id),
+    KEY idx_pack_active (pack_id, is_active),
+
+    CONSTRAINT fk_emoticon_items_pack
+        FOREIGN KEY (pack_id)
+        REFERENCES emoticon_packs (id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/plugins/emoticon/plugin.yaml
+++ b/plugins/emoticon/plugin.yaml
@@ -1,0 +1,129 @@
+# 이모티콘 플러그인
+# Emoticon Plugin - {emo:filename:width} 코드를 <img> 태그로 변환
+
+name: emoticon
+version: 1.0.0
+title: 이모티콘
+description: 게시글/댓글에서 {emo:filename:width} 코드를 이모티콘 이미지로 변환합니다.
+author: Damoang Team
+license: MIT
+homepage: https://github.com/damoang/angple-backend
+
+# 호환성
+requires:
+  angple: ">=1.0.0 <2.0.0"
+  go: ">=1.21"
+
+# DB 마이그레이션
+migrations:
+  - file: 001_init.up.sql
+    version: 1
+
+# Hook 등록
+hooks:
+  - event: post.content
+    handler: FilterPostContent
+    priority: 5
+    description: 게시글 본문의 이모티콘 코드를 이미지로 변환
+
+  - event: comment.content
+    handler: FilterCommentContent
+    priority: 5
+    description: 댓글 본문의 이모티콘 코드를 이미지로 변환
+
+# API 라우트
+routes:
+  # 공개 API
+  - path: /packs
+    method: GET
+    handler: ListPacks
+    auth: none
+    description: 활성 팩 목록 (피커용)
+
+  - path: /packs/:slug/items
+    method: GET
+    handler: ListPackItems
+    auth: none
+    description: 팩 내 아이템 목록
+
+  - path: /image/:filename
+    method: GET
+    handler: ServeImage
+    auth: none
+    description: 이모티콘 이미지 서빙
+
+  - path: /thumb/:filename
+    method: GET
+    handler: ServeThumb
+    auth: none
+    description: 이모티콘 썸네일 서빙
+
+  # 관리자 API
+  - path: /admin/packs
+    method: GET
+    handler: AdminListPacks
+    auth: required
+    description: 전체 팩 목록 (관리용)
+
+  - path: /admin/packs
+    method: POST
+    handler: CreatePack
+    auth: required
+    description: ZIP 업로드로 팩 생성
+
+  - path: /admin/packs/:id
+    method: PUT
+    handler: UpdatePack
+    auth: required
+    description: 팩 수정
+
+  - path: /admin/packs/:id
+    method: DELETE
+    handler: DeletePack
+    auth: required
+    description: 팩 삭제
+
+  - path: /admin/packs/:id/toggle
+    method: POST
+    handler: TogglePack
+    auth: required
+    description: 팩 활성/비활성 토글
+
+  - path: /admin/import-legacy
+    method: POST
+    handler: ImportLegacy
+    auth: required
+    description: ang-gnu 레거시 이모티콘 일괄 임포트
+
+# 설정 스키마
+settings:
+  - key: default_width
+    type: number
+    default: 50
+    min: 20
+    max: 200
+    label: 기본 너비 (px)
+
+  - key: max_width
+    type: number
+    default: 200
+    min: 50
+    max: 500
+    label: 최대 너비 (px)
+
+  - key: cdn_url
+    type: string
+    default: ""
+    label: CDN URL
+    description: 비워두면 로컬 서빙 사용
+
+  - key: fallback_filename
+    type: string
+    default: "damoang-emo-010.gif"
+    label: 폴백 이모티콘 파일명
+
+# 권한 정의
+permissions:
+  - id: emoticon.manage
+    label: 이모티콘 관리
+    description: 이모티콘 팩 생성/수정/삭제 권한

--- a/plugins/emoticon/service/emoticon.go
+++ b/plugins/emoticon/service/emoticon.go
@@ -1,0 +1,437 @@
+//go:build ignore
+
+// 이모티콘 서비스 - 파싱 로직 및 팩 관리
+package service
+
+import (
+	"archive/zip"
+	"fmt"
+	"html"
+	"io"
+	"mime"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"angple-backend/plugins/emoticon/domain"
+
+	"gorm.io/gorm"
+)
+
+// 허용 확장자
+var allowedExtensions = map[string]bool{
+	".gif":  true,
+	".png":  true,
+	".jpg":  true,
+	".jpeg": true,
+	".webp": true,
+}
+
+// 이모티콘 코드 정규식: {emo:filename:width} 또는 {emo:filename}
+var emoPattern = regexp.MustCompile(`\{emo:([^}]+)\}`)
+
+// Config 이모티콘 서비스 설정
+type Config struct {
+	DefaultWidth     int    `json:"default_width"`
+	MaxWidth         int    `json:"max_width"`
+	CDNURL           string `json:"cdn_url"`
+	FallbackFilename string `json:"fallback_filename"`
+	AssetsPath       string `json:"assets_path"`
+	BaseURL          string `json:"base_url"`
+}
+
+// DefaultConfig 기본 설정값 반환
+func DefaultConfig() Config {
+	return Config{
+		DefaultWidth:     50,
+		MaxWidth:         200,
+		CDNURL:           "",
+		FallbackFilename: "damoang-emo-010.gif",
+		AssetsPath:       "plugins/emoticon/assets",
+		BaseURL:          "/api/plugins/emoticon",
+	}
+}
+
+// Service 이모티콘 서비스
+type Service struct {
+	db     *gorm.DB
+	config Config
+}
+
+// NewService 서비스 생성
+func NewService(db *gorm.DB, config Config) *Service {
+	return &Service{db: db, config: config}
+}
+
+// ParseContent 콘텐츠 내 {emo:...} 코드를 <img> 태그로 변환
+func (s *Service) ParseContent(content string) string {
+	return emoPattern.ReplaceAllStringFunc(content, func(match string) string {
+		sub := emoPattern.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return s.renderEmoticon(sub[1])
+	})
+}
+
+// renderEmoticon 단일 이모티콘 코드를 <img> 태그로 변환
+func (s *Service) renderEmoticon(code string) string {
+	parts := strings.SplitN(code, ":", 2)
+	filename := parts[0]
+	width := s.config.DefaultWidth
+
+	if len(parts) > 1 {
+		if w, err := strconv.Atoi(parts[1]); err == nil && w > 0 {
+			width = w
+		}
+	}
+
+	// 너비 제한
+	if width > s.config.MaxWidth {
+		width = s.config.MaxWidth
+	}
+	if width < 20 {
+		width = 20
+	}
+
+	// 보안: path traversal 차단
+	filename = filepath.Base(filename)
+	if !isAllowedExtension(filename) {
+		return s.renderFallback()
+	}
+	if strings.Contains(filename, "..") || strings.Contains(filename, "/") || strings.Contains(filename, "\\") {
+		return s.renderFallback()
+	}
+
+	// 파일 존재 확인
+	assetPath := filepath.Join(s.config.AssetsPath, filename)
+	if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+		return s.renderFallback()
+	}
+
+	src := s.imageURL(filename)
+	escapedSrc := html.EscapeString(src)
+
+	return fmt.Sprintf(
+		`<img src="%s" width="%d" class="emoticon" loading="lazy" alt="emoticon" />`,
+		escapedSrc, width,
+	)
+}
+
+// renderFallback 삭제된 이모티콘 폴백 렌더링
+func (s *Service) renderFallback() string {
+	src := s.imageURL(s.config.FallbackFilename)
+	return fmt.Sprintf(
+		`(삭제된 이모지) <img src="%s" width="%d" class="emoticon" loading="lazy" alt="deleted emoticon" />`,
+		html.EscapeString(src), s.config.DefaultWidth,
+	)
+}
+
+// imageURL CDN 또는 로컬 이미지 URL 생성
+func (s *Service) imageURL(filename string) string {
+	if s.config.CDNURL != "" {
+		return s.config.CDNURL + "/emoticon/" + filename
+	}
+	return s.config.BaseURL + "/image/" + filename
+}
+
+// GetActivePacks 활성 팩 목록 조회
+func (s *Service) GetActivePacks() ([]domain.EmoticonPack, error) {
+	var packs []domain.EmoticonPack
+	err := s.db.Where("is_active = ?", true).
+		Order("sort_order ASC, name ASC").
+		Find(&packs).Error
+	return packs, err
+}
+
+// GetAllPacks 전체 팩 목록 조회 (관리용)
+func (s *Service) GetAllPacks() ([]domain.EmoticonPack, error) {
+	var packs []domain.EmoticonPack
+	err := s.db.Order("sort_order ASC, name ASC").Find(&packs).Error
+	return packs, err
+}
+
+// GetPackBySlug 슬러그로 팩 조회
+func (s *Service) GetPackBySlug(slug string) (*domain.EmoticonPack, error) {
+	var pack domain.EmoticonPack
+	err := s.db.Where("slug = ?", slug).First(&pack).Error
+	return &pack, err
+}
+
+// GetPackByID ID로 팩 조회
+func (s *Service) GetPackByID(id int64) (*domain.EmoticonPack, error) {
+	var pack domain.EmoticonPack
+	err := s.db.First(&pack, id).Error
+	return &pack, err
+}
+
+// GetItemsByPackSlug 팩 슬러그로 아이템 목록 조회
+func (s *Service) GetItemsByPackSlug(slug string) ([]domain.EmoticonItem, error) {
+	pack, err := s.GetPackBySlug(slug)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []domain.EmoticonItem
+	err = s.db.Where("pack_id = ? AND is_active = ?", pack.ID, true).
+		Order("filename ASC").
+		Find(&items).Error
+	return items, err
+}
+
+// CreatePackFromZip ZIP 파일에서 팩 생성
+func (s *Service) CreatePackFromZip(zipPath, slug, name string) (*domain.EmoticonPack, error) {
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("ZIP 파일 열기 실패: %w", err)
+	}
+	defer reader.Close()
+
+	// 팩 생성
+	pack := &domain.EmoticonPack{
+		Slug:         slug,
+		Name:         name,
+		DefaultWidth: s.config.DefaultWidth,
+		IsActive:     true,
+	}
+	if err := s.db.Create(pack).Error; err != nil {
+		return nil, fmt.Errorf("팩 생성 실패: %w", err)
+	}
+
+	// ZIP 내 파일 추출
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+
+		filename := filepath.Base(file.Name)
+		if !isAllowedExtension(filename) {
+			continue
+		}
+
+		// 파일 추출
+		destPath := filepath.Join(s.config.AssetsPath, filename)
+		if err := extractFile(file, destPath); err != nil {
+			continue
+		}
+
+		// DB 등록
+		mimeType := mime.TypeByExtension(filepath.Ext(filename))
+		item := domain.EmoticonItem{
+			PackID:   pack.ID,
+			Filename: filename,
+			MimeType: mimeType,
+			IsActive: true,
+		}
+		s.db.Create(&item)
+	}
+
+	return pack, nil
+}
+
+// UpdatePack 팩 수정
+func (s *Service) UpdatePack(id int64, updates map[string]interface{}) (*domain.EmoticonPack, error) {
+	var pack domain.EmoticonPack
+	if err := s.db.First(&pack, id).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Model(&pack).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+	s.db.First(&pack, id)
+	return &pack, nil
+}
+
+// DeletePack 팩 삭제 (아이템 + 파일 포함)
+func (s *Service) DeletePack(id int64) error {
+	// 아이템 파일 삭제
+	var items []domain.EmoticonItem
+	s.db.Where("pack_id = ?", id).Find(&items)
+	for _, item := range items {
+		os.Remove(filepath.Join(s.config.AssetsPath, item.Filename))
+	}
+
+	// DB 삭제 (CASCADE로 아이템도 삭제됨)
+	return s.db.Delete(&domain.EmoticonPack{}, id).Error
+}
+
+// TogglePack 팩 활성/비활성 토글
+func (s *Service) TogglePack(id int64) (*domain.EmoticonPack, error) {
+	var pack domain.EmoticonPack
+	if err := s.db.First(&pack, id).Error; err != nil {
+		return nil, err
+	}
+	pack.IsActive = !pack.IsActive
+	if err := s.db.Save(&pack).Error; err != nil {
+		return nil, err
+	}
+	return &pack, nil
+}
+
+// GetAssetPath 이미지 파일 경로 반환 (보안 검증 포함)
+func (s *Service) GetAssetPath(filename string) (string, error) {
+	filename = filepath.Base(filename)
+	if !isAllowedExtension(filename) {
+		return "", fmt.Errorf("허용되지 않는 파일 형식")
+	}
+
+	fullPath := filepath.Join(s.config.AssetsPath, filename)
+	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("파일을 찾을 수 없음")
+	}
+
+	return fullPath, nil
+}
+
+// ImportLegacy ang-gnu 레거시 이모티콘 디렉토리에서 팩/아이템 일괄 임포트
+func (s *Service) ImportLegacy(legacyDir string) (int, int, error) {
+	entries, err := os.ReadDir(legacyDir)
+	if err != nil {
+		return 0, 0, fmt.Errorf("레거시 디렉토리 읽기 실패: %w", err)
+	}
+
+	packMap := map[string]*domain.EmoticonPack{}
+	packsCreated := 0
+	itemsCreated := 0
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		filename := entry.Name()
+		if !isAllowedExtension(filename) {
+			continue
+		}
+		// 썸네일 파일 건너뛰기
+		if strings.Contains(filename, "_thumb") {
+			continue
+		}
+
+		// 파일명에서 팩 슬러그 추출: damoang-air-001.gif → damoang-air
+		baseName := strings.TrimSuffix(filename, filepath.Ext(filename))
+		parts := strings.Split(baseName, "-")
+		if len(parts) < 3 {
+			continue
+		}
+		// 마지막 파트(번호)를 제외한 나머지가 슬러그
+		slug := strings.Join(parts[:len(parts)-1], "-")
+
+		// 팩 생성 (최초 1회)
+		pack, exists := packMap[slug]
+		if !exists {
+			pack = &domain.EmoticonPack{
+				Slug:         slug,
+				Name:         slug,
+				DefaultWidth: s.config.DefaultWidth,
+				IsActive:     true,
+			}
+			// 이미 DB에 존재하면 조회
+			var existing domain.EmoticonPack
+			if err := s.db.Where("slug = ?", slug).First(&existing).Error; err == nil {
+				pack = &existing
+			} else {
+				if err := s.db.Create(pack).Error; err != nil {
+					continue
+				}
+				packsCreated++
+			}
+			packMap[slug] = pack
+		}
+
+		// 파일 복사
+		srcPath := filepath.Join(legacyDir, filename)
+		destPath := filepath.Join(s.config.AssetsPath, filename)
+		if err := copyFile(srcPath, destPath); err != nil {
+			continue
+		}
+
+		// 썸네일 복사 (존재하면)
+		thumbName := findThumbFile(legacyDir, baseName)
+		thumbPath := ""
+		if thumbName != "" {
+			thumbSrc := filepath.Join(legacyDir, thumbName)
+			thumbDest := filepath.Join(s.config.AssetsPath, thumbName)
+			if err := copyFile(thumbSrc, thumbDest); err == nil {
+				thumbPath = thumbName
+			}
+		}
+
+		// DB에 아이템이 이미 존재하면 건너뛰기
+		var count int64
+		s.db.Model(&domain.EmoticonItem{}).Where("filename = ?", filename).Count(&count)
+		if count > 0 {
+			continue
+		}
+
+		mimeType := mime.TypeByExtension(filepath.Ext(filename))
+		item := domain.EmoticonItem{
+			PackID:    pack.ID,
+			Filename:  filename,
+			ThumbPath: thumbPath,
+			MimeType:  mimeType,
+			IsActive:  true,
+		}
+		if err := s.db.Create(&item).Error; err == nil {
+			itemsCreated++
+		}
+	}
+
+	return packsCreated, itemsCreated, nil
+}
+
+// findThumbFile 레거시 디렉토리에서 썸네일 파일 찾기
+func findThumbFile(dir, baseName string) string {
+	for _, ext := range []string{".webp", ".gif", ".png", ".jpg"} {
+		thumbName := baseName + "_thumb" + ext
+		if _, err := os.Stat(filepath.Join(dir, thumbName)); err == nil {
+			return thumbName
+		}
+	}
+	return ""
+}
+
+// copyFile 파일 복사
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// isAllowedExtension 허용 확장자 확인
+func isAllowedExtension(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	return allowedExtensions[ext]
+}
+
+// extractFile ZIP 파일에서 단일 파일 추출
+func extractFile(file *zip.File, destPath string) error {
+	rc, err := file.Open()
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	outFile, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer outFile.Close()
+
+	// 파일 크기 제한 (10MB)
+	_, err = io.Copy(outFile, io.LimitReader(rc, 10*1024*1024))
+	return err
+}


### PR DESCRIPTION
## Summary
- `{emo:filename:width}` 형식의 이모티콘 코드를 `<img>` 태그로 변환하는 플러그인
- EmoticonPack / EmoticonItem 도메인 모델 및 DB 마이그레이션
- 공개 API (팩 목록, 아이템 조회, 이미지/썸네일 서빙) + 관리자 API (팩 CRUD, ZIP 업로드, 토글)
- ang-gnu 레거시 이모티콘 일괄 임포트 엔드포인트 (`POST /admin/import-legacy`)
- 보안: path traversal 차단, 확장자 화이트리스트(.gif/.png/.jpg/.webp), HTML escape, 10MB 파일 크기 제한

## 파일 구조
```
plugins/emoticon/
├── plugin.yaml                    # 매니페스트 (라우트 12개, 설정 4개, 훅 2개)
├── main.go                        # plugin.Register 진입점
├── domain/models.go               # EmoticonPack, EmoticonItem 구조체
├── service/emoticon.go            # 파싱 로직, 팩 관리, ZIP 업로드, 레거시 임포트
├── handlers/
│   ├── public.go                  # GET /packs, /packs/:slug/items, /image/:filename, /thumb/:filename
│   └── admin.go                   # POST/PUT/DELETE /admin/packs, POST /admin/packs/:id/toggle, POST /admin/import-legacy
├── hooks/content_filter.go        # post.content, comment.content 필터 훅
├── migrations/
│   ├── 001_init.up.sql
│   └── 001_init.down.sql
└── assets/                        # 이모티콘 이미지 저장소
```

## 콘텐츠 필터 동작
- 입력: `{emo:damoang-meme-002.gif:50}`
- 출력: `<img src="/api/plugins/emoticon/image/damoang-meme-002.gif" width="50" class="emoticon" loading="lazy" />`
- 미존재 파일: `(삭제된 이모지) <img src=".../damoang-emo-010.gif" .../>` 폴백

## Test plan
- [ ] `{emo:damoang-meme-002.gif:50}` 포함 게시글 → API 응답에서 `<img>` 태그 확인
- [ ] 악의적 입력 차단: `{emo:../../etc/passwd:50}`, `{emo:test.exe:50}`
- [ ] ZIP 업로드 → 팩 생성 → 목록 조회 → 비활성화 → 삭제 플로우
- [ ] ang-gnu 레거시 디렉토리 임포트 → 팩 자동 분류 확인