### PR TITLE
플러그인 현황 및 상세 정보 API 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -334,6 +334,7 @@ func main() {
 			adminPlugins.GET("/rate-limits", storeHandler.RateLimitConfigs)
 			adminPlugins.GET("/metrics", storeHandler.PluginMetrics)
 			adminPlugins.GET("/event-subscriptions", storeHandler.EventSubscriptions)
+			adminPlugins.GET("/overview", storeHandler.PluginOverview)
 			adminPlugins.GET("/settings/export", settingHandler.ExportAllSettings)
 			adminPlugins.POST("/settings/import", settingHandler.ImportSettings)
 			adminPlugins.GET("/:name", storeHandler.GetPlugin)
@@ -349,6 +350,7 @@ func main() {
 			adminPlugins.PUT("/:name/permissions/:permId", permHandler.UpdatePermission)
 			adminPlugins.GET("/:name/health", storeHandler.HealthCheckSingle)
 			adminPlugins.GET("/:name/metrics", storeHandler.PluginMetricsSingle)
+			adminPlugins.GET("/:name/detail", storeHandler.PluginDetail)
 		}
 
 		// 플러그인 스케줄러 시작

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -1,18 +1,18 @@
 package plugin
 
-// PluginOverview 플러그인 전체 현황 요약
-type PluginOverview struct {
+// Overview 플러그인 전체 현황 요약
+type Overview struct {
 	TotalPlugins   int             `json:"total_plugins"`
 	EnabledCount   int             `json:"enabled_count"`
 	DisabledCount  int             `json:"disabled_count"`
 	ErrorCount     int             `json:"error_count"`
-	Plugins        []PluginSummary `json:"plugins"`
+	Plugins        []Summary `json:"plugins"`
 	TotalRoutes    int             `json:"total_routes"`
 	TotalSchedules int             `json:"total_schedules"`
 }
 
-// PluginSummary 개별 플러그인 요약
-type PluginSummary struct {
+// Summary 개별 플러그인 요약
+type Summary struct {
 	Name        string       `json:"name"`
 	Version     string       `json:"version"`
 	Title       string       `json:"title"`
@@ -25,7 +25,7 @@ type PluginSummary struct {
 }
 
 // GetOverview 플러그인 전체 현황 조회
-func (m *Manager) GetOverview() PluginOverview {
+func (m *Manager) GetOverview() Overview {
 	m.mu.RLock()
 	plugins := make([]*PluginInfo, 0, len(m.plugins))
 	for _, info := range m.plugins {
@@ -33,7 +33,7 @@ func (m *Manager) GetOverview() PluginOverview {
 	}
 	m.mu.RUnlock()
 
-	overview := PluginOverview{}
+	overview := Overview{}
 	overview.TotalPlugins = len(plugins)
 
 	routes := m.registry.GetRegisteredRoutes()
@@ -54,7 +54,7 @@ func (m *Manager) GetOverview() PluginOverview {
 		routeCount := len(routes[name])
 		overview.TotalRoutes += routeCount
 
-		summary := PluginSummary{
+		summary := Summary{
 			Name:        name,
 			Version:     info.Manifest.Version,
 			Title:       info.Manifest.Title,
@@ -92,8 +92,8 @@ func (m *Manager) GetOverview() PluginOverview {
 	return overview
 }
 
-// PluginDetail 플러그인 상세 정보 (capabilities 포함)
-type PluginDetail struct {
+// Detail 플러그인 상세 정보 (capabilities 포함)
+type Detail struct {
 	Name        string              `json:"name"`
 	Version     string              `json:"version"`
 	Title       string              `json:"title"`
@@ -111,8 +111,8 @@ type PluginDetail struct {
 	Health      PluginHealth        `json:"health"`
 }
 
-// GetPluginDetail 플러그인 상세 정보 조회
-func (m *Manager) GetPluginDetail(name string) *PluginDetail {
+// GetDetail 플러그인 상세 정보 조회
+func (m *Manager) GetDetail(name string) *Detail {
 	m.mu.RLock()
 	info, exists := m.plugins[name]
 	m.mu.RUnlock()
@@ -121,7 +121,7 @@ func (m *Manager) GetPluginDetail(name string) *PluginDetail {
 		return nil
 	}
 
-	detail := &PluginDetail{
+	detail := &Detail{
 		Name:        info.Manifest.Name,
 		Version:     info.Manifest.Version,
 		Title:       info.Manifest.Title,

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -1,0 +1,180 @@
+package plugin
+
+// PluginOverview 플러그인 전체 현황 요약
+type PluginOverview struct {
+	TotalPlugins   int             `json:"total_plugins"`
+	EnabledCount   int             `json:"enabled_count"`
+	DisabledCount  int             `json:"disabled_count"`
+	ErrorCount     int             `json:"error_count"`
+	Plugins        []PluginSummary `json:"plugins"`
+	TotalRoutes    int             `json:"total_routes"`
+	TotalSchedules int             `json:"total_schedules"`
+}
+
+// PluginSummary 개별 플러그인 요약
+type PluginSummary struct {
+	Name        string       `json:"name"`
+	Version     string       `json:"version"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	Status      PluginStatus `json:"status"`
+	IsBuiltIn   bool         `json:"is_built_in"`
+	Routes      int          `json:"routes"`
+	HasSchedule bool         `json:"has_schedule"`
+	HasEvents   bool         `json:"has_events"`
+}
+
+// GetOverview 플러그인 전체 현황 조회
+func (m *Manager) GetOverview() PluginOverview {
+	m.mu.RLock()
+	plugins := make([]*PluginInfo, 0, len(m.plugins))
+	for _, info := range m.plugins {
+		plugins = append(plugins, info)
+	}
+	m.mu.RUnlock()
+
+	overview := PluginOverview{}
+	overview.TotalPlugins = len(plugins)
+
+	routes := m.registry.GetRegisteredRoutes()
+	schedules := m.scheduler.GetTasks()
+	events := m.eventBus.GetSubscriptions()
+
+	for _, info := range plugins {
+		switch info.Status {
+		case StatusEnabled:
+			overview.EnabledCount++
+		case StatusDisabled:
+			overview.DisabledCount++
+		case StatusError:
+			overview.ErrorCount++
+		}
+
+		name := info.Manifest.Name
+		routeCount := len(routes[name])
+		overview.TotalRoutes += routeCount
+
+		summary := PluginSummary{
+			Name:        name,
+			Version:     info.Manifest.Version,
+			Title:       info.Manifest.Title,
+			Description: info.Manifest.Description,
+			Status:      info.Status,
+			IsBuiltIn:   info.IsBuiltIn,
+			Routes:      routeCount,
+		}
+
+		// 스케줄 확인
+		for _, task := range schedules {
+			if task.PluginName == name {
+				summary.HasSchedule = true
+				overview.TotalSchedules++
+				break
+			}
+		}
+
+		// 이벤트 구독 확인
+		for _, subscribers := range events {
+			for _, sub := range subscribers {
+				if sub == name {
+					summary.HasEvents = true
+					break
+				}
+			}
+			if summary.HasEvents {
+				break
+			}
+		}
+
+		overview.Plugins = append(overview.Plugins, summary)
+	}
+
+	return overview
+}
+
+// PluginDetail 플러그인 상세 정보 (capabilities 포함)
+type PluginDetail struct {
+	Name        string              `json:"name"`
+	Version     string              `json:"version"`
+	Title       string              `json:"title"`
+	Description string              `json:"description"`
+	Author      string              `json:"author"`
+	Homepage    string              `json:"homepage"`
+	Status      PluginStatus        `json:"status"`
+	IsBuiltIn   bool                `json:"is_built_in"`
+	Routes      []RegisteredRoute   `json:"routes"`
+	Schedules   []ScheduledTaskInfo `json:"schedules"`
+	Events      []string            `json:"events"`
+	Menus       []MenuConfig        `json:"menus"`
+	Permissions []Permission        `json:"permissions"`
+	Settings    []SettingConfig     `json:"settings"`
+	Health      PluginHealth        `json:"health"`
+}
+
+// GetPluginDetail 플러그인 상세 정보 조회
+func (m *Manager) GetPluginDetail(name string) *PluginDetail {
+	m.mu.RLock()
+	info, exists := m.plugins[name]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil
+	}
+
+	detail := &PluginDetail{
+		Name:        info.Manifest.Name,
+		Version:     info.Manifest.Version,
+		Title:       info.Manifest.Title,
+		Description: info.Manifest.Description,
+		Author:      info.Manifest.Author,
+		Homepage:    info.Manifest.Homepage,
+		Status:      info.Status,
+		IsBuiltIn:   info.IsBuiltIn,
+		Menus:       info.Manifest.Menus,
+		Permissions: info.Manifest.Permissions,
+		Settings:    info.Manifest.Settings,
+		Health:      m.CheckHealth(name),
+	}
+
+	// 라우트
+	detail.Routes = m.registry.GetPluginRoutes(name)
+	if detail.Routes == nil {
+		detail.Routes = []RegisteredRoute{}
+	}
+
+	// 스케줄
+	for _, task := range m.scheduler.GetTasks() {
+		if task.PluginName == name {
+			detail.Schedules = append(detail.Schedules, task)
+		}
+	}
+	if detail.Schedules == nil {
+		detail.Schedules = []ScheduledTaskInfo{}
+	}
+
+	// 이벤트 구독 토픽 목록
+	for topic, subs := range m.eventBus.GetSubscriptions() {
+		for _, sub := range subs {
+			if sub == name {
+				detail.Events = append(detail.Events, topic)
+				break
+			}
+		}
+	}
+	if detail.Events == nil {
+		detail.Events = []string{}
+	}
+
+	// nil 슬라이스 방지
+	if detail.Menus == nil {
+		detail.Menus = []MenuConfig{}
+	}
+	if detail.Permissions == nil {
+		detail.Permissions = []Permission{}
+	}
+	if detail.Settings == nil {
+		detail.Settings = []SettingConfig{}
+	}
+
+	return detail
+}

--- a/internal/plugin/info.go
+++ b/internal/plugin/info.go
@@ -2,13 +2,13 @@ package plugin
 
 // Overview 플러그인 전체 현황 요약
 type Overview struct {
-	TotalPlugins   int             `json:"total_plugins"`
-	EnabledCount   int             `json:"enabled_count"`
-	DisabledCount  int             `json:"disabled_count"`
-	ErrorCount     int             `json:"error_count"`
+	TotalPlugins   int       `json:"total_plugins"`
+	EnabledCount   int       `json:"enabled_count"`
+	DisabledCount  int       `json:"disabled_count"`
+	ErrorCount     int       `json:"error_count"`
 	Plugins        []Summary `json:"plugins"`
-	TotalRoutes    int             `json:"total_routes"`
-	TotalSchedules int             `json:"total_schedules"`
+	TotalRoutes    int       `json:"total_routes"`
+	TotalSchedules int       `json:"total_schedules"`
 }
 
 // Summary 개별 플러그인 요약

--- a/internal/plugin/info_test.go
+++ b/internal/plugin/info_test.go
@@ -1,0 +1,99 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type infoTestPlugin struct{}
+
+func (p *infoTestPlugin) Name() string                      { return "info-test" }
+func (p *infoTestPlugin) Migrate(_ *gorm.DB) error          { return nil }
+func (p *infoTestPlugin) Initialize(_ *PluginContext) error { return nil }
+func (p *infoTestPlugin) RegisterRoutes(_ gin.IRouter)      {}
+func (p *infoTestPlugin) Shutdown() error                   { return nil }
+
+func TestGetOverview(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	m := NewManager("plugins", nil, nil, logger, nil, nil)
+
+	m.mu.Lock()
+	m.plugins["alpha"] = &PluginInfo{
+		Manifest:  &PluginManifest{Name: "alpha", Version: "1.0.0", Title: "Alpha"},
+		Status:    StatusEnabled,
+		IsBuiltIn: true,
+		Instance:  &infoTestPlugin{},
+	}
+	m.plugins["beta"] = &PluginInfo{
+		Manifest: &PluginManifest{Name: "beta", Version: "0.1.0", Title: "Beta"},
+		Status:   StatusDisabled,
+		Instance: &infoTestPlugin{},
+	}
+	m.mu.Unlock()
+
+	overview := m.GetOverview()
+
+	if overview.TotalPlugins != 2 {
+		t.Fatalf("expected 2 total, got %d", overview.TotalPlugins)
+	}
+	if overview.EnabledCount != 1 {
+		t.Fatalf("expected 1 enabled, got %d", overview.EnabledCount)
+	}
+	if overview.DisabledCount != 1 {
+		t.Fatalf("expected 1 disabled, got %d", overview.DisabledCount)
+	}
+}
+
+func TestGetPluginDetail(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	m := NewManager("plugins", nil, nil, logger, nil, nil)
+
+	m.mu.Lock()
+	m.plugins["test-detail"] = &PluginInfo{
+		Manifest: &PluginManifest{
+			Name:    "test-detail",
+			Version: "2.0.0",
+			Title:   "Detail Test",
+			Author:  "tester",
+			Settings: []SettingConfig{
+				{Key: "color", Type: "string"},
+			},
+		},
+		Status:   StatusEnabled,
+		Instance: &infoTestPlugin{},
+	}
+	m.mu.Unlock()
+
+	detail := m.GetPluginDetail("test-detail")
+	if detail == nil {
+		t.Fatal("expected detail, got nil")
+	}
+	if detail.Name != "test-detail" {
+		t.Fatalf("expected test-detail, got %s", detail.Name)
+	}
+	if detail.Author != "tester" {
+		t.Fatalf("expected tester, got %s", detail.Author)
+	}
+	if len(detail.Settings) != 1 {
+		t.Fatalf("expected 1 setting, got %d", len(detail.Settings))
+	}
+	// nil 슬라이스가 아닌 빈 슬라이스인지 확인
+	if detail.Routes == nil {
+		t.Fatal("routes should not be nil")
+	}
+	if detail.Events == nil {
+		t.Fatal("events should not be nil")
+	}
+}
+
+func TestGetPluginDetail_NotFound(t *testing.T) {
+	logger := NewDefaultLogger("test")
+	m := NewManager("plugins", nil, nil, logger, nil, nil)
+
+	detail := m.GetPluginDetail("nonexistent")
+	if detail != nil {
+		t.Fatal("expected nil for nonexistent plugin")
+	}
+}

--- a/internal/plugin/info_test.go
+++ b/internal/plugin/info_test.go
@@ -66,7 +66,7 @@ func TestGetPluginDetail(t *testing.T) {
 	}
 	m.mu.Unlock()
 
-	detail := m.GetPluginDetail("test-detail")
+	detail := m.GetDetail("test-detail")
 	if detail == nil {
 		t.Fatal("expected detail, got nil")
 	}
@@ -92,7 +92,7 @@ func TestGetPluginDetail_NotFound(t *testing.T) {
 	logger := NewDefaultLogger("test")
 	m := NewManager("plugins", nil, nil, logger, nil, nil)
 
-	detail := m.GetPluginDetail("nonexistent")
+	detail := m.GetDetail("nonexistent")
 	if detail != nil {
 		t.Fatal("expected nil for nonexistent plugin")
 	}

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -226,7 +226,7 @@ func (h *StoreHandler) PluginOverview(c *gin.Context) {
 // GET /api/v2/admin/plugins/:name/detail
 func (h *StoreHandler) PluginDetail(c *gin.Context) {
 	name := c.Param("name")
-	detail := h.manager.GetPluginDetail(name)
+	detail := h.manager.GetDetail(name)
 	if detail == nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": gin.H{"code": "PLUGIN_NOT_FOUND", "message": "플러그인을 찾을 수 없습니다"},

--- a/internal/pluginstore/handler/store_handler.go
+++ b/internal/pluginstore/handler/store_handler.go
@@ -215,6 +215,27 @@ func (h *StoreHandler) EventSubscriptions(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": subs})
 }
 
+// PluginOverview 플러그인 전체 현황 조회
+// GET /api/v2/admin/plugins/overview
+func (h *StoreHandler) PluginOverview(c *gin.Context) {
+	overview := h.manager.GetOverview()
+	c.JSON(http.StatusOK, gin.H{"data": overview})
+}
+
+// PluginDetail 플러그인 상세 정보 (capabilities 포함)
+// GET /api/v2/admin/plugins/:name/detail
+func (h *StoreHandler) PluginDetail(c *gin.Context) {
+	name := c.Param("name")
+	detail := h.manager.GetPluginDetail(name)
+	if detail == nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": gin.H{"code": "PLUGIN_NOT_FOUND", "message": "플러그인을 찾을 수 없습니다"},
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": detail})
+}
+
 // getActorID 요청에서 사용자 ID 추출
 func getActorID(c *gin.Context) string {
 	// damoang_jwt 쿠키 인증에서 mb_id를 가져옴


### PR DESCRIPTION
## Summary
- 플러그인 전체 현황 조회 API (`/overview`) - 활성/비활성/에러 수, 총 라우트, 스케줄 수
- 플러그인 상세 정보 API (`/:name/detail`) - 라우트, 스케줄, 이벤트, 메뉴, 권한, 설정, 헬스 통합 조회
- 프론트엔드에서 플러그인 대시보드 구성에 필요한 정보 제공

## Test plan
- [x] GetOverview 전체 현황 집계 테스트
- [x] GetPluginDetail 상세 정보 조회 테스트
- [x] 존재하지 않는 플러그인 조회 시 nil 반환 테스트
- [x] `go build ./...` 성공