### PR TITLE
feat: add semver validation for plugin version compatibility

### DIFF
--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -56,6 +56,15 @@ func (l *Loader) validateManifest(m *PluginManifest) error {
 	if m.Requires.Angple == "" {
 		return fmt.Errorf("requires.angple version is required")
 	}
+
+	// 버전 문자열 문법 검증
+	if _, err := ParseSemVer(m.Version); err != nil {
+		return fmt.Errorf("invalid plugin version %q: %w", m.Version, err)
+	}
+	if _, err := ParseVersionRange(m.Requires.Angple); err != nil {
+		return fmt.Errorf("invalid requires.angple %q: %w", m.Requires.Angple, err)
+	}
+
 	return nil
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -100,6 +100,13 @@ func (m *Manager) Enable(name string) error {
 		return nil // 이미 활성화됨
 	}
 
+	// 버전 호환성 검증
+	if info.Manifest != nil && info.Manifest.Requires.Angple != "" {
+		if err := CheckVersionRange(CoreVersion, info.Manifest.Requires.Angple); err != nil {
+			return fmt.Errorf("plugin %s is not compatible: %w", name, err)
+		}
+	}
+
 	// 플러그인 인스턴스가 있으면 마이그레이션 → 초기화
 	if info.Instance != nil {
 		// 1) 마이그레이션 먼저

--- a/internal/plugin/version.go
+++ b/internal/plugin/version.go
@@ -1,0 +1,216 @@
+package plugin
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CoreVersion 현재 Angple Core 버전
+const CoreVersion = "1.0.0"
+
+// SemVer 시맨틱 버전
+type SemVer struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// ParseSemVer 버전 문자열 파싱 (프리릴리즈 태그 무시)
+func ParseSemVer(s string) (SemVer, error) {
+	s = strings.TrimSpace(s)
+	// 프리릴리즈 태그 제거 (e.g., "1.0.0-beta" → "1.0.0")
+	if idx := strings.IndexAny(s, "-+"); idx >= 0 {
+		s = s[:idx]
+	}
+
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return SemVer{}, fmt.Errorf("invalid semver: %q (expected x.y.z)", s)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid major version: %q", parts[0])
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid minor version: %q", parts[1])
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return SemVer{}, fmt.Errorf("invalid patch version: %q", parts[2])
+	}
+
+	return SemVer{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// Compare 비교: -1 (v < other), 0 (v == other), 1 (v > other)
+func (v SemVer) Compare(other SemVer) int {
+	if v.Major != other.Major {
+		if v.Major < other.Major {
+			return -1
+		}
+		return 1
+	}
+	if v.Minor != other.Minor {
+		if v.Minor < other.Minor {
+			return -1
+		}
+		return 1
+	}
+	if v.Patch != other.Patch {
+		if v.Patch < other.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func (v SemVer) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// VersionConstraint 버전 제약 조건
+type VersionConstraint struct {
+	Op      string // ">=", "<", "~", "^"
+	Version SemVer
+}
+
+// ParseVersionRange 버전 범위 문자열 파싱
+// 지원 형식: ">=1.0.0", ">=1.0.0 <2.0.0", "~1.2.0", "^1.2.0"
+func ParseVersionRange(s string) ([]VersionConstraint, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, fmt.Errorf("empty version range")
+	}
+
+	tokens := strings.Fields(s)
+	constraints := make([]VersionConstraint, 0, len(tokens))
+
+	for _, token := range tokens {
+		c, err := parseConstraint(token)
+		if err != nil {
+			return nil, err
+		}
+		constraints = append(constraints, c)
+	}
+
+	return constraints, nil
+}
+
+func parseConstraint(s string) (VersionConstraint, error) {
+	if strings.HasPrefix(s, ">=") {
+		v, err := ParseSemVer(s[2:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: ">=", Version: v}, nil
+	}
+	if strings.HasPrefix(s, ">") {
+		v, err := ParseSemVer(s[1:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: ">", Version: v}, nil
+	}
+	if strings.HasPrefix(s, "<=") {
+		v, err := ParseSemVer(s[2:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: "<=", Version: v}, nil
+	}
+	if strings.HasPrefix(s, "<") {
+		v, err := ParseSemVer(s[1:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: "<", Version: v}, nil
+	}
+	if strings.HasPrefix(s, "~") {
+		v, err := ParseSemVer(s[1:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: "~", Version: v}, nil
+	}
+	if strings.HasPrefix(s, "^") {
+		v, err := ParseSemVer(s[1:])
+		if err != nil {
+			return VersionConstraint{}, err
+		}
+		return VersionConstraint{Op: "^", Version: v}, nil
+	}
+
+	// 연산자 없으면 exact match
+	v, err := ParseSemVer(s)
+	if err != nil {
+		return VersionConstraint{}, fmt.Errorf("unknown version constraint: %q", s)
+	}
+	return VersionConstraint{Op: "=", Version: v}, nil
+}
+
+// CheckVersion 버전이 제약 조건을 만족하는지 확인
+func CheckVersion(version SemVer, constraints []VersionConstraint) bool {
+	for _, c := range constraints {
+		if !matchConstraint(version, c) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchConstraint(v SemVer, c VersionConstraint) bool {
+	cmp := v.Compare(c.Version)
+
+	switch c.Op {
+	case ">=":
+		return cmp >= 0
+	case ">":
+		return cmp > 0
+	case "<=":
+		return cmp <= 0
+	case "<":
+		return cmp < 0
+	case "=":
+		return cmp == 0
+	case "~":
+		// ~1.2.0 → >=1.2.0 <1.3.0 (패치만 허용)
+		if cmp < 0 {
+			return false
+		}
+		return v.Major == c.Version.Major && v.Minor == c.Version.Minor
+	case "^":
+		// ^1.2.0 → >=1.2.0 <2.0.0 (마이너+패치 허용)
+		// ^0.2.0 → >=0.2.0 <0.3.0 (major가 0이면 마이너가 범위)
+		if cmp < 0 {
+			return false
+		}
+		if c.Version.Major == 0 {
+			return v.Major == 0 && v.Minor == c.Version.Minor
+		}
+		return v.Major == c.Version.Major
+	}
+	return false
+}
+
+// CheckVersionRange 버전 범위 문자열로 직접 검증
+func CheckVersionRange(version, rangeStr string) error {
+	v, err := ParseSemVer(version)
+	if err != nil {
+		return fmt.Errorf("invalid version %q: %w", version, err)
+	}
+
+	constraints, err := ParseVersionRange(rangeStr)
+	if err != nil {
+		return fmt.Errorf("invalid version range %q: %w", rangeStr, err)
+	}
+
+	if !CheckVersion(v, constraints) {
+		return fmt.Errorf("version %s does not satisfy constraint %q", version, rangeStr)
+	}
+
+	return nil
+}

--- a/internal/plugin/version_test.go
+++ b/internal/plugin/version_test.go
@@ -1,0 +1,167 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestParseSemVer(t *testing.T) {
+	tests := []struct {
+		input string
+		want  SemVer
+		ok    bool
+	}{
+		{"1.0.0", SemVer{1, 0, 0}, true},
+		{"2.1.3", SemVer{2, 1, 3}, true},
+		{"0.0.1", SemVer{0, 0, 1}, true},
+		{"1.0.0-beta", SemVer{1, 0, 0}, true},
+		{"1.0.0+build.123", SemVer{1, 0, 0}, true},
+		{"1.0", SemVer{}, false},
+		{"abc", SemVer{}, false},
+		{"", SemVer{}, false},
+	}
+
+	for _, tc := range tests {
+		got, err := ParseSemVer(tc.input)
+		if tc.ok && err != nil {
+			t.Errorf("ParseSemVer(%q) unexpected error: %v", tc.input, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("ParseSemVer(%q) expected error, got %v", tc.input, got)
+		}
+		if tc.ok && got != tc.want {
+			t.Errorf("ParseSemVer(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSemVer_Compare(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.1", -1},
+		{"2.0.0", "1.9.9", 1},
+		{"1.1.0", "1.0.9", 1},
+	}
+
+	for _, tc := range tests {
+		a, _ := ParseSemVer(tc.a)
+		b, _ := ParseSemVer(tc.b)
+		got := a.Compare(b)
+		if got != tc.want {
+			t.Errorf("%s.Compare(%s) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestCheckVersionRange_GTE(t *testing.T) {
+	// >=1.0.0
+	if err := CheckVersionRange("1.0.0", ">=1.0.0"); err != nil {
+		t.Errorf("1.0.0 should satisfy >=1.0.0: %v", err)
+	}
+	if err := CheckVersionRange("2.0.0", ">=1.0.0"); err != nil {
+		t.Errorf("2.0.0 should satisfy >=1.0.0: %v", err)
+	}
+	if err := CheckVersionRange("0.9.9", ">=1.0.0"); err == nil {
+		t.Error("0.9.9 should NOT satisfy >=1.0.0")
+	}
+}
+
+func TestCheckVersionRange_Compound(t *testing.T) {
+	// >=1.0.0 <2.0.0
+	constraint := ">=1.0.0 <2.0.0"
+
+	good := []string{"1.0.0", "1.5.0", "1.9.9"}
+	for _, v := range good {
+		if err := CheckVersionRange(v, constraint); err != nil {
+			t.Errorf("%s should satisfy %q: %v", v, constraint, err)
+		}
+	}
+
+	bad := []string{"0.9.9", "2.0.0", "3.0.0"}
+	for _, v := range bad {
+		if err := CheckVersionRange(v, constraint); err == nil {
+			t.Errorf("%s should NOT satisfy %q", v, constraint)
+		}
+	}
+}
+
+func TestCheckVersionRange_Tilde(t *testing.T) {
+	// ~1.2.0 → >=1.2.0, same major.minor
+	constraint := "~1.2.0"
+
+	good := []string{"1.2.0", "1.2.5", "1.2.99"}
+	for _, v := range good {
+		if err := CheckVersionRange(v, constraint); err != nil {
+			t.Errorf("%s should satisfy %q: %v", v, constraint, err)
+		}
+	}
+
+	bad := []string{"1.1.9", "1.3.0", "2.0.0"}
+	for _, v := range bad {
+		if err := CheckVersionRange(v, constraint); err == nil {
+			t.Errorf("%s should NOT satisfy %q", v, constraint)
+		}
+	}
+}
+
+func TestCheckVersionRange_Caret(t *testing.T) {
+	// ^1.2.0 → >=1.2.0, same major
+	constraint := "^1.2.0"
+
+	good := []string{"1.2.0", "1.3.0", "1.99.99"}
+	for _, v := range good {
+		if err := CheckVersionRange(v, constraint); err != nil {
+			t.Errorf("%s should satisfy %q: %v", v, constraint, err)
+		}
+	}
+
+	bad := []string{"1.1.9", "2.0.0", "0.9.0"}
+	for _, v := range bad {
+		if err := CheckVersionRange(v, constraint); err == nil {
+			t.Errorf("%s should NOT satisfy %q", v, constraint)
+		}
+	}
+}
+
+func TestCheckVersionRange_CaretZero(t *testing.T) {
+	// ^0.2.0 → >=0.2.0, same 0.minor
+	constraint := "^0.2.0"
+
+	good := []string{"0.2.0", "0.2.5"}
+	for _, v := range good {
+		if err := CheckVersionRange(v, constraint); err != nil {
+			t.Errorf("%s should satisfy %q: %v", v, constraint, err)
+		}
+	}
+
+	bad := []string{"0.1.9", "0.3.0", "1.0.0"}
+	for _, v := range bad {
+		if err := CheckVersionRange(v, constraint); err == nil {
+			t.Errorf("%s should NOT satisfy %q", v, constraint)
+		}
+	}
+}
+
+func TestCheckVersionRange_ExactMatch(t *testing.T) {
+	if err := CheckVersionRange("1.0.0", "1.0.0"); err != nil {
+		t.Errorf("exact match should pass: %v", err)
+	}
+	if err := CheckVersionRange("1.0.1", "1.0.0"); err == nil {
+		t.Error("1.0.1 should NOT match exact 1.0.0")
+	}
+}
+
+func TestCheckVersionRange_InvalidInputs(t *testing.T) {
+	if err := CheckVersionRange("bad", ">=1.0.0"); err == nil {
+		t.Error("expected error for bad version")
+	}
+	if err := CheckVersionRange("1.0.0", ""); err == nil {
+		t.Error("expected error for empty range")
+	}
+	if err := CheckVersionRange("1.0.0", "???"); err == nil {
+		t.Error("expected error for invalid range")
+	}
+}

--- a/internal/pluginstore/service/store_service.go
+++ b/internal/pluginstore/service/store_service.go
@@ -229,6 +229,13 @@ func (s *StoreService) checkDependencies(manifest *plugin.PluginManifest) error 
 		if inst.Status != domain.StatusEnabled {
 			return fmt.Errorf("dependency not satisfied: plugin %s requires %s to be enabled", manifest.Name, dep.Name)
 		}
+		// 의존 플러그인 버전 범위 검증
+		if dep.Version != "" {
+			if err := plugin.CheckVersionRange(inst.Version, dep.Version); err != nil {
+				return fmt.Errorf("dependency version not satisfied: plugin %s requires %s %s, installed %s",
+					manifest.Name, dep.Name, dep.Version, inst.Version)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Add version.go: ParseSemVer, ParseVersionRange, CheckVersionRange
- Support all spec operators: >=, <, ~, ^, exact match, compound ranges
- CoreVersion constant (1.0.0) for compatibility checks
- Manager.Enable() validates requires.angple before activation
- Loader.validateManifest() checks version syntax at load time
- StoreService.checkDependencies() validates plugin dependency versions
- 9 test cases covering all operators and edge cases