### PR TITLE
플러그인 메트릭 수집 시스템 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -320,6 +320,7 @@ func main() {
 			adminPlugins.GET("/health", storeHandler.HealthCheck)
 			adminPlugins.GET("/schedules", storeHandler.ScheduledTasks)
 			adminPlugins.GET("/rate-limits", storeHandler.RateLimitConfigs)
+			adminPlugins.GET("/metrics", storeHandler.PluginMetrics)
 			adminPlugins.GET("/settings/export", settingHandler.ExportAllSettings)
 			adminPlugins.POST("/settings/import", settingHandler.ImportSettings)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)
@@ -334,6 +335,7 @@ func main() {
 			adminPlugins.GET("/:name/permissions", permHandler.GetPermissions)
 			adminPlugins.PUT("/:name/permissions/:permId", permHandler.UpdatePermission)
 			adminPlugins.GET("/:name/health", storeHandler.HealthCheckSingle)
+			adminPlugins.GET("/:name/metrics", storeHandler.PluginMetricsSingle)
 		}
 
 		// 플러그인 스케줄러 시작

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -26,7 +26,7 @@ type Manager struct {
 	permissions PermissionSyncer
 	scheduler   *Scheduler
 	rateLimiter *RateLimiter
-	metrics     *PluginMetrics
+	metrics     *Metrics
 }
 
 // NewManager 새 매니저 생성
@@ -43,7 +43,7 @@ func NewManager(pluginsDir string, db *gorm.DB, redisClient *redis.Client, logge
 		permissions: permissions,
 		scheduler:   NewScheduler(logger),
 		rateLimiter: NewRateLimiter(redisClient),
-		metrics:     NewPluginMetrics(),
+		metrics:     NewMetrics(),
 	}
 }
 
@@ -294,17 +294,17 @@ func (m *Manager) GetRateLimitConfigs() []RateLimitConfig {
 }
 
 // GetPluginMetrics 특정 플러그인 메트릭 조회
