### PR TITLE
feat(auth): refreshToken httpOnly 쿠키 기반으로 변경

### DIFF
--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -55,19 +55,32 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, common.APIResponse{Data: response})
+	// refreshToken → httpOnly 쿠키 설정
+	h.setRefreshTokenCookie(c, response.RefreshToken)
+
+	// 응답에는 accessToken + user만 반환 (refreshToken 제외)
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
+		"access_token": response.AccessToken,
+		"user":         response.User,
+	}})
 }
 
 // RefreshToken handles POST /api/v2/auth/refresh
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
-	var req RefreshRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		common.ErrorResponse(c, 400, "Invalid request body", err)
-		return
+	// 1순위: httpOnly 쿠키에서 refreshToken 읽기
+	refreshToken, err := c.Cookie("refresh_token")
+	if err != nil || refreshToken == "" {
+		// 2순위: JSON body (하위 호환)
+		var req RefreshRequest
+		if err := c.ShouldBindJSON(&req); err != nil || req.RefreshToken == "" {
+			common.ErrorResponse(c, 401, "Refresh token not found", nil)
+			return
+		}
+		refreshToken = req.RefreshToken
 	}
 
-	// Refresh tokens
-	tokens, err := h.service.RefreshToken(req.RefreshToken)
+	// 토큰 갱신 (토큰 로테이션)
+	tokens, err := h.service.RefreshToken(refreshToken)
 	if errors.Is(err, common.ErrInvalidToken) {
 		common.ErrorResponse(c, 401, "Invalid refresh token", err)
 		return
@@ -77,7 +90,13 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, common.APIResponse{Data: tokens})
+	// 새 refreshToken → httpOnly 쿠키
+	h.setRefreshTokenCookie(c, tokens.RefreshToken)
+
+	// 응답에는 accessToken만 반환
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
+		"access_token": tokens.AccessToken,
+	}})
 }
 
 // GetProfile handles GET /api/v2/auth/profile (requires JWT)
@@ -120,20 +139,44 @@ func (h *AuthHandler) GetCurrentUser(c *gin.Context) {
 // Logout handles POST /api/v2/auth/logout
 // Clears the httpOnly refresh token cookie
 func (h *AuthHandler) Logout(c *gin.Context) {
-	// Clear the refresh token cookie
-	c.SetCookie(
-		"refresh_token", // name
-		"",              // value
-		-1,              // maxAge
-		"/",             // path
-		"",              // domain
-		true,            // secure
-		true,            // httpOnly
-	)
+	h.clearRefreshTokenCookie(c)
 
 	c.JSON(http.StatusOK, common.APIResponse{
 		Data: gin.H{
 			"message": "Logged out successfully",
 		},
 	})
+}
+
+// setRefreshTokenCookie refreshToken을 httpOnly 쿠키로 설정
+func (h *AuthHandler) setRefreshTokenCookie(c *gin.Context, token string) {
+	secure := !h.config.IsDevelopment()
+	maxAge := 60 * 60 * 24 * 7 // 7일
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		"refresh_token", // name
+		token,           // value
+		maxAge,          // maxAge (seconds)
+		"/",             // path
+		"",              // domain
+		secure,          // secure (dev: false, prod: true)
+		true,            // httpOnly
+	)
+}
+
+// clearRefreshTokenCookie refreshToken 쿠키 삭제
+func (h *AuthHandler) clearRefreshTokenCookie(c *gin.Context) {
+	secure := !h.config.IsDevelopment()
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		"refresh_token",
+		"",
+		-1,
+		"/",
+		"",
+		secure,
+		true,
+	)
 }


### PR DESCRIPTION
## Summary
- Login 응답에서 refreshToken 제거, httpOnly 쿠키로 설정
- RefreshToken 핸들러: 쿠키 우선 읽기 (JSON body 하위 호환 유지)
- 토큰 로테이션: 갱신 시 새 refreshToken 쿠키 자동 발급
- 환경별 secure 플래그 (`IsDevelopment()` → dev: false, prod: true)
- `setRefreshTokenCookie` / `clearRefreshTokenCookie` 헬퍼 메서드 추가

## 변경 파일
- `internal/handler/auth_handler.go`

## Test plan
- [ ] `curl -X POST /api/v2/auth/login` → 응답에 refreshToken 없음, Set-Cookie 헤더에 refresh_token 존재
- [ ] `curl -X POST /api/v2/auth/refresh --cookie "refresh_token=..."` → 새 accessToken 반환 + 새 Set-Cookie
- [ ] `curl -X POST /api/v2/auth/logout --cookie "refresh_token=..."` → 쿠키 삭제 확인
- [ ] JSON body로 refreshToken 전달해도 동작 (하위 호환)