### PR TITLE
feat: 외부 플러그인 SQL 마이그레이션 실행 및 버전 추적 구현

### DIFF
--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -9,7 +9,7 @@ import (
 // Run executes AutoMigrate for the menus table and seeds default data if empty.
 func Run(db *gorm.DB) error {
 	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
-	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginPermission{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
 		return err
 	}
 

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -9,7 +9,7 @@ import (
 // Run executes AutoMigrate for the menus table and seeds default data if empty.
 func Run(db *gorm.DB) error {
 	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
-	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
 		return err
 	}
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -2,6 +2,9 @@ package plugin
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -266,6 +269,18 @@ func (m *Manager) Shutdown() error {
 	return nil
 }
 
+// PluginMigrationRecord 마이그레이션 실행 이력 (GORM 모델)
+type PluginMigrationRecord struct {
+	ID         int64     `gorm:"primaryKey"`
+	PluginName string    `gorm:"size:100;uniqueIndex:uk_plugin_migration"`
+	Filename   string    `gorm:"size:255;uniqueIndex:uk_plugin_migration"`
+	ExecutedAt time.Time `gorm:"autoCreateTime"`
+}
+
+func (PluginMigrationRecord) TableName() string {
+	return "plugin_migrations"
+}
+
 // RunMigrations 플러그인 마이그레이션 실행
 func (m *Manager) RunMigrations(name string) error {
 	m.mu.RLock()
@@ -277,8 +292,11 @@ func (m *Manager) RunMigrations(name string) error {
 	}
 
 	if info.IsBuiltIn {
-		// 내장 플러그인은 별도 마이그레이션 디렉토리 사용
 		return m.runBuiltInMigrations(name)
+	}
+
+	if m.db == nil {
+		return fmt.Errorf("database not initialized")
 	}
 
 	files, err := m.loader.GetMigrationFiles(info.Path)
@@ -290,8 +308,47 @@ func (m *Manager) RunMigrations(name string) error {
 		return nil
 	}
 
-	// TODO: 마이그레이션 버전 추적 및 실행
-	m.logger.Info("Found %d migration files for plugin %s", len(files), name)
+	// 파일명 순서 정렬 (001_init.up.sql, 002_add_column.up.sql, ...)
+	sort.Strings(files)
+
+	// 이미 실행된 마이그레이션 조회
+	var executed []PluginMigrationRecord
+	m.db.Where("plugin_name = ?", name).Find(&executed)
+	executedMap := make(map[string]bool, len(executed))
+	for _, rec := range executed {
+		executedMap[rec.Filename] = true
+	}
+
+	// 미실행 마이그레이션 순서대로 실행
+	for _, filePath := range files {
+		filename := filepath.Base(filePath)
+
+		if executedMap[filename] {
+			continue // 이미 실행됨
+		}
+
+		sql, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("마이그레이션 파일 읽기 실패 %s: %w", filename, err)
+		}
+
+		// SQL 실행
+		if err := m.db.Exec(string(sql)).Error; err != nil {
+			return fmt.Errorf("마이그레이션 실행 실패 %s: %w", filename, err)
+		}
+
+		// 실행 이력 기록
+		record := &PluginMigrationRecord{
+			PluginName: name,
+			Filename:   filename,
+		}
+		if err := m.db.Create(record).Error; err != nil {
+			return fmt.Errorf("마이그레이션 이력 기록 실패 %s: %w", filename, err)
+		}
+
+		m.logger.Info("마이그레이션 실행 완료: %s/%s", name, filename)
+	}
+
 	return nil
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -327,7 +327,8 @@ func (m *Manager) RunMigrations(name string) error {
 			continue // 이미 실행됨
 		}
 
-		sql, err := os.ReadFile(filePath)
+		cleanPath := filepath.Clean(filePath)
+		sql, err := os.ReadFile(cleanPath) // #nosec G304 -- path from plugin dir + glob, not user input
 		if err != nil {
 			return fmt.Errorf("마이그레이션 파일 읽기 실패 %s: %w", filename, err)
 		}

--- a/internal/plugin/migration_test.go
+++ b/internal/plugin/migration_test.go
@@ -1,0 +1,150 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupMigrationTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("DB 생성 실패: %v", err)
+	}
+	db.AutoMigrate(&PluginMigrationRecord{})
+	return db
+}
+
+func setupMigrationFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	migDir := filepath.Join(dir, "migrations")
+	os.MkdirAll(migDir, 0o755)
+	for name, content := range files {
+		os.WriteFile(filepath.Join(migDir, name), []byte(content), 0o644)
+	}
+}
+
+func TestRunMigrations_ExecutesSQL(t *testing.T) {
+	db := setupMigrationTestDB(t)
+	logger := NewDefaultLogger("test")
+
+	// 임시 플러그인 디렉토리 생성
+	tmpDir := t.TempDir()
+	pluginDir := filepath.Join(tmpDir, "test-plugin")
+	os.MkdirAll(pluginDir, 0o755)
+
+	// 마이그레이션 파일 생성
+	setupMigrationFiles(t, pluginDir, map[string]string{
+		"001_init.up.sql":      "CREATE TABLE test_items (id INTEGER PRIMARY KEY, name TEXT);",
+		"002_add_field.up.sql": "ALTER TABLE test_items ADD COLUMN price REAL;",
+	})
+
+	manager := NewManager(tmpDir, db, nil, logger, nil, nil)
+	manager.mu.Lock()
+	manager.plugins["test-plugin"] = &PluginInfo{
+		Manifest: &PluginManifest{Name: "test-plugin", Version: "1.0.0"},
+		Path:     pluginDir,
+		Status:   StatusDisabled,
+	}
+	manager.mu.Unlock()
+
+	// 마이그레이션 실행
+	if err := manager.RunMigrations("test-plugin"); err != nil {
+		t.Fatalf("RunMigrations 실패: %v", err)
+	}
+
+	// 테이블이 생성되었는지 확인
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM test_items").Scan(&count)
+	// 에러 없으면 테이블 존재
+
+	// 이력 확인
+	var records []PluginMigrationRecord
+	db.Where("plugin_name = ?", "test-plugin").Order("filename").Find(&records)
+	if len(records) != 2 {
+		t.Fatalf("마이그레이션 이력 2건 예상, %d건 조회됨", len(records))
+	}
+	if records[0].Filename != "001_init.up.sql" {
+		t.Errorf("첫 번째 이력 파일명: %s", records[0].Filename)
+	}
+	if records[1].Filename != "002_add_field.up.sql" {
+		t.Errorf("두 번째 이력 파일명: %s", records[1].Filename)
+	}
+}
+
+func TestRunMigrations_SkipsAlreadyExecuted(t *testing.T) {
+	db := setupMigrationTestDB(t)
+	logger := NewDefaultLogger("test")
+
+	tmpDir := t.TempDir()
+	pluginDir := filepath.Join(tmpDir, "test-plugin")
+	os.MkdirAll(pluginDir, 0o755)
+
+	setupMigrationFiles(t, pluginDir, map[string]string{
+		"001_init.up.sql": "CREATE TABLE skip_test (id INTEGER PRIMARY KEY);",
+	})
+
+	manager := NewManager(tmpDir, db, nil, logger, nil, nil)
+	manager.mu.Lock()
+	manager.plugins["test-plugin"] = &PluginInfo{
+		Manifest: &PluginManifest{Name: "test-plugin", Version: "1.0.0"},
+		Path:     pluginDir,
+		Status:   StatusDisabled,
+	}
+	manager.mu.Unlock()
+
+	// 첫 번째 실행
+	if err := manager.RunMigrations("test-plugin"); err != nil {
+		t.Fatalf("첫 번째 RunMigrations 실패: %v", err)
+	}
+
+	// 두 번째 실행 (스킵되어야 함)
+	if err := manager.RunMigrations("test-plugin"); err != nil {
+		t.Fatalf("두 번째 RunMigrations 실패: %v", err)
+	}
+
+	// 이력은 1건만
+	var records []PluginMigrationRecord
+	db.Where("plugin_name = ?", "test-plugin").Find(&records)
+	if len(records) != 1 {
+		t.Errorf("이력 1건 예상, %d건 조회됨", len(records))
+	}
+}
+
+func TestRunMigrations_NoFiles(t *testing.T) {
+	db := setupMigrationTestDB(t)
+	logger := NewDefaultLogger("test")
+
+	tmpDir := t.TempDir()
+	pluginDir := filepath.Join(tmpDir, "empty-plugin")
+	os.MkdirAll(pluginDir, 0o755)
+
+	manager := NewManager(tmpDir, db, nil, logger, nil, nil)
+	manager.mu.Lock()
+	manager.plugins["empty-plugin"] = &PluginInfo{
+		Manifest: &PluginManifest{Name: "empty-plugin", Version: "1.0.0"},
+		Path:     pluginDir,
+		Status:   StatusDisabled,
+	}
+	manager.mu.Unlock()
+
+	// 마이그레이션 없으면 정상 반환
+	if err := manager.RunMigrations("empty-plugin"); err != nil {
+		t.Fatalf("빈 마이그레이션 실패: %v", err)
+	}
+}
+
+func TestRunMigrations_PluginNotFound(t *testing.T) {
+	db := setupMigrationTestDB(t)
+	logger := NewDefaultLogger("test")
+
+	manager := NewManager(t.TempDir(), db, nil, logger, nil, nil)
+
+	if err := manager.RunMigrations("nonexistent"); err == nil {
+		t.Error("존재하지 않는 플러그인에 대해 에러 예상")
+	}
+}

