### PR TITLE
플러그인 이벤트 버스 시스템 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -321,6 +321,7 @@ func main() {
 			adminPlugins.GET("/schedules", storeHandler.ScheduledTasks)
 			adminPlugins.GET("/rate-limits", storeHandler.RateLimitConfigs)
 			adminPlugins.GET("/metrics", storeHandler.PluginMetrics)
+			adminPlugins.GET("/event-subscriptions", storeHandler.EventSubscriptions)
 			adminPlugins.GET("/settings/export", settingHandler.ExportAllSettings)
 			adminPlugins.POST("/settings/import", settingHandler.ImportSettings)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)

--- a/internal/plugin/eventbus.go
+++ b/internal/plugin/eventbus.go
@@ -1,0 +1,115 @@
+package plugin
+
+import (
+	"sync"
+	"time"
+)
+
+// Event 플러그인 간 이벤트
+type Event struct {
+	Topic     string                 `json:"topic"`
+	Source    string                 `json:"source"`     // 발행 플러그인
+	Payload   map[string]interface{} `json:"payload"`
+	Timestamp time.Time              `json:"timestamp"`
+}
+
+// EventHandler 이벤트 핸들러 함수
+type EventHandler func(event Event)
+
+type subscription struct {
+	pluginName string
+	handler    EventHandler
+}
+
+// EventBus 플러그인 간 이벤트 발행/구독 시스템
+type EventBus struct {
+	subscribers map[string][]subscription // topic -> handlers
+	mu          sync.RWMutex
+	logger      Logger
+}
+
+// NewEventBus 생성자
+func NewEventBus(logger Logger) *EventBus {
+	return &EventBus{
+		subscribers: make(map[string][]subscription),
+		logger:      logger,
+	}
+}
+
+// Subscribe 토픽 구독
+func (eb *EventBus) Subscribe(pluginName, topic string, handler EventHandler) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	eb.subscribers[topic] = append(eb.subscribers[topic], subscription{
+		pluginName: pluginName,
+		handler:    handler,
+	})
+	eb.logger.Debug("Plugin %s subscribed to topic: %s", pluginName, topic)
+}
+
+// Unsubscribe 플러그인의 모든 구독 해제
+func (eb *EventBus) Unsubscribe(pluginName string) {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	for topic, subs := range eb.subscribers {
+		var remaining []subscription
+		for _, s := range subs {
+			if s.pluginName != pluginName {
+				remaining = append(remaining, s)
+			}
+		}
+		if len(remaining) == 0 {
+			delete(eb.subscribers, topic)
+		} else {
+			eb.subscribers[topic] = remaining
+		}
+	}
+}
+
+// Publish 이벤트 발행 (동기: 모든 핸들러 순차 실행)
+func (eb *EventBus) Publish(source, topic string, payload map[string]interface{}) {
+	eb.mu.RLock()
+	subs := make([]subscription, len(eb.subscribers[topic]))
+	copy(subs, eb.subscribers[topic])
+	eb.mu.RUnlock()
+
+	if len(subs) == 0 {
+		return
+	}
+
+	event := Event{
+		Topic:     topic,
+		Source:    source,
+		Payload:   payload,
+		Timestamp: time.Now(),
+	}
+
+	for _, s := range subs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					eb.logger.Error("Event handler panicked [%s/%s → %s]: %v", source, topic, s.pluginName, r)
+				}
+			}()
+			s.handler(event)
+		}()
+	}
+}
+
+// PublishAsync 이벤트 비동기 발행
+func (eb *EventBus) PublishAsync(source, topic string, payload map[string]interface{}) {
+	go eb.Publish(source, topic, payload)
+}
+
+// GetSubscriptions 구독 현황 조회
+func (eb *EventBus) GetSubscriptions() map[string][]string {
+	eb.mu.RLock()
+	defer eb.mu.RUnlock()
+	result := make(map[string][]string)
+	for topic, subs := range eb.subscribers {
+		for _, s := range subs {
+			result[topic] = append(result[topic], s.pluginName)
+		}
+	}
+	return result
+}

