### PR TITLE
플러그인 라이프사이클 훅 구현

### DIFF
--- a/internal/plugin/lifecycle_test.go
+++ b/internal/plugin/lifecycle_test.go
@@ -1,0 +1,119 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type lifecycleMock struct {
+	name        string
+	installed   bool
+	uninstalled bool
+	enabled     bool
+	disabled    bool
+}
+
+func (m *lifecycleMock) Name() string                      { return m.name }
+func (m *lifecycleMock) Migrate(_ *gorm.DB) error          { return nil }
+func (m *lifecycleMock) Initialize(_ *PluginContext) error { return nil }
+func (m *lifecycleMock) RegisterRoutes(_ gin.IRouter)      {}
+func (m *lifecycleMock) Shutdown() error                   { return nil }
+func (m *lifecycleMock) OnInstall() error                  { m.installed = true; return nil }
+func (m *lifecycleMock) OnUninstall() error                { m.uninstalled = true; return nil }
+func (m *lifecycleMock) OnEnable() error                   { m.enabled = true; return nil }
+func (m *lifecycleMock) OnDisable() error                  { m.disabled = true; return nil }
+
+func setupLifecycleTest(t *testing.T) (*Manager, *lifecycleMock) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger := NewDefaultLogger("test")
+	mgr := NewManager("", db, nil, logger, nil, nil)
+	mock := &lifecycleMock{name: "lc-plugin"}
+	manifest := &PluginManifest{Name: "lc-plugin", Version: "1.0.0"}
+	mgr.RegisterBuiltIn("lc-plugin", mock, manifest)
+	return mgr, mock
+}
+
+func TestLifecycle_OnEnable(t *testing.T) {
+	mgr, mock := setupLifecycleTest(t)
+
+	if err := mgr.Enable("lc-plugin"); err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+	if !mock.enabled {
+		t.Error("expected OnEnable to be called")
+	}
+}
+
+func TestLifecycle_OnDisable(t *testing.T) {
+	mgr, mock := setupLifecycleTest(t)
+
+	_ = mgr.Enable("lc-plugin")
+	if err := mgr.Disable("lc-plugin"); err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+	if !mock.disabled {
+		t.Error("expected OnDisable to be called")
+	}
+}
+
+func TestLifecycle_OnInstall(t *testing.T) {
+	mgr, mock := setupLifecycleTest(t)
+
+	_ = mgr.Enable("lc-plugin")
+	mgr.NotifyInstall("lc-plugin")
+	if !mock.installed {
+		t.Error("expected OnInstall to be called")
+	}
+}
+
+func TestLifecycle_OnUninstall(t *testing.T) {
+	mgr, mock := setupLifecycleTest(t)
+
+	_ = mgr.Enable("lc-plugin")
+	mgr.NotifyUninstall("lc-plugin")
+	if !mock.uninstalled {
+		t.Error("expected OnUninstall to be called")
+	}
+}
+
+func TestLifecycle_NotImplemented(t *testing.T) {
+	// Plugin that does NOT implement LifecycleAware should not panic
+	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	logger := NewDefaultLogger("test")
+	mgr := NewManager("", db, nil, logger, nil, nil)
+
+	type simplePlugin struct {
+		lifecycleMockBase
+	}
+	simple := &simplePlugin{}
+	simple.name = "simple"
+	manifest := &PluginManifest{Name: "simple", Version: "1.0.0"}
+	mgr.RegisterBuiltIn("simple", simple, manifest)
+
+	// Should not panic
+	if err := mgr.Enable("simple"); err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+	mgr.NotifyInstall("simple")
+	mgr.NotifyUninstall("simple")
+	if err := mgr.Disable("simple"); err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+}
+
+type lifecycleMockBase struct {
+	name string
+}
+
+func (m *lifecycleMockBase) Name() string                      { return m.name }
+func (m *lifecycleMockBase) Migrate(_ *gorm.DB) error          { return nil }
+func (m *lifecycleMockBase) Initialize(_ *PluginContext) error { return nil }
+func (m *lifecycleMockBase) RegisterRoutes(_ gin.IRouter)      {}
+func (m *lifecycleMockBase) Shutdown() error                   { return nil }

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -210,3 +210,11 @@ type Schedulable interface {
 type RateLimitable interface {
 	ConfigureRateLimit(limiter *RateLimiter)
 }
+
+// LifecycleAware 선택적 인터페이스 - 설치/제거/활성화/비활성화 이벤트 수신
+type LifecycleAware interface {
+	OnInstall() error
+	OnUninstall() error
+	OnEnable() error
+	OnDisable() error
+}

--- a/internal/pluginstore/service/store_service.go
+++ b/internal/pluginstore/service/store_service.go
@@ -86,6 +86,9 @@ func (s *StoreService) Install(name, actorID string, manager *plugin.Manager) er
 		return fmt.Errorf("failed to enable plugin: %w", err)
 	}
 
+	// 라이프사이클 훅: OnInstall
+	manager.NotifyInstall(name)
+
 	// 이벤트 로그
 	s.logEvent(name, domain.EventInstalled, map[string]string{"version": manifest.Version}, actorID)
 
@@ -178,6 +181,9 @@ func (s *StoreService) Uninstall(name, actorID string, manager *plugin.Manager) 
 	if dependents, err := s.checkReverseDependencies(name, manager); err == nil && len(dependents) > 0 {
 		return fmt.Errorf("cannot uninstall %s: plugins %v depend on it", name, dependents)
 	}
+
+	// 라이프사이클 훅: OnUninstall
+	manager.NotifyUninstall(name)
 
 	// 활성화 상태면 먼저 비활성화
 	if inst.Status == domain.StatusEnabled {


### PR DESCRIPTION
## Summary
- `LifecycleAware` 선택적 인터페이스: OnInstall/OnUninstall/OnEnable/OnDisable
- Enable/Disable 시 Manager에서 자동 호출, Install/Uninstall 시 StoreService에서 호출
- 미구현 플러그인은 훅 무시 (안전)

## Test plan
- [x] TestLifecycle_OnEnable
- [x] TestLifecycle_OnDisable
- [x] TestLifecycle_OnInstall
- [x] TestLifecycle_OnUninstall
- [x] TestLifecycle_NotImplemented (미구현 시 패닉 없음)