### PR TITLE
플러그인 스케줄러 시스템 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -318,6 +318,7 @@ func main() {
 			adminPlugins.GET("", storeHandler.ListPlugins)
 			adminPlugins.GET("/dashboard", storeHandler.Dashboard)
 			adminPlugins.GET("/health", storeHandler.HealthCheck)
+			adminPlugins.GET("/schedules", storeHandler.ScheduledTasks)
 			adminPlugins.GET("/settings/export", settingHandler.ExportAllSettings)
 			adminPlugins.POST("/settings/import", settingHandler.ImportSettings)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)
@@ -333,6 +334,9 @@ func main() {
 			adminPlugins.PUT("/:name/permissions/:permId", permHandler.UpdatePermission)
 			adminPlugins.GET("/:name/health", storeHandler.HealthCheckSingle)
 		}
+
+		// 플러그인 스케줄러 시작
+		pluginManager.StartScheduler()
 
 		pkglogger.Info("Plugin Store initialized")
 	}

--- a/internal/plugin/scheduler.go
+++ b/internal/plugin/scheduler.go
@@ -1,0 +1,155 @@
+package plugin
+
+import (
+	"sync"
+	"time"
+)
+
+// ScheduledTask 등록된 주기적 작업
+type ScheduledTask struct {
+	Name       string
+	PluginName string
+	Interval   time.Duration
+	Handler    func() error
+	LastRun    time.Time
+	NextRun    time.Time
+	RunCount   int64
+	LastError  error
+}
+
+// Scheduler 플러그인 스케줄러 (in-process)
+type Scheduler struct {
+	tasks  []*ScheduledTask
+	mu     sync.RWMutex
+	logger Logger
+	stop   chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewScheduler 스케줄러 생성
+func NewScheduler(logger Logger) *Scheduler {
+	return &Scheduler{
+		tasks:  make([]*ScheduledTask, 0),
+		logger: logger,
+		stop:   make(chan struct{}),
+	}
+}
+
+// Register 주기적 작업 등록
+func (s *Scheduler) Register(pluginName, taskName string, interval time.Duration, handler func() error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tasks = append(s.tasks, &ScheduledTask{
+		Name:       taskName,
+		PluginName: pluginName,
+		Interval:   interval,
+		Handler:    handler,
+		NextRun:    time.Now().Add(interval),
+	})
+
+	s.logger.Info("Scheduled task registered: %s/%s (every %s)", pluginName, taskName, interval)
+}
+
+// Unregister 플러그인의 모든 작업 해제
+func (s *Scheduler) Unregister(pluginName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	filtered := s.tasks[:0]
+	for _, t := range s.tasks {
+		if t.PluginName != pluginName {
+			filtered = append(filtered, t)
+		}
+	}
+	s.tasks = filtered
+}
+
+// Start 스케줄러 시작 (백그라운드 goroutine)
+func (s *Scheduler) Start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.stop:
+				return
+			case now := <-ticker.C:
+				s.tick(now)
+			}
+		}
+	}()
+	s.logger.Info("Plugin scheduler started")
+}
+
+// Stop 스케줄러 중지
+func (s *Scheduler) Stop() {
+	close(s.stop)
+	s.wg.Wait()
+	s.logger.Info("Plugin scheduler stopped")
+}
+
+// tick 실행 대상 작업 체크 및 실행
+func (s *Scheduler) tick(now time.Time) {
+	s.mu.RLock()
+	tasks := make([]*ScheduledTask, len(s.tasks))
+	copy(tasks, s.tasks)
+	s.mu.RUnlock()
+
+	for _, task := range tasks {
+		if now.Before(task.NextRun) {
+			continue
+		}
+
+		s.logger.Info("Running scheduled task: %s/%s", task.PluginName, task.Name)
+
+		if err := task.Handler(); err != nil {
+			s.logger.Error("Scheduled task error [%s/%s]: %v", task.PluginName, task.Name, err)
+			task.LastError = err
+		} else {
+			task.LastError = nil
+		}
+
+		task.LastRun = now
+		task.NextRun = now.Add(task.Interval)
+		task.RunCount++
+	}
+}
+
+// GetTasks 등록된 작업 목록 조회 (모니터링용)
+func (s *Scheduler) GetTasks() []ScheduledTaskInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]ScheduledTaskInfo, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		info := ScheduledTaskInfo{
+			Name:       t.Name,
+			PluginName: t.PluginName,
+			Interval:   t.Interval.String(),
+			LastRun:    t.LastRun,
+			NextRun:    t.NextRun,
+			RunCount:   t.RunCount,
+		}
+		if t.LastError != nil {
+			errMsg := t.LastError.Error()
+			info.LastError = &errMsg
+		}
+		result = append(result, info)
+	}
+	return result
+}
+
+// ScheduledTaskInfo 작업 정보 (JSON 응답용)
+type ScheduledTaskInfo struct {
+	Name       string    `json:"name"`
+	PluginName string    `json:"plugin_name"`
+	Interval   string    `json:"interval"`
+	LastRun    time.Time `json:"last_run"`
+	NextRun    time.Time `json:"next_run"`
+	RunCount   int64     `json:"run_count"`
+	LastError  *string   `json:"last_error,omitempty"`
+}

