### PR TITLE
플러그인 샌드박스 미들웨어 구현

### DIFF
--- a/internal/plugin/sandbox.go
+++ b/internal/plugin/sandbox.go
@@ -1,0 +1,85 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SandboxConfig 플러그인 샌드박스 설정
+type SandboxConfig struct {
+	RequestTimeout time.Duration // API 요청 타임아웃 (기본 30초)
+	RecoverPanics  bool          // 패닉 복구 여부 (기본 true)
+}
+
+// DefaultSandboxConfig 기본 샌드박스 설정
+func DefaultSandboxConfig() SandboxConfig {
+	return SandboxConfig{
+		RequestTimeout: 30 * time.Second,
+		RecoverPanics:  true,
+	}
+}
+
+// SandboxMiddleware 플러그인 라우트용 샌드박스 미들웨어
+// 패닉 복구 + 타임아웃 제한으로 플러그인이 시스템을 불안정하게 만드는 것을 방지
+func SandboxMiddleware(pluginName string, cfg SandboxConfig, logger Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// 패닉 복구
+		if cfg.RecoverPanics {
+			defer func() {
+				if r := recover(); r != nil {
+					stack := string(debug.Stack())
+					logger.Error("Plugin %s panicked: %v\n%s", pluginName, r, stack)
+					c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+						"error": gin.H{
+							"code":    "PLUGIN_PANIC",
+							"message": fmt.Sprintf("플러그인 %s에서 내부 오류가 발생했습니다", pluginName),
+						},
+					})
+				}
+			}()
+		}
+
+		// 타임아웃 컨텍스트
+		if cfg.RequestTimeout > 0 {
+			ctx, cancel := context.WithTimeout(c.Request.Context(), cfg.RequestTimeout)
+			defer cancel()
+			c.Request = c.Request.WithContext(ctx)
+		}
+
+		c.Next()
+
+		// 타임아웃 체크
+		if c.Request.Context().Err() == context.DeadlineExceeded {
+			logger.Warn("Plugin %s request timeout: %s %s", pluginName, c.Request.Method, c.Request.URL.Path)
+			if !c.Writer.Written() {
+				c.AbortWithStatusJSON(http.StatusGatewayTimeout, gin.H{
+					"error": gin.H{
+						"code":    "PLUGIN_TIMEOUT",
+						"message": fmt.Sprintf("플러그인 %s 요청 시간이 초과되었습니다", pluginName),
+					},
+				})
+			}
+		}
+	}
+}
+
+// SafeCall 플러그인 함수를 안전하게 호출 (패닉 복구)
+func SafeCall(pluginName string, logger Logger, fn func() error) error {
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := string(debug.Stack())
+				logger.Error("Plugin %s panicked during call: %v\n%s", pluginName, r, stack)
+				err = fmt.Errorf("plugin %s panicked: %v", pluginName, r)
+			}
+		}()
+		err = fn()
+	}()
+	return err
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -1,0 +1,137 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSandbox_RecoverPanic(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	cfg := DefaultSandboxConfig()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/panic", SandboxMiddleware("test-plugin", cfg, logger), func(_ *gin.Context) {
+		panic("something went wrong")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/panic", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if w.Body.String() == "" {
+		t.Fatal("expected error response body")
+	}
+}
+
+func TestSandbox_NoPanic(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	cfg := DefaultSandboxConfig()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/ok", SandboxMiddleware("test-plugin", cfg, logger), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/ok", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestSandbox_Timeout(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	cfg := SandboxConfig{
+		RequestTimeout: 50 * time.Millisecond,
+		RecoverPanics:  true,
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/slow", SandboxMiddleware("slow-plugin", cfg, logger), func(c *gin.Context) {
+		select {
+		case <-time.After(200 * time.Millisecond):
+			c.String(http.StatusOK, "done")
+		case <-c.Request.Context().Done():
+			// Context cancelled
+			return
+		}
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/slow", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d", w.Code)
+	}
+}
+
+func TestSandbox_RecoverDisabled(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	cfg := SandboxConfig{
+		RecoverPanics: false,
+	}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/panic", SandboxMiddleware("test-plugin", cfg, logger), func(_ *gin.Context) {
+		panic("boom")
+	})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic to propagate when RecoverPanics is false")
+		}
+	}()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/panic", nil)
+	r.ServeHTTP(w, req)
+}
+
+func TestSafeCall_Normal(t *testing.T) {
+	logger := NewDefaultLogger("test")
+
+	err := SafeCall("test", logger, func() error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}
+
+func TestSafeCall_Error(t *testing.T) {
+	logger := NewDefaultLogger("test")
+
+	err := SafeCall("test", logger, func() error {
+		return errors.New("expected error")
+	})
+	if err == nil || err.Error() != "expected error" {
+		t.Fatalf("expected 'expected error', got: %v", err)
+	}
+}
+
+func TestSafeCall_Panic(t *testing.T) {
+	logger := NewDefaultLogger("test")
+
+	err := SafeCall("test", logger, func() error {
+		panic("boom")
+	})
+	if err == nil {
+		t.Fatal("expected error from panic")
+	}
+}

--- a/internal/plugin/sandbox_test.go
+++ b/internal/plugin/sandbox_test.go
@@ -66,7 +66,7 @@ func TestSandbox_Timeout(t *testing.T) {
 		case <-time.After(200 * time.Millisecond):
 			c.String(http.StatusOK, "done")
 		case <-c.Request.Context().Done():
-			// Context cancelled
+			// Context canceled
 			return
 		}
 	})


### PR DESCRIPTION
## Summary
- `SandboxMiddleware`: 패닉 복구 + 요청 타임아웃으로 플러그인 격리
- `SafeCall`: 플러그인 함수 안전 호출 유틸리티 (패닉 → error)
- 플러그인 오류가 전체 시스템에 영향을 주지 않도록 방어

## Test plan
- [x] TestSandbox_RecoverPanic (패닉 → 500 응답)
- [x] TestSandbox_NoPanic (정상 요청)
- [x] TestSandbox_Timeout (타임아웃 → 504 응답)
- [x] TestSandbox_RecoverDisabled (복구 비활성화 시 패닉 전파)
- [x] TestSafeCall_Normal / Error / Panic