### PR TITLE
플러그인 헬스 체크 시스템 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -316,6 +316,7 @@ func main() {
 		// TODO: 운영 환경에서는 admin 미들웨어 추가 필요
 		{
 			adminPlugins.GET("", storeHandler.ListPlugins)
+			adminPlugins.GET("/health", storeHandler.HealthCheck)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)
 			adminPlugins.POST("/:name/install", storeHandler.InstallPlugin)
 			adminPlugins.POST("/:name/enable", storeHandler.EnablePlugin)
@@ -326,6 +327,7 @@ func main() {
 			adminPlugins.GET("/:name/events", storeHandler.GetEvents)
 			adminPlugins.GET("/:name/permissions", permHandler.GetPermissions)
 			adminPlugins.PUT("/:name/permissions/:permId", permHandler.UpdatePermission)
+			adminPlugins.GET("/:name/health", storeHandler.HealthCheckSingle)
 		}
 
 		pkglogger.Info("Plugin Store initialized")

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -184,6 +184,18 @@ type PluginReloader interface {
 	ReloadPlugin(name string) error
 }
 
+// HealthCheckable 선택적 인터페이스 - 플러그인 상태 점검
+type HealthCheckable interface {
+	HealthCheck() error
+}
+
+// PluginHealth 플러그인 헬스 체크 결과
+type PluginHealth struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"` // healthy, unhealthy, disabled
+	Message string `json:"message,omitempty"`
+}
+
 // HookAware 선택적 인터페이스 - Hook을 등록하고 싶은 플러그인이 구현
 type HookAware interface {
 	RegisterHooks(hm *HookManager)

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -151,6 +151,21 @@ func (h *StoreHandler) GetEvents(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": events})
 }
 
+// HealthCheck 플러그인 헬스 체크
+// GET /api/v2/admin/plugins/health
+func (h *StoreHandler) HealthCheck(c *gin.Context) {
+	results := h.manager.CheckAllHealth()
+	c.JSON(http.StatusOK, gin.H{"data": results})
+}
+
+// HealthCheckSingle 단일 플러그인 헬스 체크
+// GET /api/v2/admin/plugins/:name/health
+func (h *StoreHandler) HealthCheckSingle(c *gin.Context) {
+	name := c.Param("name")
+	result := h.manager.CheckHealth(name)
+	c.JSON(http.StatusOK, gin.H{"data": result})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- 플러그인 상태를 API로 점검할 수 있는 헬스 체크 시스템 구현
- HealthCheckable 인터페이스를 구현한 플러그인은 상세 상태 보고 가능

## 변경 내용
- `types.go`: `HealthCheckable` 인터페이스, `PluginHealth` 결과 구조체
- `manager.go`: `CheckHealth()`, `CheckAllHealth()` 메서드
- `store_handler.go`: 전체/개별 헬스 체크 API 핸들러
- `main.go`: `/health`, `/:name/health` 라우트 등록
- `manager_test.go`: healthy, unhealthy, disabled, checkAll 테스트 4건

## Test plan
- [x] TestCheckHealth_Healthy 통과
- [x] TestCheckHealth_Unhealthy 통과
- [x] TestCheckHealth_Disabled 통과
- [x] TestCheckAllHealth 통과
- [x] go test ./... 전체 통과