--- a/internal/plugin/scheduler_test.go
+++ b/internal/plugin/scheduler_test.go
@@ -1,0 +1,102 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestScheduler_RegisterAndGetTasks(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	s := NewScheduler(logger)
+
+	s.Register("test-plugin", "cleanup", time.Hour, func() error { return nil })
+	s.Register("test-plugin", "report", 24*time.Hour, func() error { return nil })
+
+	tasks := s.GetTasks()
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Name != "cleanup" {
+		t.Errorf("expected cleanup, got %s", tasks[0].Name)
+	}
+}
+
+func TestScheduler_Unregister(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	s := NewScheduler(logger)
+
+	s.Register("plugin-a", "task1", time.Hour, func() error { return nil })
+	s.Register("plugin-b", "task2", time.Hour, func() error { return nil })
+
+	s.Unregister("plugin-a")
+
+	tasks := s.GetTasks()
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task after unregister, got %d", len(tasks))
+	}
+	if tasks[0].PluginName != "plugin-b" {
+		t.Errorf("expected plugin-b, got %s", tasks[0].PluginName)
+	}
+}
+
+func TestScheduler_Tick(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	s := NewScheduler(logger)
+
+	var count int
+	s.Register("test-plugin", "counter", time.Millisecond, func() error {
+		count++
+		return nil
+	})
+
+	// Force NextRun to past
+	s.tasks[0].NextRun = time.Now().Add(-time.Second)
+
+	s.tick(time.Now())
+
+	if count != 1 {
+		t.Errorf("expected handler called once, got %d", count)
+	}
+	if s.tasks[0].RunCount != 1 {
+		t.Errorf("expected RunCount 1, got %d", s.tasks[0].RunCount)
+	}
+}
+
+func TestScheduler_TickError(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	s := NewScheduler(logger)
+
+	s.Register("test-plugin", "failing", time.Millisecond, func() error {
+		return errors.New("db down")
+	})
+	s.tasks[0].NextRun = time.Now().Add(-time.Second)
+
+	s.tick(time.Now())
+
+	if s.tasks[0].LastError == nil {
+		t.Error("expected LastError to be set")
+	}
+
+	tasks := s.GetTasks()
+	if tasks[0].LastError == nil || *tasks[0].LastError != "db down" {
+		t.Errorf("expected error message 'db down', got %v", tasks[0].LastError)
+	}
+}
+
+func TestScheduler_SkipNotReady(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	s := NewScheduler(logger)
+
+	var count int
+	s.Register("test-plugin", "future", time.Hour, func() error {
+		count++
+		return nil
+	})
+
+	s.tick(time.Now())
+
+	if count != 0 {
+		t.Error("expected handler NOT called for future task")
+	}
+}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -200,3 +200,8 @@ type PluginHealth struct {
 type HookAware interface {
 	RegisterHooks(hm *HookManager)
 }
+
+// Schedulable 선택적 인터페이스 - 주기적 작업을 등록하고 싶은 플러그인이 구현
+type Schedulable interface {
+	RegisterSchedules(scheduler *Scheduler)
+}

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -179,6 +179,13 @@ func (h *StoreHandler) Dashboard(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": data})
 }
 
+// ScheduledTasks 스케줄 작업 목록 조회
+// GET /api/v2/admin/plugins/schedules
+func (h *StoreHandler) ScheduledTasks(c *gin.Context) {
+	tasks := h.manager.GetScheduledTasks()
+	c.JSON(http.StatusOK, gin.H{"data": tasks})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- 플러그인이 주기적 작업을 등록할 수 있는 Scheduler 시스템 추가
- `Schedulable` 인터페이스 구현 시 자동으로 스케줄 등록/해제
- `GET /api/v2/admin/plugins/schedules` 엔드포인트로 등록된 작업 조회

## 변경 사항
- `internal/plugin/scheduler.go` — Scheduler 구조체 (Register, Unregister, Start, Stop, tick)
- `internal/plugin/scheduler_test.go` — 테스트 5건
- `internal/plugin/types.go` — Schedulable 인터페이스
- `internal/plugin/manager.go` — 스케줄러 통합
- `internal/pluginstore/handler/store_handler.go` — ScheduledTasks 핸들러
- `cmd/api/main.go` — 라우트 및 StartScheduler 호출

## Test plan
- [x] TestScheduler_RegisterAndGetTasks
- [x] TestScheduler_Unregister
- [x] TestScheduler_Tick
- [x] TestScheduler_TickError
- [x] TestScheduler_SkipNotReady