### PR TITLE
플러그인 라우트 인증 미들웨어 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -289,6 +289,15 @@ func main() {
 		// Plugin Manager 생성 (settingSvc, permSvc 전달)
 		pluginManager := plugin.NewManager("plugins", db, redisClient, pluginLogger, settingSvc, permSvc)
 		pluginManager.GetRegistry().SetRouter(router)
+		pluginManager.GetRegistry().SetJWTVerifier(plugin.NewDefaultJWTVerifier(
+			func(token string) (string, string, int, error) {
+				claims, err := jwtManager.VerifyToken(token)
+				if err != nil {
+					return "", "", 0, err
+				}
+				return claims.UserID, claims.Nickname, claims.Level, nil
+			},
+		))
 
 		// 설정 변경 시 플러그인 자동 리로드 연결
 		settingSvc.SetReloader(pluginManager)

--- a/internal/plugin/auth.go
+++ b/internal/plugin/auth.go
@@ -1,0 +1,89 @@
+package plugin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// JWTVerifier JWT 토큰 검증 인터페이스 (순환 의존 방지)
+type JWTVerifier interface {
+	VerifyAndSetContext(c *gin.Context) error
+}
+
+// PluginAuthMiddleware 플러그인 라우트용 인증 미들웨어
+// auth: "required" - 인증 필수, "optional" - 인증 선택 (있으면 컨텍스트 설정), "none" - 인증 불필요
+func PluginAuthMiddleware(authType string, verifier JWTVerifier) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if verifier == nil || authType == "none" || authType == "" {
+			c.Next()
+			return
+		}
+
+		err := verifier.VerifyAndSetContext(c)
+
+		switch authType {
+		case "required":
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+					"error":   "UNAUTHORIZED",
+					"message": "Authentication required",
+				})
+				return
+			}
+		case "optional":
+			// 인증 실패해도 계속 진행 (로그인 안 한 사용자도 접근 가능)
+		}
+
+		c.Next()
+	}
+}
+
+// DefaultJWTVerifier 기본 JWT 검증기 구현
+type DefaultJWTVerifier struct {
+	verifyFn func(token string) (userID string, nickname string, level int, err error)
+}
+
+// NewDefaultJWTVerifier 생성자
+func NewDefaultJWTVerifier(verifyFn func(token string) (string, string, int, error)) *DefaultJWTVerifier {
+	return &DefaultJWTVerifier{verifyFn: verifyFn}
+}
+
+// VerifyAndSetContext 토큰 검증 후 컨텍스트에 사용자 정보 설정
+func (v *DefaultJWTVerifier) VerifyAndSetContext(c *gin.Context) error {
+	authHeader := c.GetHeader("Authorization")
+	if authHeader == "" {
+		return ErrNoToken
+	}
+
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return ErrInvalidToken
+	}
+
+	userID, nickname, level, err := v.verifyFn(parts[1])
+	if err != nil {
+		return err
+	}
+
+	c.Set("userID", userID)
+	c.Set("nickname", nickname)
+	c.Set("level", level)
+	return nil
+}
+
+// 인증 관련 에러
+var (
+	ErrNoToken      = &AuthError{Message: "no token provided"}
+	ErrInvalidToken = &AuthError{Message: "invalid token format"}
+)
+
+// AuthError 인증 에러
+type AuthError struct {
+	Message string
+}
+
+func (e *AuthError) Error() string {
+	return e.Message
+}

--- a/internal/plugin/auth.go
+++ b/internal/plugin/auth.go
@@ -12,9 +12,9 @@ type JWTVerifier interface {
 	VerifyAndSetContext(c *gin.Context) error
 }
 
-// PluginAuthMiddleware 플러그인 라우트용 인증 미들웨어
+// AuthMiddleware 플러그인 라우트용 인증 미들웨어
 // auth: "required" - 인증 필수, "optional" - 인증 선택 (있으면 컨텍스트 설정), "none" - 인증 불필요
