### PR TITLE
feat(plugin): core hook 이벤트 상수 정의 및 서비스 hook 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ __pycache__/
 
 # Serena
 .serena/
-api
+/api

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -184,7 +184,7 @@ func main() {
 		notificationRepo := repository.NewNotificationRepository(db)
 
 		// Services
-		authService := service.NewAuthService(memberRepo, jwtManager)
+		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
 		postService := service.NewPostService(postRepo, hookManager)
 		commentService := service.NewCommentService(commentRepo, goodRepo, hookManager)
 		menuService := service.NewMenuService(menuRepo)

--- a/internal/plugin/hooks.go
+++ b/internal/plugin/hooks.go
@@ -1,0 +1,28 @@
+package plugin
+
+// Post hooks
+const (
+	HookPostBeforeCreate = "post.before_create"
+	HookPostAfterCreate  = "post.after_create"
+	HookPostBeforeUpdate = "post.before_update"
+	HookPostAfterUpdate  = "post.after_update"
+	HookPostBeforeDelete = "post.before_delete"
+	HookPostAfterDelete  = "post.after_delete"
+	HookPostContent      = "post.content"
+)
+
+// Comment hooks
+const (
+	HookCommentBeforeCreate = "comment.before_create"
+	HookCommentAfterCreate  = "comment.after_create"
+	HookCommentBeforeUpdate = "comment.before_update"
+	HookCommentAfterUpdate  = "comment.after_update"
+	HookCommentBeforeDelete = "comment.before_delete"
+	HookCommentAfterDelete  = "comment.after_delete"
+	HookCommentContent      = "comment.content"
+)
+
+// User hooks
+const (
+	HookUserAfterLogin = "user.after_login"
+)

--- a/internal/plugin/hooks_test.go
+++ b/internal/plugin/hooks_test.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"testing"
+)
+
+func TestHookConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		constant string
+		expected string
+	}{
+		// Post hooks
+		{"HookPostBeforeCreate", HookPostBeforeCreate, "post.before_create"},
+		{"HookPostAfterCreate", HookPostAfterCreate, "post.after_create"},
+		{"HookPostBeforeUpdate", HookPostBeforeUpdate, "post.before_update"},
+		{"HookPostAfterUpdate", HookPostAfterUpdate, "post.after_update"},
+		{"HookPostBeforeDelete", HookPostBeforeDelete, "post.before_delete"},
+		{"HookPostAfterDelete", HookPostAfterDelete, "post.after_delete"},
+		{"HookPostContent", HookPostContent, "post.content"},
+		// Comment hooks
+		{"HookCommentBeforeCreate", HookCommentBeforeCreate, "comment.before_create"},
+		{"HookCommentAfterCreate", HookCommentAfterCreate, "comment.after_create"},
+		{"HookCommentBeforeUpdate", HookCommentBeforeUpdate, "comment.before_update"},
+		{"HookCommentAfterUpdate", HookCommentAfterUpdate, "comment.after_update"},
+		{"HookCommentBeforeDelete", HookCommentBeforeDelete, "comment.before_delete"},
+		{"HookCommentAfterDelete", HookCommentAfterDelete, "comment.after_delete"},
+		{"HookCommentContent", HookCommentContent, "comment.content"},
+		// User hooks
+		{"HookUserAfterLogin", HookUserAfterLogin, "user.after_login"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.constant != tt.expected {
+				t.Errorf("%s = %q, want %q", tt.name, tt.constant, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHookManagerDoUserAfterLogin(t *testing.T) {
+	hm := newTestHookManager()
+
+	var captured map[string]interface{}
+	hm.Register(HookUserAfterLogin, "test-plugin", func(ctx *HookContext) error {
+		captured = ctx.Input
+		return nil
+	}, 10)
+
+	hm.Do(HookUserAfterLogin, map[string]interface{}{
+		"user_id":  "testuser",
+		"nickname": "테스트",
+		"level":    10,
+	})
+
+	if captured == nil {
+		t.Fatal("hook handler was not called")
+	}
+	if captured["user_id"] != "testuser" {
+		t.Errorf("user_id = %v, want %q", captured["user_id"], "testuser")
+	}
+	if captured["nickname"] != "테스트" {
+		t.Errorf("nickname = %v, want %q", captured["nickname"], "테스트")
+	}
+	if captured["level"] != 10 {
+		t.Errorf("level = %v, want %d", captured["level"], 10)
+	}
+}
+

--- a/internal/service/comment_service.go
+++ b/internal/service/comment_service.go
@@ -56,7 +56,7 @@ func (s *commentService) GetComment(boardID string, id int) (*domain.CommentResp
 
 	// comment.content Filter
 	if s.hooks != nil {
-		data := s.hooks.Apply("comment.content", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookCommentContent, map[string]interface{}{
 			"board_id":   boardID,
 			"comment_id": id,
 			"content":    resp.Content,
@@ -113,7 +113,7 @@ func (s *commentService) CreateComment(
 
 	// before_create Filter
 	if s.hooks != nil {
-		data := s.hooks.Apply("comment.before_create", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookCommentBeforeCreate, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   postID,
 			"content":   comment.Content,
@@ -130,7 +130,7 @@ func (s *commentService) CreateComment(
 
 	// after_create Action
 	if s.hooks != nil {
-		s.hooks.Do("comment.after_create", map[string]interface{}{
+		s.hooks.Do(plugin.HookCommentAfterCreate, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   postID,
 			"author_id": authorID,
@@ -163,7 +163,7 @@ func (s *commentService) UpdateComment(
 
 	// before_update Filter
 	if s.hooks != nil {
-		data := s.hooks.Apply("comment.before_update", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookCommentBeforeUpdate, map[string]interface{}{
 			"board_id":   boardID,
 			"comment_id": id,
 			"content":    comment.Content,
@@ -180,7 +180,7 @@ func (s *commentService) UpdateComment(
 
 	// after_update Action
 	if s.hooks != nil {
-		s.hooks.Do("comment.after_update", map[string]interface{}{
+		s.hooks.Do(plugin.HookCommentAfterUpdate, map[string]interface{}{
 			"board_id":   boardID,
 			"comment_id": id,
 			"author_id":  authorID,
@@ -206,7 +206,7 @@ func (s *commentService) DeleteComment(boardID string, id int, authorID string) 
 
 	// before_delete Filter
 	if s.hooks != nil {
-		s.hooks.Apply("comment.before_delete", map[string]interface{}{
+		s.hooks.Apply(plugin.HookCommentBeforeDelete, map[string]interface{}{
 			"board_id":   boardID,
 			"comment_id": id,
 			"author_id":  authorID,
@@ -219,7 +219,7 @@ func (s *commentService) DeleteComment(boardID string, id int, authorID string) 
 
 	// after_delete Action
 	if s.hooks != nil {
-		s.hooks.Do("comment.after_delete", map[string]interface{}{
+		s.hooks.Do(plugin.HookCommentAfterDelete, map[string]interface{}{
 			"board_id":   boardID,
 			"comment_id": id,
 			"author_id":  authorID,

--- a/internal/service/post_service.go
+++ b/internal/service/post_service.go
@@ -74,7 +74,7 @@ func (s *postService) GetPost(boardID string, id int) (*domain.PostResponse, err
 
 	// post.content Filter (content 렌더링 시)
 	if s.hooks != nil {
-		data := s.hooks.Apply("post.content", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookPostContent, map[string]interface{}{
 			"board_id": boardID,
 			"post_id":  id,
 			"content":  resp.Content,
@@ -100,7 +100,7 @@ func (s *postService) CreatePost(boardID string, req *domain.CreatePostRequest, 
 
 	// before_create Filter
 	if s.hooks != nil {
-		data := s.hooks.Apply("post.before_create", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookPostBeforeCreate, map[string]interface{}{
 			"board_id":  boardID,
 			"title":     post.Title,
 			"content":   post.Content,
@@ -120,7 +120,7 @@ func (s *postService) CreatePost(boardID string, req *domain.CreatePostRequest, 
 
 	// after_create Action
 	if s.hooks != nil {
-		s.hooks.Do("post.after_create", map[string]interface{}{
+		s.hooks.Do(plugin.HookPostAfterCreate, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   post.ID,
 			"title":     post.Title,
@@ -152,7 +152,7 @@ func (s *postService) UpdatePost(boardID string, id int, req *domain.UpdatePostR
 
 	// before_update Filter
 	if s.hooks != nil {
-		data := s.hooks.Apply("post.before_update", map[string]interface{}{
+		data := s.hooks.Apply(plugin.HookPostBeforeUpdate, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   id,
 			"title":     post.Title,
@@ -173,7 +173,7 @@ func (s *postService) UpdatePost(boardID string, id int, req *domain.UpdatePostR
 
 	// after_update Action
 	if s.hooks != nil {
-		s.hooks.Do("post.after_update", map[string]interface{}{
+		s.hooks.Do(plugin.HookPostAfterUpdate, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   id,
 			"author_id": authorID,
@@ -200,7 +200,7 @@ func (s *postService) DeletePost(boardID string, id int, authorID string) error 
 
 	// before_delete Filter
 	if s.hooks != nil {
-		s.hooks.Apply("post.before_delete", map[string]interface{}{
+		s.hooks.Apply(plugin.HookPostBeforeDelete, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   id,
 			"author_id": authorID,
@@ -213,7 +213,7 @@ func (s *postService) DeletePost(boardID string, id int, authorID string) error 
 
 	// after_delete Action
 	if s.hooks != nil {
-		s.hooks.Do("post.after_delete", map[string]interface{}{
+		s.hooks.Do(plugin.HookPostAfterDelete, map[string]interface{}{
 			"board_id":  boardID,
 			"post_id":   id,
 			"author_id": authorID,


### PR DESCRIPTION
## Summary
- Post/Comment/User hook 이벤트 상수 정의 (`internal/plugin/hooks.go`)
- AuthService, PostService, CommentService에 HookManager 주입 연동
- hook 상수 테스트 추가
- .gitignore: `api` → `/api` (cmd/api 디렉토리 무시 방지)

## Test plan
- [x] `go build ./...` 빌드 확인
- [x] `go test ./internal/plugin/...` hook 상수 테스트 통과