--- a/internal/pluginstore/domain/installation.go
+++ b/internal/pluginstore/domain/installation.go
@@ -64,6 +64,19 @@ func (PluginPermission) TableName() string {
 	return "plugin_permissions"
 }
 
+// PluginMigration 플러그인 마이그레이션 실행 이력
+type PluginMigration struct {
+	ID         int64     `gorm:"primaryKey" json:"id"`
+	PluginName string    `gorm:"size:100;uniqueIndex:uk_plugin_migration" json:"plugin_name"`
+	Filename   string    `gorm:"size:255;uniqueIndex:uk_plugin_migration" json:"filename"`
+	ExecutedAt time.Time `gorm:"autoCreateTime" json:"executed_at"`
+}
+
+// TableName GORM 테이블명
+func (PluginMigration) TableName() string {
+	return "plugin_migrations"
+}
+
 // 이벤트 타입 상수
 const (
 	EventInstalled     = "installed"


### PR DESCRIPTION
- PluginMigration 모델 추가 (plugin_name + filename 유니크 인덱스)
- RunMigrations(): .sql 파일을 파일명 순서대로 실행, 이미 실행된 파일은 스킵
- plugin_migrations 테이블로 실행 이력 추적
- AutoMigrate에 plugin_migrations 테이블 추가
- 4개 테스트: SQL 실행, 중복 스킵, 빈 마이그레이션, 존재하지 않는 플러그인