### PR TITLE
플러그인 레이트 리미터 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -319,6 +319,7 @@ func main() {
 			adminPlugins.GET("/dashboard", storeHandler.Dashboard)
 			adminPlugins.GET("/health", storeHandler.HealthCheck)
 			adminPlugins.GET("/schedules", storeHandler.ScheduledTasks)
+			adminPlugins.GET("/rate-limits", storeHandler.RateLimitConfigs)
 			adminPlugins.GET("/settings/export", settingHandler.ExportAllSettings)
 			adminPlugins.POST("/settings/import", settingHandler.ImportSettings)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)

--- a/internal/plugin/ratelimiter.go
+++ b/internal/plugin/ratelimiter.go
@@ -1,0 +1,203 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
+)
+
+// RateLimitConfig 플러그인별 레이트 리밋 설정
+type RateLimitConfig struct {
+	PluginName string        // 플러그인 이름
+	Requests   int           // 허용 요청 수
+	Window     time.Duration // 시간 윈도우
+}
+
+// RateLimiter Redis 기반 슬라이딩 윈도우 레이트 리미터
+type RateLimiter struct {
+	redis    *redis.Client
+	configs  map[string]*RateLimitConfig // pluginName -> config
+	mu       sync.RWMutex
+	fallback *inMemoryLimiter // Redis 없을 때 폴백
+}
+
+// NewRateLimiter 생성자
+func NewRateLimiter(redisClient *redis.Client) *RateLimiter {
+	return &RateLimiter{
+		redis:    redisClient,
+		configs:  make(map[string]*RateLimitConfig),
+		fallback: newInMemoryLimiter(),
+	}
+}
+
+// Configure 플러그인 레이트 리밋 설정
+func (rl *RateLimiter) Configure(pluginName string, requests int, window time.Duration) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.configs[pluginName] = &RateLimitConfig{
+		PluginName: pluginName,
+		Requests:   requests,
+		Window:     window,
+	}
+}
+
+// Remove 플러그인 레이트 리밋 제거
+func (rl *RateLimiter) Remove(pluginName string) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	delete(rl.configs, pluginName)
+	rl.fallback.remove(pluginName)
+}
+
+// GetConfig 설정 조회
+func (rl *RateLimiter) GetConfig(pluginName string) *RateLimitConfig {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	return rl.configs[pluginName]
+}
+
+// GetAllConfigs 전체 설정 조회
+func (rl *RateLimiter) GetAllConfigs() []RateLimitConfig {
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+	result := make([]RateLimitConfig, 0, len(rl.configs))
+	for _, cfg := range rl.configs {
+		result = append(result, *cfg)
+	}
+	return result
+}
+
+// Middleware Gin 미들웨어 - 플러그인 라우트에 적용
+func (rl *RateLimiter) Middleware(pluginName string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rl.mu.RLock()
+		cfg, exists := rl.configs[pluginName]
+		rl.mu.RUnlock()
+
+		if !exists {
+			c.Next()
+			return
+		}
+
+		clientIP := c.ClientIP()
+		key := fmt.Sprintf("ratelimit:%s:%s", pluginName, clientIP)
+
+		var allowed bool
+		var remaining int
+		if rl.redis != nil {
+			var err error
+			allowed, remaining, err = rl.check(key, cfg)
+			if err != nil {
+				allowed, remaining = rl.fallback.check(pluginName, clientIP, cfg)
+			}
+		} else {
+			allowed, remaining = rl.fallback.check(pluginName, clientIP, cfg)
+		}
+
+		c.Header("X-RateLimit-Limit", fmt.Sprintf("%d", cfg.Requests))
+		c.Header("X-RateLimit-Remaining", fmt.Sprintf("%d", remaining))
+		c.Header("X-RateLimit-Window", cfg.Window.String())
+
+		if !allowed {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": gin.H{
+					"code":    "RATE_LIMIT_EXCEEDED",
+					"message": fmt.Sprintf("요청 한도 초과: %d회/%s", cfg.Requests, cfg.Window),
+				},
+			})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// check Redis 슬라이딩 윈도우 카운터
+func (rl *RateLimiter) check(key string, cfg *RateLimitConfig) (bool, int, error) {
+	ctx := context.Background()
+	now := time.Now()
+
+	pipe := rl.redis.Pipeline()
+
+	// 윈도우 밖 요소 제거
+	pipe.ZRemRangeByScore(ctx, key, "0", fmt.Sprintf("%d", now.Add(-cfg.Window).UnixNano()))
+	// 현재 요청 추가
+	pipe.ZAdd(ctx, key, redis.Z{Score: float64(now.UnixNano()), Member: now.UnixNano()})
+	// 카운트 조회
+	countCmd := pipe.ZCard(ctx, key)
+	// TTL 설정
+	pipe.Expire(ctx, key, cfg.Window)
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		return false, 0, err
+	}
+
+	count := int(countCmd.Val())
+	remaining := cfg.Requests - count
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	return count <= cfg.Requests, remaining, nil
+}
+
+// inMemoryLimiter Redis 없을 때 사용하는 간단한 인메모리 리미터
+type inMemoryLimiter struct {
+	buckets map[string]*bucket
+	mu      sync.Mutex
+}
+
+type bucket struct {
+	count    int
+	resetAt  time.Time
+	requests int
+	window   time.Duration
+}
+
+func newInMemoryLimiter() *inMemoryLimiter {
+	return &inMemoryLimiter{
+		buckets: make(map[string]*bucket),
+	}
+}
+
+func (m *inMemoryLimiter) check(pluginName, clientIP string, cfg *RateLimitConfig) (bool, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := pluginName + ":" + clientIP
+	b, exists := m.buckets[key]
+	now := time.Now()
+
+	if !exists || now.After(b.resetAt) {
+		m.buckets[key] = &bucket{
+			count:    1,
+			resetAt:  now.Add(cfg.Window),
+			requests: cfg.Requests,
+			window:   cfg.Window,
+		}
+		return true, cfg.Requests - 1
+	}
+
+	b.count++
+	remaining := cfg.Requests - b.count
+	if remaining < 0 {
+		remaining = 0
+	}
+	return b.count <= cfg.Requests, remaining
+}
+
+func (m *inMemoryLimiter) remove(pluginName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key := range m.buckets {
+		if len(key) > len(pluginName) && key[:len(pluginName)+1] == pluginName+":" {
+			delete(m.buckets, key)
+		}
+	}
+}

