### PR TITLE
플러그인 Admin 대시보드 API 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -316,6 +316,7 @@ func main() {
 		// TODO: 운영 환경에서는 admin 미들웨어 추가 필요
 		{
 			adminPlugins.GET("", storeHandler.ListPlugins)
+			adminPlugins.GET("/dashboard", storeHandler.Dashboard)
 			adminPlugins.GET("/health", storeHandler.HealthCheck)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)
 			adminPlugins.POST("/:name/install", storeHandler.InstallPlugin)

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -166,6 +166,19 @@ func (h *StoreHandler) HealthCheckSingle(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": result})
 }
 
+// Dashboard 플러그인 대시보드
+// GET /api/v2/admin/plugins/dashboard
+func (h *StoreHandler) Dashboard(c *gin.Context) {
+	data, err := h.storeSvc.GetDashboard(h.manager)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": gin.H{"code": "DASHBOARD_ERROR", "message": err.Error()},
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": data})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴

--- a/internal/pluginstore/repository/event_repo.go
+++ b/internal/pluginstore/repository/event_repo.go
@@ -20,6 +20,16 @@ func (r *EventRepository) Create(event *domain.PluginEvent) error {
 	return r.db.Create(event).Error
 }
 
+// ListRecent 전체 최근 이벤트 조회
+func (r *EventRepository) ListRecent(limit int) ([]domain.PluginEvent, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	var list []domain.PluginEvent
+	err := r.db.Order("created_at DESC").Limit(limit).Find(&list).Error
+	return list, err
+}
+
 // ListByPlugin 플러그인별 이벤트 조회 (최신순, 기본 50개)
 func (r *EventRepository) ListByPlugin(pluginName string, limit int) ([]domain.PluginEvent, error) {
 	if limit <= 0 {


### PR DESCRIPTION
## Summary
- 관리자가 한눈에 플러그인 현황을 볼 수 있는 대시보드 API 추가
- 통계 + 플러그인 목록 + 최근 이벤트 + 헬스 체크를 단일 엔드포인트로 제공

## 변경 내용
- `store_service.go`: `GetDashboard()`, `DashboardData`, `DashboardPlugin` 구조체
- `event_repo.go`: `ListRecent()` 전체 최근 이벤트 조회
- `store_handler.go`: `Dashboard()` 핸들러
- `main.go`: `GET /api/v2/admin/plugins/dashboard` 라우트

## 응답 예시
```json
{
  "data": {
    "total": 2,
    "installed": 1,
    "enabled": 1,
    "disabled": 0,
    "error": 0,
    "plugins": [...],
    "recent_events": [...],
    "health": [...]
  }
}
```

## Test plan
- [x] go build ./... 통과
- [x] go test ./... 전체 통과