-func (m *Manager) GetPluginMetrics(name string) *PluginMetricsSummary {
+func (m *Manager) GetPluginMetrics(name string) *MetricsSummary {
 	return m.metrics.GetSummary(name)
 }
 
 // GetAllPluginMetrics 전체 플러그인 메트릭 조회
-func (m *Manager) GetAllPluginMetrics() []PluginMetricsSummary {
+func (m *Manager) GetAllPluginMetrics() []MetricsSummary {
 	return m.metrics.GetAllSummaries()
 }
 
 // GetMetrics 메트릭 수집기 반환 (미들웨어 등록용)
-func (m *Manager) GetMetrics() *PluginMetrics {
+func (m *Manager) GetMetrics() *Metrics {
 	return m.metrics
 }
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -26,6 +26,7 @@ type Manager struct {
 	permissions PermissionSyncer
 	scheduler   *Scheduler
 	rateLimiter *RateLimiter
+	metrics     *PluginMetrics
 }
 
 // NewManager 새 매니저 생성
@@ -42,6 +43,7 @@ func NewManager(pluginsDir string, db *gorm.DB, redisClient *redis.Client, logge
 		permissions: permissions,
 		scheduler:   NewScheduler(logger),
 		rateLimiter: NewRateLimiter(redisClient),
+		metrics:     NewPluginMetrics(),
 	}
 }
 
@@ -289,6 +291,21 @@ func (m *Manager) GetRateLimiter() *RateLimiter {
 // GetRateLimitConfigs 레이트 리밋 설정 목록 조회
 func (m *Manager) GetRateLimitConfigs() []RateLimitConfig {
 	return m.rateLimiter.GetAllConfigs()
+}
+
+// GetPluginMetrics 특정 플러그인 메트릭 조회
+func (m *Manager) GetPluginMetrics(name string) *PluginMetricsSummary {
+	return m.metrics.GetSummary(name)
+}
+
+// GetAllPluginMetrics 전체 플러그인 메트릭 조회
+func (m *Manager) GetAllPluginMetrics() []PluginMetricsSummary {
+	return m.metrics.GetAllSummaries()
+}
+
+// GetMetrics 메트릭 수집기 반환 (미들웨어 등록용)
+func (m *Manager) GetMetrics() *PluginMetrics {
+	return m.metrics
 }
 
 // CheckHealth 단일 플러그인 헬스 체크

--- a/internal/plugin/metrics.go
+++ b/internal/plugin/metrics.go
@@ -1,0 +1,199 @@
+package plugin
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PluginMetrics 플러그인별 API 메트릭 수집기
+type PluginMetrics struct {
+	plugins map[string]*pluginMetric
+	mu      sync.RWMutex
+}
+
+type pluginMetric struct {
+	TotalRequests  int64
+	TotalErrors    int64
+	TotalLatencyMs int64
+	StatusCodes    map[int]int64
+	Endpoints      map[string]*endpointMetric
+}
+
+type endpointMetric struct {
+	Requests   int64
+	Errors     int64
+	LatencyMs  int64
+	MinLatency int64
+	MaxLatency int64
+}
+
+// PluginMetricsSummary API 응답용 메트릭 요약
+type PluginMetricsSummary struct {
+	PluginName    string                      `json:"plugin_name"`
+	TotalRequests int64                       `json:"total_requests"`
+	TotalErrors   int64                       `json:"total_errors"`
+	ErrorRate     float64                     `json:"error_rate"`
+	AvgLatencyMs  float64                     `json:"avg_latency_ms"`
+	StatusCodes   map[int]int64               `json:"status_codes"`
+	Endpoints     map[string]*EndpointSummary `json:"endpoints"`
+}
+
+// EndpointSummary 엔드포인트별 요약
+type EndpointSummary struct {
+	Requests     int64   `json:"requests"`
+	Errors       int64   `json:"errors"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	MinLatencyMs int64   `json:"min_latency_ms"`
+	MaxLatencyMs int64   `json:"max_latency_ms"`
+}
+
+// NewPluginMetrics 생성자
+func NewPluginMetrics() *PluginMetrics {
+	return &PluginMetrics{
+		plugins: make(map[string]*pluginMetric),
+	}
+}
+
+// Middleware Gin 미들웨어 - 플러그인 API 호출 메트릭 수집
+func (pm *PluginMetrics) Middleware(pluginName string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		c.Next()
+
+		latency := time.Since(start).Milliseconds()
+		status := c.Writer.Status()
+		endpoint := c.Request.Method + " " + c.FullPath()
+
+		pm.record(pluginName, endpoint, status, latency)
+	}
+}
+
+// record 메트릭 기록
+func (pm *PluginMetrics) record(pluginName, endpoint string, status int, latencyMs int64) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	m, exists := pm.plugins[pluginName]
+	if !exists {
+		m = &pluginMetric{
+			StatusCodes: make(map[int]int64),
+			Endpoints:   make(map[string]*endpointMetric),
+		}
+		pm.plugins[pluginName] = m
+	}
+
+	m.TotalRequests++
+	m.TotalLatencyMs += latencyMs
+	m.StatusCodes[status]++
+
+	if status >= http.StatusBadRequest {
+		m.TotalErrors++
+	}
+
+	ep, exists := m.Endpoints[endpoint]
+	if !exists {
+		ep = &endpointMetric{
+			MinLatency: latencyMs,
+			MaxLatency: latencyMs,
+		}
+		m.Endpoints[endpoint] = ep
+	}
+
+	ep.Requests++
+	ep.LatencyMs += latencyMs
+	if status >= http.StatusBadRequest {
+		ep.Errors++
+	}
+	if latencyMs < ep.MinLatency {
+		ep.MinLatency = latencyMs
+	}
+	if latencyMs > ep.MaxLatency {
+		ep.MaxLatency = latencyMs
+	}
+}
+
+// GetSummary 특정 플러그인 메트릭 요약
+func (pm *PluginMetrics) GetSummary(pluginName string) *PluginMetricsSummary {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	m, exists := pm.plugins[pluginName]
+	if !exists {
+		return &PluginMetricsSummary{
+			PluginName:  pluginName,
+			StatusCodes: make(map[int]int64),
+			Endpoints:   make(map[string]*EndpointSummary),
+		}
+	}
+
+	return pm.buildSummary(pluginName, m)
+}
+
+// GetAllSummaries 전체 플러그인 메트릭 요약
+func (pm *PluginMetrics) GetAllSummaries() []PluginMetricsSummary {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	result := make([]PluginMetricsSummary, 0, len(pm.plugins))
+	for name, m := range pm.plugins {
+		result = append(result, *pm.buildSummary(name, m))
+	}
+	return result
+}
+
+func (pm *PluginMetrics) buildSummary(name string, m *pluginMetric) *PluginMetricsSummary {
+	var avgLatency float64
+	var errorRate float64
+	if m.TotalRequests > 0 {
+		avgLatency = float64(m.TotalLatencyMs) / float64(m.TotalRequests)
+		errorRate = float64(m.TotalErrors) / float64(m.TotalRequests)
+	}
+
+	codes := make(map[int]int64, len(m.StatusCodes))
+	for k, v := range m.StatusCodes {
+		codes[k] = v
+	}
+
+	endpoints := make(map[string]*EndpointSummary, len(m.Endpoints))
+	for ep, em := range m.Endpoints {
+		var epAvg float64
+		if em.Requests > 0 {
+			epAvg = float64(em.LatencyMs) / float64(em.Requests)
+		}
+		endpoints[ep] = &EndpointSummary{
+			Requests:     em.Requests,
+			Errors:       em.Errors,
+			AvgLatencyMs: epAvg,
+			MinLatencyMs: em.MinLatency,
+			MaxLatencyMs: em.MaxLatency,
+		}
+	}
+
+	return &PluginMetricsSummary{
+		PluginName:    name,
+		TotalRequests: m.TotalRequests,
+		TotalErrors:   m.TotalErrors,
+		ErrorRate:     errorRate,
+		AvgLatencyMs:  avgLatency,
+		StatusCodes:   codes,
+		Endpoints:     endpoints,
+	}
+}
+
+// Reset 특정 플러그인 메트릭 초기화
+func (pm *PluginMetrics) Reset(pluginName string) {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	delete(pm.plugins, pluginName)
+}
+
+// ResetAll 전체 메트릭 초기화
+func (pm *PluginMetrics) ResetAll() {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pm.plugins = make(map[string]*pluginMetric)
+}

--- a/internal/plugin/metrics_test.go
+++ b/internal/plugin/metrics_test.go
@@ -1,0 +1,160 @@
+package plugin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMetrics_Record(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("test-plugin", "GET /api/test", 200, 50)
+	pm.record("test-plugin", "GET /api/test", 200, 30)
+	pm.record("test-plugin", "GET /api/test", 500, 100)
+
+	summary := pm.GetSummary("test-plugin")
+	if summary.TotalRequests != 3 {
+		t.Fatalf("expected 3 requests, got %d", summary.TotalRequests)
+	}
+	if summary.TotalErrors != 1 {
+		t.Fatalf("expected 1 error, got %d", summary.TotalErrors)
+	}
+	if summary.AvgLatencyMs != 60 {
+		t.Fatalf("expected avg 60ms, got %.2f", summary.AvgLatencyMs)
+	}
+}
+
+func TestMetrics_Middleware(t *testing.T) {
+	pm := NewPluginMetrics()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/test", pm.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	r.GET("/api/error", pm.Middleware("test-plugin"), func(c *gin.Context) {
+		c.String(http.StatusInternalServerError, "fail")
+	})
+
+	// 2 success + 1 error
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequestWithContext(context.Background(), "GET", "/api/test", nil)
+		r.ServeHTTP(w, req)
+	}
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/api/error", nil)
+	r.ServeHTTP(w, req)
+
+	summary := pm.GetSummary("test-plugin")
+	if summary.TotalRequests != 3 {
+		t.Fatalf("expected 3 total, got %d", summary.TotalRequests)
+	}
+	if summary.TotalErrors != 1 {
+		t.Fatalf("expected 1 error, got %d", summary.TotalErrors)
+	}
+	if len(summary.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(summary.Endpoints))
+	}
+}
+
+func TestMetrics_ErrorRate(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("p", "GET /", 200, 10)
+	pm.record("p", "GET /", 200, 10)
+	pm.record("p", "GET /", 400, 10)
+	pm.record("p", "GET /", 500, 10)
+
+	summary := pm.GetSummary("p")
+	if summary.ErrorRate != 0.5 {
+		t.Fatalf("expected error rate 0.5, got %.2f", summary.ErrorRate)
+	}
+}
+
+func TestMetrics_EmptyPlugin(t *testing.T) {
+	pm := NewPluginMetrics()
+	summary := pm.GetSummary("nonexistent")
+	if summary.TotalRequests != 0 {
+		t.Fatal("expected 0 requests for nonexistent plugin")
+	}
+}
+
+func TestMetrics_GetAllSummaries(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("a", "GET /", 200, 10)
+	pm.record("b", "GET /", 200, 20)
+
+	summaries := pm.GetAllSummaries()
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 summaries, got %d", len(summaries))
+	}
+}
+
+func TestMetrics_Reset(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("test", "GET /", 200, 10)
+
+	pm.Reset("test")
+	summary := pm.GetSummary("test")
+	if summary.TotalRequests != 0 {
+		t.Fatal("expected 0 after reset")
+	}
+}
+
+func TestMetrics_EndpointMinMax(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("p", "GET /api", 200, 10)
+	pm.record("p", "GET /api", 200, 50)
+	pm.record("p", "GET /api", 200, 30)
+
+	summary := pm.GetSummary("p")
+	ep := summary.Endpoints["GET /api"]
+	if ep == nil {
+		t.Fatal("expected endpoint summary")
+	}
+	if ep.MinLatencyMs != 10 {
+		t.Fatalf("expected min 10, got %d", ep.MinLatencyMs)
+	}
+	if ep.MaxLatencyMs != 50 {
+		t.Fatalf("expected max 50, got %d", ep.MaxLatencyMs)
+	}
+}
+
+func TestMetrics_StatusCodes(t *testing.T) {
+	pm := NewPluginMetrics()
+	pm.record("p", "GET /", 200, 10)
+	pm.record("p", "GET /", 200, 10)
+	pm.record("p", "GET /", 404, 10)
+
+	summary := pm.GetSummary("p")
+	if summary.StatusCodes[200] != 2 {
+		t.Fatalf("expected 2 x 200, got %d", summary.StatusCodes[200])
+	}
+	if summary.StatusCodes[404] != 1 {
+		t.Fatalf("expected 1 x 404, got %d", summary.StatusCodes[404])
+	}
+}
+
+func TestMetrics_LatencyTracking(t *testing.T) {
+	pm := NewPluginMetrics()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/slow", pm.Middleware("slow-plugin"), func(c *gin.Context) {
+		time.Sleep(10 * time.Millisecond)
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/slow", nil)
+	r.ServeHTTP(w, req)
+
+	summary := pm.GetSummary("slow-plugin")
+	if summary.AvgLatencyMs < 10 {
+		t.Fatalf("expected latency >= 10ms, got %.2f", summary.AvgLatencyMs)
+	}
+}

--- a/internal/plugin/metrics_test.go
+++ b/internal/plugin/metrics_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMetrics_Record(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("test-plugin", "GET /api/test", 200, 50)
 	pm.record("test-plugin", "GET /api/test", 200, 30)
 	pm.record("test-plugin", "GET /api/test", 500, 100)
@@ -29,7 +29,7 @@ func TestMetrics_Record(t *testing.T) {
 }
 
 func TestMetrics_Middleware(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -63,7 +63,7 @@ func TestMetrics_Middleware(t *testing.T) {
 }
 
 func TestMetrics_ErrorRate(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("p", "GET /", 200, 10)
 	pm.record("p", "GET /", 200, 10)
 	pm.record("p", "GET /", 400, 10)
@@ -76,7 +76,7 @@ func TestMetrics_ErrorRate(t *testing.T) {
 }
 
 func TestMetrics_EmptyPlugin(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	summary := pm.GetSummary("nonexistent")
 	if summary.TotalRequests != 0 {
 		t.Fatal("expected 0 requests for nonexistent plugin")
@@ -84,7 +84,7 @@ func TestMetrics_EmptyPlugin(t *testing.T) {
 }
 
 func TestMetrics_GetAllSummaries(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("a", "GET /", 200, 10)
 	pm.record("b", "GET /", 200, 20)
 
@@ -95,7 +95,7 @@ func TestMetrics_GetAllSummaries(t *testing.T) {
 }
 
 func TestMetrics_Reset(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("test", "GET /", 200, 10)
 
 	pm.Reset("test")
@@ -106,7 +106,7 @@ func TestMetrics_Reset(t *testing.T) {
 }
 
 func TestMetrics_EndpointMinMax(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("p", "GET /api", 200, 10)
 	pm.record("p", "GET /api", 200, 50)
 	pm.record("p", "GET /api", 200, 30)
@@ -125,7 +125,7 @@ func TestMetrics_EndpointMinMax(t *testing.T) {
 }
 
 func TestMetrics_StatusCodes(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 	pm.record("p", "GET /", 200, 10)
 	pm.record("p", "GET /", 200, 10)
 	pm.record("p", "GET /", 404, 10)
@@ -140,7 +140,7 @@ func TestMetrics_StatusCodes(t *testing.T) {
 }
 
 func TestMetrics_LatencyTracking(t *testing.T) {
-	pm := NewPluginMetrics()
+	pm := NewMetrics()
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -193,6 +193,21 @@ func (h *StoreHandler) RateLimitConfigs(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": configs})
 }
 
+// PluginMetrics 전체 플러그인 메트릭 조회
+// GET /api/v2/admin/plugins/metrics
+func (h *StoreHandler) PluginMetrics(c *gin.Context) {
+	metrics := h.manager.GetAllPluginMetrics()
+	c.JSON(http.StatusOK, gin.H{"data": metrics})
+}
+
+// PluginMetricsSingle 단일 플러그인 메트릭 조회
+// GET /api/v2/admin/plugins/:name/metrics
+func (h *StoreHandler) PluginMetricsSingle(c *gin.Context) {
+	name := c.Param("name")
+	metrics := h.manager.GetPluginMetrics(name)
+	c.JSON(http.StatusOK, gin.H{"data": metrics})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- 플러그인별 API 호출 횟수, 응답시간, 에러율을 인메모리로 수집
- 엔드포인트별 min/max/avg 레이턴시 및 HTTP 상태코드별 카운트
- `GET /api/v2/admin/plugins/metrics` 전체 조회, `/:name/metrics` 단일 조회

## Test plan
- [x] TestMetrics_Record
- [x] TestMetrics_Middleware
- [x] TestMetrics_ErrorRate
- [x] TestMetrics_EmptyPlugin
- [x] TestMetrics_GetAllSummaries
- [x] TestMetrics_Reset
- [x] TestMetrics_EndpointMinMax
- [x] TestMetrics_StatusCodes
- [x] TestMetrics_LatencyTracking