--- a/internal/plugin/ratelimiter_test.go
+++ b/internal/plugin/ratelimiter_test.go
@@ -1,0 +1,179 @@
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRateLimiter_InMemory_Allow(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("test-plugin", 5, time.Minute)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", rl.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	for i := 0; i < 5; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "192.168.1.1:1234"
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i+1, w.Code)
+		}
+	}
+}
+
+func TestRateLimiter_InMemory_Block(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("test-plugin", 3, time.Minute)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", rl.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// 3 allowed
+	for i := 0; i < 3; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d should pass, got %d", i+1, w.Code)
+		}
+	}
+
+	// 4th blocked
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("4th request: expected 429, got %d", w.Code)
+	}
+}
+
+func TestRateLimiter_NoConfig_Passthrough(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	// no Configure call
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", rl.Middleware("unconfigured"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected passthrough 200, got %d", w.Code)
+	}
+}
+
+func TestRateLimiter_DifferentIPs(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("test-plugin", 1, time.Minute)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", rl.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// IP 1 - allowed
+	w1 := httptest.NewRecorder()
+	req1, _ := http.NewRequest("GET", "/test", nil)
+	req1.RemoteAddr = "1.1.1.1:1234"
+	r.ServeHTTP(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("IP1: expected 200, got %d", w1.Code)
+	}
+
+	// IP 2 - also allowed (separate counter)
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("GET", "/test", nil)
+	req2.RemoteAddr = "2.2.2.2:1234"
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("IP2: expected 200, got %d", w2.Code)
+	}
+}
+
+func TestRateLimiter_Remove(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("plugin-a", 10, time.Minute)
+
+	if cfg := rl.GetConfig("plugin-a"); cfg == nil {
+		t.Fatal("expected config to exist")
+	}
+
+	rl.Remove("plugin-a")
+
+	if cfg := rl.GetConfig("plugin-a"); cfg != nil {
+		t.Fatal("expected config to be removed")
+	}
+}
+
+func TestRateLimiter_GetAllConfigs(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("a", 10, time.Minute)
+	rl.Configure("b", 20, time.Hour)
+
+	configs := rl.GetAllConfigs()
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 configs, got %d", len(configs))
+	}
+}
+
+func TestRateLimiter_WindowReset(t *testing.T) {
+	rl := NewRateLimiter(nil)
+	rl.Configure("test-plugin", 1, 50*time.Millisecond)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/test", rl.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	// 1st request - allowed
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "3.3.3.3:1234"
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("1st: expected 200, got %d", w.Code)
+	}
+
+	// 2nd request - blocked
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "3.3.3.3:1234"
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("2nd: expected 429, got %d", w.Code)
+	}
+
+	// Wait for window to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// 3rd request - allowed again
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "3.3.3.3:1234"
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("3rd after reset: expected 200, got %d", w.Code)
+	}
+}

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -205,3 +205,8 @@ type HookAware interface {
 type Schedulable interface {
 	RegisterSchedules(scheduler *Scheduler)
 }
+
+// RateLimitable 선택적 인터페이스 - API 레이트 리밋을 설정하고 싶은 플러그인이 구현
+type RateLimitable interface {
+	ConfigureRateLimit(limiter *RateLimiter)
+}

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -186,6 +186,13 @@ func (h *StoreHandler) ScheduledTasks(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": tasks})
 }
 
+// RateLimitConfigs 레이트 리밋 설정 목록 조회
+// GET /api/v2/admin/plugins/rate-limits
+func (h *StoreHandler) RateLimitConfigs(c *gin.Context) {
+	configs := h.manager.GetRateLimitConfigs()
+	c.JSON(http.StatusOK, gin.H{"data": configs})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- Redis 기반 슬라이딩 윈도우 레이트 리미터 (Redis 없을 시 인메모리 폴백)
- `RateLimitable` 인터페이스 구현 시 플러그인별 API 요청 제한 자동 적용
- `GET /api/v2/admin/plugins/rate-limits` 엔드포인트로 설정 조회

## 주요 기능
- IP별 독립 카운터로 공정한 제한
- `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Window` 응답 헤더
- 429 Too Many Requests 응답 시 한국어 에러 메시지

## Test plan
- [x] TestRateLimiter_InMemory_Allow (허용 범위 내 통과)
- [x] TestRateLimiter_InMemory_Block (한도 초과 시 429)
- [x] TestRateLimiter_NoConfig_Passthrough (설정 없으면 통과)
- [x] TestRateLimiter_DifferentIPs (IP별 독립 카운터)
- [x] TestRateLimiter_Remove (설정 제거)
- [x] TestRateLimiter_GetAllConfigs (전체 설정 조회)
- [x] TestRateLimiter_WindowReset (윈도우 만료 후 재허용)