### PR TITLE
플러그인 설정 변경 시 자동 리로드

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -290,6 +290,9 @@ func main() {
 		pluginManager := plugin.NewManager("plugins", db, redisClient, pluginLogger, settingSvc, permSvc)
 		pluginManager.GetRegistry().SetRouter(router)
 
+		// 설정 변경 시 플러그인 자동 리로드 연결
+		settingSvc.SetReloader(pluginManager)
+
 		// 내장 플러그인 등록 (바이너리에 컴파일됨, 활성화는 DB 기반)
 		commercePlugin := commerce.New()
 		if err := pluginManager.RegisterBuiltIn("commerce", commercePlugin, commerce.Manifest); err != nil {

--- a/internal/pluginstore/service/setting_reload_test.go
+++ b/internal/pluginstore/service/setting_reload_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/damoang/angple-backend/internal/plugin"
+	"github.com/damoang/angple-backend/internal/pluginstore/domain"
+	"github.com/damoang/angple-backend/internal/pluginstore/repository"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// mockReloader 리로더 모의 객체
+type mockReloader struct {
+	reloaded []string
+}
+
+func (m *mockReloader) ReloadPlugin(name string) error {
+	m.reloaded = append(m.reloaded, name)
+	return nil
+}
+
+func setupSettingTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := db.AutoMigrate(&domain.PluginSetting{}, &domain.PluginEvent{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+func TestSaveSettings_TriggersReload(t *testing.T) {
+	db := setupSettingTestDB(t)
+	settingRepo := repository.NewSettingRepository(db)
+	eventRepo := repository.NewEventRepository(db)
+
+	// CatalogService에 매니페스트 등록
+	catalogSvc := NewCatalogService(nil)
+	catalogSvc.RegisterManifest(&plugin.PluginManifest{
+		Name: "test-plugin",
+		Settings: []plugin.SettingConfig{
+			{Key: "color", Type: "string", Label: "Color"},
+		},
+	})
+
+	svc := NewSettingService(settingRepo, eventRepo, catalogSvc)
+
+	reloader := &mockReloader{}
+	svc.SetReloader(reloader)
+
+	err := svc.SaveSettings("test-plugin", map[string]string{"color": "blue"}, "admin")
+	if err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+
+	if len(reloader.reloaded) != 1 || reloader.reloaded[0] != "test-plugin" {
+		t.Fatalf("expected reload of test-plugin, got %v", reloader.reloaded)
+	}
+}
+
+func TestSaveSettings_NoReloader(t *testing.T) {
+	db := setupSettingTestDB(t)
+	settingRepo := repository.NewSettingRepository(db)
+	eventRepo := repository.NewEventRepository(db)
+
+	catalogSvc := NewCatalogService(nil)
+	catalogSvc.RegisterManifest(&plugin.PluginManifest{
+		Name: "test-plugin",
+		Settings: []plugin.SettingConfig{
+			{Key: "color", Type: "string", Label: "Color"},
+		},
+	})
+
+	svc := NewSettingService(settingRepo, eventRepo, catalogSvc)
+	// No reloader set - should not panic
+
+	err := svc.SaveSettings("test-plugin", map[string]string{"color": "red"}, "admin")
+	if err != nil {
+		t.Fatalf("SaveSettings failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- 플러그인 설정 저장 시 자동으로 플러그인 리로드 (Disable → Enable)
- PluginReloader 인터페이스로 순환 의존 방지
- 리로드 실패 시에도 설정 저장은 유지

## Test plan
- [x] SaveSettings 후 리로드 트리거 테스트
- [x] 리로더 미설정 시 패닉 없이 동작 테스트
- [x] 전체 테스트 통과