### PR TITLE
feat: implement plugin permission system with level-based access control

### DIFF
--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -2,13 +2,14 @@ package migration
 
 import (
 	"github.com/damoang/angple-backend/internal/domain"
+	pluginstoreDomain "github.com/damoang/angple-backend/internal/pluginstore/domain"
 	"gorm.io/gorm"
 )
 
 // Run executes AutoMigrate for the menus table and seeds default data if empty.
 func Run(db *gorm.DB) error {
 	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
-	if err := db.AutoMigrate(&domain.Menu{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginPermission{}); err != nil {
 		return err
 	}
 

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -39,7 +39,7 @@ func (m *MockPlugin) Shutdown() error {
 
 func TestManager_RegisterBuiltIn(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil, nil)
 
 	mockPlugin := &MockPlugin{name: "test-plugin"}
 	manifest := &PluginManifest{
@@ -73,7 +73,7 @@ func TestManager_EnableDisable(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil, nil)
 
 	// 테스트용 라우터 설정
 	router := gin.New()
@@ -123,7 +123,7 @@ func TestManager_EnableDisable(t *testing.T) {
 
 func TestManager_GetAllPlugins(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil, nil)
 
 	// 여러 플러그인 등록
 	for _, name := range []string{"plugin-a", "plugin-b", "plugin-c"} {
@@ -147,7 +147,7 @@ func TestManager_GetAllPlugins(t *testing.T) {
 
 func TestManager_EnableNonExistent(t *testing.T) {
 	logger := NewDefaultLogger("test")
-	manager := NewManager("/tmp/plugins", nil, nil, logger, nil)
+	manager := NewManager("/tmp/plugins", nil, nil, logger, nil, nil)
 
 	err := manager.Enable("non-existent")
 	if err == nil {

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -172,6 +172,13 @@ type SettingGetter interface {
 	GetSettingsAsMap(pluginName string) (map[string]interface{}, error)
 }
 
+// PermissionSyncer 플러그인 권한 동기화 인터페이스 (순환 의존 방지)
+type PermissionSyncer interface {
+	SyncPermissions(pluginName string, permissions []Permission) error
+	DeletePermissions(pluginName string) error
+	CheckPermission(pluginName, permissionID string, userLevel int) (bool, error)
+}
+
 // HookAware 선택적 인터페이스 - Hook을 등록하고 싶은 플러그인이 구현
 type HookAware interface {
 	RegisterHooks(hm *HookManager)

--- a/internal/pluginstore/domain/installation.go
+++ b/internal/pluginstore/domain/installation.go
@@ -50,6 +50,20 @@ func (PluginEvent) TableName() string {
 	return "plugin_events"
 }
 
+// PluginPermission 플러그인 권한 매핑 (권한 → 최소 회원 레벨)
+type PluginPermission struct {
+	ID           int64  `gorm:"primaryKey" json:"id"`
+	PluginName   string `gorm:"size:100;uniqueIndex:uk_plugin_perm" json:"plugin_name"`
+	PermissionID string `gorm:"size:200;uniqueIndex:uk_plugin_perm" json:"permission_id"`
+	Label        string `gorm:"size:200" json:"label"`
+	MinLevel     int    `gorm:"default:1" json:"min_level"` // 최소 회원 레벨 (1=일반, 10=관리자)
+}
+
+// TableName GORM 테이블명
+func (PluginPermission) TableName() string {
+	return "plugin_permissions"
+}
+
 // 이벤트 타입 상수
 const (
 	EventInstalled     = "installed"

--- a/internal/pluginstore/handler/permission_handler.go
+++ b/internal/pluginstore/handler/permission_handler.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/damoang/angple-backend/internal/pluginstore/service"
+	"github.com/gin-gonic/gin"
+)
+
+// PermissionHandler 플러그인 권한 핸들러
+type PermissionHandler struct {
+	permSvc *service.PermissionService
+}
+
+// NewPermissionHandler 생성자
+func NewPermissionHandler(permSvc *service.PermissionService) *PermissionHandler {
+	return &PermissionHandler{permSvc: permSvc}
+}
+
+// GetPermissions 플러그인 권한 목록 조회
+// GET /api/v2/admin/plugins/:name/permissions
+func (h *PermissionHandler) GetPermissions(c *gin.Context) {
+	name := c.Param("name")
+
+	perms, err := h.permSvc.GetPermissions(name)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{"code": "PERMISSION_ERROR", "message": err.Error()},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": perms})
+}
+
+// UpdatePermission 권한 최소 레벨 변경
+// PUT /api/v2/admin/plugins/:name/permissions/:permId
+func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
+	name := c.Param("name")
+	permID := c.Param("permId")
+
+	var req struct {
+		MinLevel int `json:"min_level" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{"code": "INVALID_REQUEST", "message": "min_level은 필수입니다"},
+		})
+		return
+	}
+
+	if err := h.permSvc.UpdatePermissionLevel(name, permID, req.MinLevel); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{"code": "UPDATE_ERROR", "message": err.Error()},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": gin.H{"message": "권한이 업데이트되었습니다"}})
+}

--- a/internal/pluginstore/repository/permission_repository.go
+++ b/internal/pluginstore/repository/permission_repository.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"github.com/damoang/angple-backend/internal/pluginstore/domain"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// PermissionRepository 플러그인 권한 저장소
+type PermissionRepository struct {
+	db *gorm.DB
+}
+
+// NewPermissionRepository 생성자
+func NewPermissionRepository(db *gorm.DB) *PermissionRepository {
+	return &PermissionRepository{db: db}
+}
+
+// Upsert 권한 생성 또는 업데이트 (label만 갱신, min_level은 유지)
+func (r *PermissionRepository) Upsert(perm *domain.PluginPermission) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "plugin_name"}, {Name: "permission_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"label"}),
+	}).Create(perm).Error
+}
+
+// UpdateMinLevel 권한의 최소 레벨 변경
+func (r *PermissionRepository) UpdateMinLevel(pluginName, permissionID string, minLevel int) error {
+	return r.db.Model(&domain.PluginPermission{}).
+		Where("plugin_name = ? AND permission_id = ?", pluginName, permissionID).
+		Update("min_level", minLevel).Error
+}
+
+// GetByPlugin 플러그인의 모든 권한 조회
+func (r *PermissionRepository) GetByPlugin(pluginName string) ([]domain.PluginPermission, error) {
+	var perms []domain.PluginPermission
+	err := r.db.Where("plugin_name = ?", pluginName).Find(&perms).Error
+	return perms, err
+}
+
+// GetByID 특정 권한 조회
+func (r *PermissionRepository) GetByID(pluginName, permissionID string) (*domain.PluginPermission, error) {
+	var perm domain.PluginPermission
+	err := r.db.Where("plugin_name = ? AND permission_id = ?", pluginName, permissionID).First(&perm).Error
+	if err != nil {
+		return nil, err
+	}
+	return &perm, nil
+}
+
+// DeleteByPlugin 플러그인의 모든 권한 삭제
+func (r *PermissionRepository) DeleteByPlugin(pluginName string) error {
+	return r.db.Where("plugin_name = ?", pluginName).Delete(&domain.PluginPermission{}).Error
+}

--- a/internal/pluginstore/service/permission_service.go
+++ b/internal/pluginstore/service/permission_service.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/damoang/angple-backend/internal/plugin"
+	"github.com/damoang/angple-backend/internal/pluginstore/domain"
+	"github.com/damoang/angple-backend/internal/pluginstore/repository"
+)
+
+// PermissionService 플러그인 권한 관리 서비스
+type PermissionService struct {
+	permRepo   *repository.PermissionRepository
+	catalogSvc *CatalogService
+}
+
+// NewPermissionService 생성자
+func NewPermissionService(
+	permRepo *repository.PermissionRepository,
+	catalogSvc *CatalogService,
+) *PermissionService {
+	return &PermissionService{
+		permRepo:   permRepo,
+		catalogSvc: catalogSvc,
+	}
+}
+
+// SyncPermissions 매니페스트의 권한 정의를 DB에 동기화
+// 새 권한은 기본 min_level=1로 생성, 기존 권한의 min_level은 유지
+func (s *PermissionService) SyncPermissions(pluginName string, permissions []plugin.Permission) error {
+	for _, p := range permissions {
+		perm := &domain.PluginPermission{
+			PluginName:   pluginName,
+			PermissionID: p.ID,
+			Label:        p.Label,
+			MinLevel:     1, // 기본값 (Upsert에서 기존 min_level 유지)
+		}
+		if err := s.permRepo.Upsert(perm); err != nil {
+			return fmt.Errorf("failed to sync permission %s: %w", p.ID, err)
+		}
+	}
+	return nil
+}
+
+// DeletePermissions 플러그인 권한 삭제 (언인스톨 시)
+func (s *PermissionService) DeletePermissions(pluginName string) error {
+	return s.permRepo.DeleteByPlugin(pluginName)
+}
+
+// CheckPermission 사용자가 특정 권한을 가지는지 확인
+func (s *PermissionService) CheckPermission(pluginName, permissionID string, userLevel int) (bool, error) {
+	perm, err := s.permRepo.GetByID(pluginName, permissionID)
+	if err != nil {
+		// 권한 정의가 없으면 허용 (정의되지 않은 권한은 체크하지 않음)
+		return true, nil
+	}
+	return userLevel >= perm.MinLevel, nil
+}
+
+// GetPermissions 플러그인의 권한 목록 조회
+func (s *PermissionService) GetPermissions(pluginName string) ([]domain.PluginPermission, error) {
+	return s.permRepo.GetByPlugin(pluginName)
+}
+
+// UpdatePermissionLevel 권한의 최소 레벨 변경
+func (s *PermissionService) UpdatePermissionLevel(pluginName, permissionID string, minLevel int) error {
+	if minLevel < 1 || minLevel > 10 {
+		return fmt.Errorf("min_level must be between 1 and 10")
+	}
+	return s.permRepo.UpdateMinLevel(pluginName, permissionID, minLevel)
+}

--- a/internal/pluginstore/service/permission_service_test.go
+++ b/internal/pluginstore/service/permission_service_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/damoang/angple-backend/internal/plugin"
+	"github.com/damoang/angple-backend/internal/pluginstore/domain"
+	"github.com/damoang/angple-backend/internal/pluginstore/repository"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupPermTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	db.AutoMigrate(&domain.PluginPermission{})
+	return db
+}
+
+func TestPermissionService_SyncPermissions(t *testing.T) {
+	db := setupPermTestDB(t)
+	permRepo := repository.NewPermissionRepository(db)
+	svc := NewPermissionService(permRepo, nil)
+
+	perms := []plugin.Permission{
+		{ID: "commerce.use", Label: "상점 이용"},
+		{ID: "commerce.admin", Label: "상점 관리"},
+	}
+
+	if err := svc.SyncPermissions("commerce", perms); err != nil {
+		t.Fatalf("SyncPermissions failed: %v", err)
+	}
+
+	// 조회 확인
+	result, err := svc.GetPermissions("commerce")
+	if err != nil {
+		t.Fatalf("GetPermissions failed: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 permissions, got %d", len(result))
+	}
+
+	// 기본 min_level = 1
+	for _, p := range result {
+		if p.MinLevel != 1 {
+			t.Errorf("expected default min_level 1, got %d for %s", p.MinLevel, p.PermissionID)
+		}
+	}
+}
+
+func TestPermissionService_SyncPreservesMinLevel(t *testing.T) {
+	db := setupPermTestDB(t)
+	permRepo := repository.NewPermissionRepository(db)
+	svc := NewPermissionService(permRepo, nil)
+
+	// 초기 동기화
+	perms := []plugin.Permission{{ID: "commerce.admin", Label: "관리"}}
+	svc.SyncPermissions("commerce", perms)
+
+	// 관리자 레벨로 변경
+	svc.UpdatePermissionLevel("commerce", "commerce.admin", 10)
+
+	// 재동기화 (라벨 변경)
+	perms[0].Label = "관리 (업데이트)"
+	svc.SyncPermissions("commerce", perms)
+
+	// min_level이 10으로 유지되는지 확인
+	result, _ := svc.GetPermissions("commerce")
+	if result[0].MinLevel != 10 {
+		t.Errorf("expected min_level 10 after re-sync, got %d", result[0].MinLevel)
+	}
+	if result[0].Label != "관리 (업데이트)" {
+		t.Errorf("expected updated label, got %q", result[0].Label)
+	}
+}
+
+func TestPermissionService_CheckPermission(t *testing.T) {
+	db := setupPermTestDB(t)
+	permRepo := repository.NewPermissionRepository(db)
+	svc := NewPermissionService(permRepo, nil)
+
+	svc.SyncPermissions("commerce", []plugin.Permission{
+		{ID: "commerce.use", Label: "이용"},
+		{ID: "commerce.admin", Label: "관리"},
+	})
+	svc.UpdatePermissionLevel("commerce", "commerce.admin", 10)
+
+	tests := []struct {
+		perm  string
+		level int
+		want  bool
+	}{
+		{"commerce.use", 1, true},     // level 1 >= min 1
+		{"commerce.use", 0, false},    // level 0 < min 1
+		{"commerce.admin", 5, false},  // level 5 < min 10
+		{"commerce.admin", 10, true},  // level 10 >= min 10
+		{"commerce.unknown", 1, true}, // 정의되지 않은 권한 → 허용
+	}
+
+	for _, tc := range tests {
+		got, err := svc.CheckPermission("commerce", tc.perm, tc.level)
+		if err != nil {
+			t.Errorf("CheckPermission(%q, %d) error: %v", tc.perm, tc.level, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("CheckPermission(%q, %d) = %v, want %v", tc.perm, tc.level, got, tc.want)
+		}
+	}
+}
+
+func TestPermissionService_UpdatePermissionLevel_InvalidRange(t *testing.T) {
+	db := setupPermTestDB(t)
+	permRepo := repository.NewPermissionRepository(db)
+	svc := NewPermissionService(permRepo, nil)
+
+	if err := svc.UpdatePermissionLevel("x", "x.use", 0); err == nil {
+		t.Error("expected error for min_level 0")
+	}
+	if err := svc.UpdatePermissionLevel("x", "x.use", 11); err == nil {
+		t.Error("expected error for min_level 11")
+	}
+}
+
+func TestPermissionService_DeletePermissions(t *testing.T) {
+	db := setupPermTestDB(t)
+	permRepo := repository.NewPermissionRepository(db)
+	svc := NewPermissionService(permRepo, nil)
+
+	svc.SyncPermissions("commerce", []plugin.Permission{
+		{ID: "commerce.use", Label: "이용"},
+	})
+
+	if err := svc.DeletePermissions("commerce"); err != nil {
+		t.Fatalf("DeletePermissions failed: %v", err)
+	}
+
+	result, _ := svc.GetPermissions("commerce")
+	if len(result) != 0 {
+		t.Errorf("expected 0 permissions after delete, got %d", len(result))
+	}
+}

--- a/internal/pluginstore/service/store_service_test.go
+++ b/internal/pluginstore/service/store_service_test.go
@@ -40,7 +40,7 @@ func setupStoreService(t *testing.T) (*StoreService, *CatalogService, *plugin.Ma
 	logger := plugin.NewDefaultLogger("test")
 	storeSvc := NewStoreService(installRepo, eventRepo, settingRepo, catalogSvc, logger)
 
-	manager := plugin.NewManager("", db, nil, logger, nil)
+	manager := plugin.NewManager("", db, nil, logger, nil, nil)
 
 	// 내장 플러그인 등록
 	mockPlugin := &mockPlugin{name: "test-plugin"}
@@ -146,7 +146,7 @@ func TestBootEnabledPlugins(t *testing.T) {
 
 	// 새 매니저로 부팅 시뮬레이션
 	logger := plugin.NewDefaultLogger("test")
-	newManager := plugin.NewManager("", setupTestDB(t), nil, logger, nil)
+	newManager := plugin.NewManager("", setupTestDB(t), nil, logger, nil, nil)
 	mockP := &mockPlugin{name: "test-plugin"}
 	testManifest := &plugin.PluginManifest{Name: "test-plugin", Version: "1.0.0"}
 	newManager.RegisterBuiltIn("test-plugin", mockP, testManifest)
@@ -177,7 +177,7 @@ func TestConflictCheck(t *testing.T) {
 	logger := plugin.NewDefaultLogger("test")
 	storeSvc := NewStoreService(installRepo, eventRepo, settingRepo, catalogSvc, logger)
 
-	manager := plugin.NewManager("", db, nil, logger, nil)
+	manager := plugin.NewManager("", db, nil, logger, nil, nil)
 	manager.RegisterBuiltIn("plugin-a", &mockPlugin{name: "plugin-a"}, pluginA)
 	manager.RegisterBuiltIn("plugin-b", &mockPlugin{name: "plugin-b"}, pluginB)
 


### PR DESCRIPTION
- Add PluginPermission model (plugin_name + permission_id → min_level)
- Add PermissionRepository with upsert, update, query, delete operations
- Add PermissionService: SyncPermissions, CheckPermission, UpdatePermissionLevel
- Add PermissionSyncer interface in plugin/types.go to avoid circular deps
- Manager.Enable() auto-syncs manifest permissions to DB on plugin activation
- Add admin API: GET/PUT /api/v2/admin/plugins/:name/permissions/:permId
- Add plugin_permissions table to AutoMigrate
- 5 test cases covering sync, level preservation, check, delete, validation