--- a/internal/plugin/eventbus.go
+++ b/internal/plugin/eventbus.go
@@ -8,7 +8,7 @@ import (
 // Event 플러그인 간 이벤트
 type Event struct {
 	Topic     string                 `json:"topic"`
-	Source    string                 `json:"source"`     // 발행 플러그인
+	Source    string                 `json:"source"` // 발행 플러그인
 	Payload   map[string]interface{} `json:"payload"`
 	Timestamp time.Time              `json:"timestamp"`
 }

--- a/internal/plugin/eventbus_test.go
+++ b/internal/plugin/eventbus_test.go
@@ -1,0 +1,139 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventBus_PublishSubscribe(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	var received Event
+	eb.Subscribe("plugin-a", "user.created", func(e Event) {
+		received = e
+	})
+
+	eb.Publish("plugin-b", "user.created", map[string]interface{}{"user_id": "123"})
+
+	if received.Topic != "user.created" {
+		t.Fatalf("expected topic user.created, got %s", received.Topic)
+	}
+	if received.Source != "plugin-b" {
+		t.Fatalf("expected source plugin-b, got %s", received.Source)
+	}
+	if received.Payload["user_id"] != "123" {
+		t.Fatalf("expected user_id 123, got %v", received.Payload["user_id"])
+	}
+}
+
+func TestEventBus_MultipleSubscribers(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	var count int
+	var mu sync.Mutex
+
+	handler := func(_ Event) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	}
+
+	eb.Subscribe("plugin-a", "order.placed", handler)
+	eb.Subscribe("plugin-b", "order.placed", handler)
+	eb.Subscribe("plugin-c", "order.placed", handler)
+
+	eb.Publish("shop", "order.placed", nil)
+
+	if count != 3 {
+		t.Fatalf("expected 3 handlers called, got %d", count)
+	}
+}
+
+func TestEventBus_Unsubscribe(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	var called bool
+	eb.Subscribe("plugin-a", "test.event", func(_ Event) {
+		called = true
+	})
+
+	eb.Unsubscribe("plugin-a")
+	eb.Publish("source", "test.event", nil)
+
+	if called {
+		t.Fatal("expected handler NOT to be called after unsubscribe")
+	}
+}
+
+func TestEventBus_NoSubscribers(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	// Should not panic
+	eb.Publish("source", "no.subscribers", nil)
+}
+
+func TestEventBus_HandlerPanic(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	var secondCalled bool
+	eb.Subscribe("bad-plugin", "test", func(_ Event) {
+		panic("handler crash")
+	})
+	eb.Subscribe("good-plugin", "test", func(_ Event) {
+		secondCalled = true
+	})
+
+	// Should not panic, and second handler should still run
+	eb.Publish("source", "test", nil)
+
+	if !secondCalled {
+		t.Fatal("expected second handler to be called despite first panic")
+	}
+}
+
+func TestEventBus_GetSubscriptions(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	eb.Subscribe("a", "topic1", func(_ Event) {})
+	eb.Subscribe("b", "topic1", func(_ Event) {})
+	eb.Subscribe("c", "topic2", func(_ Event) {})
+
+	subs := eb.GetSubscriptions()
+	if len(subs["topic1"]) != 2 {
+		t.Fatalf("expected 2 subscribers for topic1, got %d", len(subs["topic1"]))
+	}
+	if len(subs["topic2"]) != 1 {
+		t.Fatalf("expected 1 subscriber for topic2, got %d", len(subs["topic2"]))
+	}
+}
+
+func TestEventBus_PublishAsync(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	eb := NewEventBus(logger)
+
+	var received bool
+	var mu sync.Mutex
+	eb.Subscribe("plugin-a", "async.test", func(_ Event) {
+		mu.Lock()
+		received = true
+		mu.Unlock()
+	})
+
+	eb.PublishAsync("source", "async.test", nil)
+
+	// Wait for async handler
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !received {
+		t.Fatal("expected async handler to be called")
+	}
+}

--- a/internal/plugin/eventbus_test.go
+++ b/internal/plugin/eventbus_test.go
@@ -69,7 +69,7 @@ func TestEventBus_Unsubscribe(t *testing.T) {
 	}
 }
 