-func PluginAuthMiddleware(authType string, verifier JWTVerifier) gin.HandlerFunc {
+func AuthMiddleware(authType string, verifier JWTVerifier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if verifier == nil || authType == "none" || authType == "" {
 			c.Next()

--- a/internal/plugin/auth_test.go
+++ b/internal/plugin/auth_test.go
@@ -1,0 +1,142 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func newTestVerifier(valid bool) *DefaultJWTVerifier {
+	return NewDefaultJWTVerifier(func(_ string) (string, string, int, error) {
+		if valid {
+			return "user1", "nick", 2, nil
+		}
+		return "", "", 0, errors.New("invalid token")
+	})
+}
+
+func TestPluginAuth_Required_WithValidToken(t *testing.T) {
+	verifier := newTestVerifier(true)
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+		userID, _ := c.Get("userID")
+		c.String(http.StatusOK, userID.(string))
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != "user1" {
+		t.Fatalf("expected user1, got %s", w.Body.String())
+	}
+}
+
+func TestPluginAuth_Required_NoToken(t *testing.T) {
+	verifier := newTestVerifier(true)
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPluginAuth_Required_InvalidToken(t *testing.T) {
+	verifier := newTestVerifier(false)
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPluginAuth_Optional_WithToken(t *testing.T) {
+	verifier := newTestVerifier(true)
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("optional", verifier), func(c *gin.Context) {
+		userID, _ := c.Get("userID")
+		c.String(http.StatusOK, userID.(string))
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPluginAuth_Optional_NoToken(t *testing.T) {
+	verifier := newTestVerifier(true)
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("optional", verifier), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPluginAuth_None(t *testing.T) {
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("none", nil), func(c *gin.Context) {
+		c.String(http.StatusOK, "public")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestPluginAuth_NilVerifier(t *testing.T) {
+	r := gin.New()
+	r.GET("/test", PluginAuthMiddleware("required", nil), func(c *gin.Context) {
+		c.String(http.StatusOK, "pass")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when verifier is nil, got %d", w.Code)
+	}
+}

--- a/internal/plugin/auth_test.go
+++ b/internal/plugin/auth_test.go
@@ -26,7 +26,7 @@ func newTestVerifier(valid bool) *DefaultJWTVerifier {
 func TestPluginAuth_Required_WithValidToken(t *testing.T) {
 	verifier := newTestVerifier(true)
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("required", verifier), func(c *gin.Context) {
 		userID, _ := c.Get("userID")
 		c.String(http.StatusOK, userID.(string))
 	})
@@ -47,7 +47,7 @@ func TestPluginAuth_Required_WithValidToken(t *testing.T) {
 func TestPluginAuth_Required_NoToken(t *testing.T) {
 	verifier := newTestVerifier(true)
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("required", verifier), func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
 
@@ -63,7 +63,7 @@ func TestPluginAuth_Required_NoToken(t *testing.T) {
 func TestPluginAuth_Required_InvalidToken(t *testing.T) {
 	verifier := newTestVerifier(false)
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("required", verifier), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("required", verifier), func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
 
@@ -80,7 +80,7 @@ func TestPluginAuth_Required_InvalidToken(t *testing.T) {
 func TestPluginAuth_Optional_WithToken(t *testing.T) {
 	verifier := newTestVerifier(true)
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("optional", verifier), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("optional", verifier), func(c *gin.Context) {
 		userID, _ := c.Get("userID")
 		c.String(http.StatusOK, userID.(string))
 	})
@@ -98,7 +98,7 @@ func TestPluginAuth_Optional_WithToken(t *testing.T) {
 func TestPluginAuth_Optional_NoToken(t *testing.T) {
 	verifier := newTestVerifier(true)
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("optional", verifier), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("optional", verifier), func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
 
@@ -113,7 +113,7 @@ func TestPluginAuth_Optional_NoToken(t *testing.T) {
 
 func TestPluginAuth_None(t *testing.T) {
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("none", nil), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("none", nil), func(c *gin.Context) {
 		c.String(http.StatusOK, "public")
 	})
 
@@ -128,7 +128,7 @@ func TestPluginAuth_None(t *testing.T) {
 
 func TestPluginAuth_NilVerifier(t *testing.T) {
 	r := gin.New()
-	r.GET("/test", PluginAuthMiddleware("required", nil), func(c *gin.Context) {
+	r.GET("/test", AuthMiddleware("required", nil), func(c *gin.Context) {
 		c.String(http.StatusOK, "pass")
 	})
 

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -166,7 +166,7 @@ func (r *Registry) createAuthMiddleware(pluginName string) gin.HandlerFunc {
 			}
 		}
 
-		PluginAuthMiddleware(authType, r.jwtVerifier)(c)
+		AuthMiddleware(authType, r.jwtVerifier)(c)
 	}
 }
 


### PR DESCRIPTION
## Summary
- 플러그인 라우트에 `auth: required | optional | none` 인증 미들웨어 자동 적용
- JWTVerifier 인터페이스로 JWT 검증 로직 주입 (순환 의존 방지)
- Registry에서 매니페스트 기반으로 라우트별 인증 레벨 결정

## Test plan
- [x] required + 유효 토큰 → 200
- [x] required + 토큰 없음 → 401
- [x] required + 무효 토큰 → 401
- [x] optional + 토큰 있음 → 200 + 컨텍스트 설정
- [x] optional + 토큰 없음 → 200
- [x] none → 200
- [x] nil verifier → 200 (graceful)