### PR TITLE
feat: add schema validation, type conversion, and config injection fo…

### DIFF
--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -39,7 +39,7 @@ func (m *MockPlugin) Shutdown() error {
 
 func TestManager_RegisterBuiltIn(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
 
 	mockPlugin := &MockPlugin{name: "test-plugin"}
 	manifest := &PluginManifest{
@@ -73,7 +73,7 @@ func TestManager_EnableDisable(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
 
 	// 테스트용 라우터 설정
 	router := gin.New()
@@ -123,7 +123,7 @@ func TestManager_EnableDisable(t *testing.T) {
 
 func TestManager_GetAllPlugins(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
 
 	// 여러 플러그인 등록
 	for _, name := range []string{"plugin-a", "plugin-b", "plugin-c"} {
@@ -147,7 +147,7 @@ func TestManager_GetAllPlugins(t *testing.T) {
 
 func TestManager_EnableNonExistent(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
 
 	err := manager.Enable("non-existent")
 	if err == nil {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -167,6 +167,11 @@ type Logger interface {
 	Error(msg string, args ...interface{})
 }
 
+// SettingGetter 플러그인 설정 조회 인터페이스 (순환 의존 방지)
+type SettingGetter interface {
+	GetSettingsAsMap(pluginName string) (map[string]interface{}, error)
+}
+
 // HookAware 선택적 인터페이스 - Hook을 등록하고 싶은 플러그인이 구현
 type HookAware interface {
 	RegisterHooks(hm *HookManager)

--- a/internal/pluginstore/handler/setting_handler.go
+++ b/internal/pluginstore/handler/setting_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/damoang/angple-backend/internal/pluginstore/service"
@@ -39,12 +40,18 @@ func (h *SettingHandler) SaveSettings(c *gin.Context) {
 	name := c.Param("name")
 	actorID := getActorID(c)
 
-	var req map[string]string
-	if err := c.ShouldBindJSON(&req); err != nil {
+	var raw map[string]interface{}
+	if err := c.ShouldBindJSON(&raw); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": gin.H{"code": "INVALID_REQUEST", "message": "잘못된 요청 형식입니다"},
 		})
 		return
+	}
+
+	// interface{} → string 변환 (validator는 string 기반)
+	req := make(map[string]string, len(raw))
+	for k, v := range raw {
+		req[k] = fmt.Sprintf("%v", v)
 	}
 
 	if err := h.settingSvc.SaveSettings(name, req, actorID); err != nil {

--- a/internal/pluginstore/service/setting_validator.go
+++ b/internal/pluginstore/service/setting_validator.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/plugin"
+)
+
+// ValidateSetting 스키마 기반 설정값 검증
+func ValidateSetting(schema plugin.SettingConfig, value string) error {
+	switch schema.Type {
+	case "string", "textarea":
+		// 모든 문자열 허용
+		return nil
+
+	case "number":
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("setting %s: %q is not a valid number", schema.Key, value)
+		}
+		if schema.Min != nil && n < float64(*schema.Min) {
+			return fmt.Errorf("setting %s: value %v is less than minimum %d", schema.Key, n, *schema.Min)
+		}
+		if schema.Max != nil && n > float64(*schema.Max) {
+			return fmt.Errorf("setting %s: value %v is greater than maximum %d", schema.Key, n, *schema.Max)
+		}
+		return nil
+
+	case "boolean":
+		if value != "true" && value != "false" {
+			return fmt.Errorf("setting %s: %q is not a valid boolean (must be \"true\" or \"false\")", schema.Key, value)
+		}
+		return nil
+
+	case "select":
+		for _, opt := range schema.Options {
+			if opt.Value == value {
+				return nil
+			}
+		}
+		return fmt.Errorf("setting %s: %q is not a valid option", schema.Key, value)
+
+	default:
+		return nil
+	}
+}
+
+// ConvertSettingValue string 값을 스키마 타입에 맞게 변환
+func ConvertSettingValue(schema plugin.SettingConfig, raw string) interface{} {
+	switch schema.Type {
+	case "number":
+		if v, err := strconv.ParseFloat(raw, 64); err == nil {
+			return v
+		}
+		return raw
+	case "boolean":
+		return raw == "true"
+	default:
+		return raw
+	}
+}
+
+// ApplyDefaults 누락된 설정 키에 기본값 적용
+func ApplyDefaults(schemas []plugin.SettingConfig, current map[string]string) map[string]string {
+	result := make(map[string]string, len(current))
+	for k, v := range current {
+		result[k] = v
+	}
+	for _, s := range schemas {
+		if _, exists := result[s.Key]; !exists && s.Default != nil {
+			result[s.Key] = fmt.Sprintf("%v", s.Default)
+		}
+	}
+	return result
+}

--- a/internal/pluginstore/service/setting_validator_test.go
+++ b/internal/pluginstore/service/setting_validator_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/damoang/angple-backend/internal/plugin"
+)
+
+func TestValidateSetting_String(t *testing.T) {
+	schema := plugin.SettingConfig{Key: "title", Type: "string"}
+	if err := ValidateSetting(schema, "anything"); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateSetting_Textarea(t *testing.T) {
+	schema := plugin.SettingConfig{Key: "desc", Type: "textarea"}
+	if err := ValidateSetting(schema, "long text\nwith newlines"); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateSetting_Number_Valid(t *testing.T) {
+	min, max := 0, 100
+	schema := plugin.SettingConfig{Key: "count", Type: "number", Min: &min, Max: &max}
+
+	tests := []struct {
+		value string
+		ok    bool
+	}{
+		{"50", true},
+		{"0", true},
+		{"100", true},
+		{"-1", false},
+		{"101", false},
+		{"abc", false},
+		{"3.14", true},
+	}
+
+	for _, tc := range tests {
+		err := ValidateSetting(schema, tc.value)
+		if tc.ok && err != nil {
+			t.Errorf("value %q: expected no error, got %v", tc.value, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("value %q: expected error, got nil", tc.value)
+		}
+	}
+}
+
+func TestValidateSetting_Number_NoMinMax(t *testing.T) {
+	schema := plugin.SettingConfig{Key: "count", Type: "number"}
+	if err := ValidateSetting(schema, "-999"); err != nil {
+		t.Errorf("expected no error without min/max, got %v", err)
+	}
+}
+
+func TestValidateSetting_Boolean(t *testing.T) {
+	schema := plugin.SettingConfig{Key: "enabled", Type: "boolean"}
+
+	if err := ValidateSetting(schema, "true"); err != nil {
+		t.Errorf("expected no error for 'true', got %v", err)
+	}
+	if err := ValidateSetting(schema, "false"); err != nil {
+		t.Errorf("expected no error for 'false', got %v", err)
+	}
+	if err := ValidateSetting(schema, "yes"); err == nil {
+		t.Error("expected error for 'yes', got nil")
+	}
+	if err := ValidateSetting(schema, "1"); err == nil {
+		t.Error("expected error for '1', got nil")
+	}
+}
+
+func TestValidateSetting_Select(t *testing.T) {
+	schema := plugin.SettingConfig{
+		Key:  "theme",
+		Type: "select",
+		Options: []plugin.SettingOption{
+			{Value: "light", Label: "Light"},
+			{Value: "dark", Label: "Dark"},
+		},
+	}
+
+	if err := ValidateSetting(schema, "light"); err != nil {
+		t.Errorf("expected no error for valid option, got %v", err)
+	}
+	if err := ValidateSetting(schema, "blue"); err == nil {
+		t.Error("expected error for invalid option, got nil")
+	}
+}
+
+func TestConvertSettingValue(t *testing.T) {
+	tests := []struct {
+		schema plugin.SettingConfig
+		raw    string
+		want   interface{}
+	}{
+		{plugin.SettingConfig{Type: "number"}, "42", float64(42)},
+		{plugin.SettingConfig{Type: "number"}, "3.14", float64(3.14)},
+		{plugin.SettingConfig{Type: "boolean"}, "true", true},
+		{plugin.SettingConfig{Type: "boolean"}, "false", false},
+		{plugin.SettingConfig{Type: "string"}, "hello", "hello"},
+		{plugin.SettingConfig{Type: "select"}, "dark", "dark"},
+	}
+
+	for _, tc := range tests {
+		got := ConvertSettingValue(tc.schema, tc.raw)
+		if got != tc.want {
+			t.Errorf("ConvertSettingValue(%s, %q) = %v (%T), want %v (%T)",
+				tc.schema.Type, tc.raw, got, got, tc.want, tc.want)
+		}
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	schemas := []plugin.SettingConfig{
+		{Key: "a", Default: "default_a"},
+		{Key: "b", Default: 42},
+		{Key: "c", Default: nil},
+	}
+	current := map[string]string{"a": "custom"}
+
+	result := ApplyDefaults(schemas, current)
+
+	if result["a"] != "custom" {
+		t.Errorf("expected 'custom', got %q", result["a"])
+	}
+	if result["b"] != "42" {
+		t.Errorf("expected '42', got %q", result["b"])
+	}
+	if _, exists := result["c"]; exists {
+		t.Error("expected 'c' to not be set (nil default)")
+	}
+}

--- a/internal/pluginstore/service/store_service_test.go
+++ b/internal/pluginstore/service/store_service_test.go
@@ -40,7 +40,7 @@ func setupStoreService(t *testing.T) (*StoreService, *CatalogService, *plugin.Ma
 	logger := plugin.NewDefaultLogger("test")
 	storeSvc := NewStoreService(installRepo, eventRepo, settingRepo, catalogSvc, logger)
 
-	manager := plugin.NewManager("", db, nil, logger)
+	manager := plugin.NewManager("", db, nil, logger, nil)
 
 	// 내장 플러그인 등록
 	mockPlugin := &mockPlugin{name: "test-plugin"}
@@ -146,7 +146,7 @@ func TestBootEnabledPlugins(t *testing.T) {
 
 	// 새 매니저로 부팅 시뮬레이션
 	logger := plugin.NewDefaultLogger("test")
-	newManager := plugin.NewManager("", setupTestDB(t), nil, logger)
+	newManager := plugin.NewManager("", setupTestDB(t), nil, logger, nil)
 	mockP := &mockPlugin{name: "test-plugin"}
 	testManifest := &plugin.PluginManifest{Name: "test-plugin", Version: "1.0.0"}
 	newManager.RegisterBuiltIn("test-plugin", mockP, testManifest)
@@ -177,7 +177,7 @@ func TestConflictCheck(t *testing.T) {
 	logger := plugin.NewDefaultLogger("test")
 	storeSvc := NewStoreService(installRepo, eventRepo, settingRepo, catalogSvc, logger)
 
-	manager := plugin.NewManager("", db, nil, logger)
+	manager := plugin.NewManager("", db, nil, logger, nil)
 	manager.RegisterBuiltIn("plugin-a", &mockPlugin{name: "plugin-a"}, pluginA)
 	manager.RegisterBuiltIn("plugin-b", &mockPlugin{name: "plugin-b"}, pluginB)
 


### PR DESCRIPTION
…r plugin settings

- Add setting_validator.go with ValidateSetting (type/range checks), ConvertSettingValue (string→float64/bool), ApplyDefaults
- SaveSettings now validates against schema before persisting
- GetSettingsAsMap applies defaults and converts types for PluginContext.Config
- Add SettingGetter interface to avoid circular dependency
- Manager.Enable injects settings into PluginContext.Config
- Handler accepts map[string]interface{} for number/boolean direct input
- Reorder DI in main.go: settingSvc created before pluginManager