-func TestEventBus_NoSubscribers(t *testing.T) {
+func TestEventBus_NoSubscribers(_ *testing.T) {
 	logger := NewDefaultLogger("test")
 	eb := NewEventBus(logger)
 

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -26,7 +26,8 @@ type Manager struct {
 	permissions PermissionSyncer
 	scheduler   *Scheduler
 	rateLimiter *RateLimiter
-	metrics     *Metrics
+	metrics  *Metrics
+	eventBus *EventBus
 }
 
 // NewManager 새 매니저 생성
@@ -43,7 +44,8 @@ func NewManager(pluginsDir string, db *gorm.DB, redisClient *redis.Client, logge
 		permissions: permissions,
 		scheduler:   NewScheduler(logger),
 		rateLimiter: NewRateLimiter(redisClient),
-		metrics:     NewMetrics(),
+		metrics:  NewMetrics(),
+		eventBus: NewEventBus(logger),
 	}
 }
 
@@ -168,7 +170,13 @@ func (m *Manager) Enable(name string) error {
 			m.logger.Info("Configured rate limit for plugin: %s", name)
 		}
 
-		// 6) 라우트 등록
+		// 6) 이벤트 버스 등록 (EventAware 구현 시)
+		if ea, ok := info.Instance.(EventAware); ok {
+			ea.RegisterEvents(m.eventBus)
+			m.logger.Info("Registered events for plugin: %s", name)
+		}
+
+		// 7) 라우트 등록
 		m.registry.RegisterPlugin(info)
 	}
 
@@ -239,6 +247,9 @@ func (m *Manager) Disable(name string) error {
 
 	// 레이트 리밋 해제
 	m.rateLimiter.Remove(name)
+
+	// 이벤트 버스 구독 해제
+	m.eventBus.Unsubscribe(name)
 
 	// 라우트 해제
 	m.registry.UnregisterPlugin(name)
@@ -322,6 +333,16 @@ func (m *Manager) GetAllPluginMetrics() []MetricsSummary {
 // GetMetrics 메트릭 수집기 반환 (미들웨어 등록용)
 func (m *Manager) GetMetrics() *Metrics {
 	return m.metrics
+}
+
+// GetEventBus 이벤트 버스 반환
+func (m *Manager) GetEventBus() *EventBus {
+	return m.eventBus
+}
+
+// GetEventSubscriptions 이벤트 구독 현황 조회
+func (m *Manager) GetEventSubscriptions() map[string][]string {
+	return m.eventBus.GetSubscriptions()
 }
 
 // NotifyInstall 설치 시 라이프사이클 훅 호출

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -26,8 +26,8 @@ type Manager struct {
 	permissions PermissionSyncer
 	scheduler   *Scheduler
 	rateLimiter *RateLimiter
-	metrics  *Metrics
-	eventBus *EventBus
+	metrics     *Metrics
+	eventBus    *EventBus
 }
 
 // NewManager 새 매니저 생성
@@ -44,8 +44,8 @@ func NewManager(pluginsDir string, db *gorm.DB, redisClient *redis.Client, logge
 		permissions: permissions,
 		scheduler:   NewScheduler(logger),
 		rateLimiter: NewRateLimiter(redisClient),
-		metrics:  NewMetrics(),
-		eventBus: NewEventBus(logger),
+		metrics:     NewMetrics(),
+		eventBus:    NewEventBus(logger),
 	}
 }
 

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -211,6 +211,11 @@ type RateLimitable interface {
 	ConfigureRateLimit(limiter *RateLimiter)
 }
 
+// EventAware 선택적 인터페이스 - 이벤트 버스 구독
+type EventAware interface {
+	RegisterEvents(bus *EventBus)
+}
+
 // LifecycleAware 선택적 인터페이스 - 설치/제거/활성화/비활성화 이벤트 수신
 type LifecycleAware interface {
 	OnInstall() error

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -208,6 +208,13 @@ func (h *StoreHandler) PluginMetricsSingle(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": metrics})
 }
 
+// EventSubscriptions 이벤트 구독 현황 조회
+// GET /api/v2/admin/plugins/event-subscriptions
+func (h *StoreHandler) EventSubscriptions(c *gin.Context) {
+	subs := h.manager.GetEventSubscriptions()
+	c.JSON(http.StatusOK, gin.H{"data": subs})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- 플러그인 간 pub/sub 이벤트 시스템 (EventBus) 추가
- EventAware 인터페이스로 플러그인 자동 등록/해제
- 이벤트 구독 현황 조회 API (`/event-subscriptions`) 추가

## Test plan
- [x] EventBus 발행/구독 테스트 (7개 통과)
- [x] 패닉 핸들러 격리 테스트
- [x] 비동기 발행 테스트
- [x] `go build ./...` 성공