### PR TITLE
feat(member): 회원 프로필 API 4종 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -164,6 +164,7 @@ func main() {
 	var bannerHandler *handler.BannerHandler
 	var goodHandler *handler.GoodHandler
 	var notificationHandler *handler.NotificationHandler
+	var memberProfileHandler *handler.MemberProfileHandler
 
 	if db != nil {
 		// Repositories
@@ -182,6 +183,7 @@ func main() {
 		bannerRepo := repository.NewBannerRepository(db)
 		goodRepo := repository.NewGoodRepository(db)
 		notificationRepo := repository.NewNotificationRepository(db)
+		pointRepo := repository.NewPointRepository(db)
 
 		// Services
 		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
@@ -199,6 +201,7 @@ func main() {
 		bannerService := service.NewBannerService(bannerRepo)
 		goodService := service.NewGoodService(goodRepo)
 		notificationService := service.NewNotificationService(notificationRepo)
+		memberProfileService := service.NewMemberProfileService(memberRepo, pointRepo, db)
 
 		// Handlers
 		authHandler = handler.NewAuthHandler(authService, cfg)
@@ -219,6 +222,7 @@ func main() {
 		bannerHandler = handler.NewBannerHandler(bannerService)
 		goodHandler = handler.NewGoodHandler(goodService)
 		notificationHandler = handler.NewNotificationHandler(notificationService)
+		memberProfileHandler = handler.NewMemberProfileHandler(memberProfileService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -264,7 +268,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/domain/member.go
+++ b/internal/domain/member.go
@@ -77,3 +77,75 @@ func (m *Member) ToResponse() *MemberResponse {
 		Profile:  m.Profile,
 	}
 }
+
+// MemberProfileResponse represents a public member profile
+type MemberProfileResponse struct {
+	UserID    string `json:"user_id"`
+	Nickname  string `json:"nickname"`
+	Profile   string `json:"profile,omitempty"`
+	CreatedAt string `json:"created_at"`
+	Level     int    `json:"level"`
+	Point     int    `json:"point"`
+}
+
+// ToProfileResponse converts Member to MemberProfileResponse
+func (m *Member) ToProfileResponse() *MemberProfileResponse {
+	return &MemberProfileResponse{
+		UserID:    m.UserID,
+		Nickname:  m.Nickname,
+		Profile:   m.Profile,
+		Level:     m.Level,
+		Point:     m.Point,
+		CreatedAt: m.CreatedAt.Format("2006-01-02"),
+	}
+}
+
+// MemberPostSummary represents a summary of a member's post
+type MemberPostSummary struct {
+	CreatedAt string `json:"created_at"`
+	BoardID   string `json:"board_id"`
+	Title     string `json:"title"`
+	ID        int    `json:"id"`
+	Comments  int    `json:"comments_count"`
+	Likes     int    `json:"likes"`
+	Views     int    `json:"views"`
+}
+
+// MemberCommentSummary represents a summary of a member's comment
+type MemberCommentSummary struct {
+	CreatedAt string `json:"created_at"`
+	BoardID   string `json:"board_id"`
+	Content   string `json:"content"`
+	ID        int    `json:"id"`
+	PostID    int    `json:"post_id"`
+}
+
+// PointHistory represents a point transaction record (g5_point table)
+type PointHistory struct {
+	CreatedAt string `json:"created_at"`
+	Content   string `json:"content"`
+	RelTable  string `json:"rel_table,omitempty"`
+	RelAction string `json:"rel_action,omitempty"`
+	ID        int    `json:"id"`
+	Point     int    `json:"point"`
+	RelID     int    `json:"rel_id,omitempty"`
+}
+
+// Point domain model (g5_point table)
+type Point struct {
+	Datetime  string `gorm:"column:po_datetime" json:"datetime"`
+	Content   string `gorm:"column:po_content" json:"content"`
+	RelTable  string `gorm:"column:po_rel_table" json:"rel_table"`
+	RelAction string `gorm:"column:po_rel_action" json:"rel_action"`
+	MbID      string `gorm:"column:mb_id" json:"mb_id"`
+	RelID     string `gorm:"column:po_rel_id" json:"rel_id"`
+	ID        int    `gorm:"column:po_id;primaryKey" json:"id"`
+	UsePoint  int    `gorm:"column:po_use_point" json:"use_point"`
+	Point     int    `gorm:"column:po_point" json:"point"`
+	MbPoint   int    `gorm:"column:po_mb_point" json:"mb_point"`
+	ExpireDate string `gorm:"column:po_expire_date" json:"expire_date"`
+}
+
+func (Point) TableName() string {
+	return "g5_point"
+}

--- a/internal/handler/member_profile_handler.go
+++ b/internal/handler/member_profile_handler.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// MemberProfileHandler handles member profile HTTP requests
+type MemberProfileHandler struct {
+	service service.MemberProfileService
+}
+
+// NewMemberProfileHandler creates a new MemberProfileHandler
+func NewMemberProfileHandler(service service.MemberProfileService) *MemberProfileHandler {
+	return &MemberProfileHandler{service: service}
+}
+
+// GetProfile handles GET /api/v2/members/:user_id
+// @Summary 회원 프로필 조회
+// @Description 회원 ID로 공개 프로필 정보를 조회합니다
+// @Tags members
+// @Produce json
+// @Param user_id path string true "회원 ID"
+// @Success 200 {object} common.APIResponse{data=domain.MemberProfileResponse}
+// @Failure 404 {object} common.APIResponse
+// @Router /members/{user_id} [get]
+func (h *MemberProfileHandler) GetProfile(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "회원 ID를 입력해 주세요", nil)
+		return
+	}
+
+	profile, err := h.service.GetProfile(userID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "회원을 찾을 수 없습니다", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: profile})
+}
+
+// GetPosts handles GET /api/v2/members/:user_id/posts
+// @Summary 회원 작성글 조회
+// @Description 회원의 최근 작성글 목록을 조회합니다 (최근 5개)
+// @Tags members
+// @Produce json
+// @Param user_id path string true "회원 ID"
+// @Param limit query int false "조회 개수 (기본 5, 최대 20)"
+// @Success 200 {object} common.APIResponse{data=[]domain.MemberPostSummary}
+// @Failure 404 {object} common.APIResponse
+// @Router /members/{user_id}/posts [get]
+func (h *MemberProfileHandler) GetPosts(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "회원 ID를 입력해 주세요", nil)
+		return
+	}
+
+	limit := 5
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	posts, err := h.service.GetRecentPosts(userID, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "작성글 조회 중 오류가 발생했습니다", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: posts})
+}
+
+// GetComments handles GET /api/v2/members/:user_id/comments
+// @Summary 회원 작성댓글 조회
+// @Description 회원의 최근 작성댓글 목록을 조회합니다 (최근 5개)
+// @Tags members
+// @Produce json
+// @Param user_id path string true "회원 ID"
+// @Param limit query int false "조회 개수 (기본 5, 최대 20)"
+// @Success 200 {object} common.APIResponse{data=[]domain.MemberCommentSummary}
+// @Failure 404 {object} common.APIResponse
+// @Router /members/{user_id}/comments [get]
+func (h *MemberProfileHandler) GetComments(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "회원 ID를 입력해 주세요", nil)
+		return
+	}
+
+	limit := 5
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	comments, err := h.service.GetRecentComments(userID, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "작성댓글 조회 중 오류가 발생했습니다", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: comments})
+}
+
+// GetPointHistory handles GET /api/v2/members/:user_id/points/history
+// @Summary 포인트 내역 조회
+// @Description 본인의 포인트 내역을 조회합니다 (본인만 조회 가능)
+// @Tags members
+// @Produce json
+// @Param user_id path string true "회원 ID"
+// @Param limit query int false "조회 개수 (기본 20, 최대 50)"
+// @Success 200 {object} common.APIResponse{data=[]domain.PointHistory}
+// @Failure 401 {object} common.APIResponse
+// @Failure 403 {object} common.APIResponse
+// @Router /members/{user_id}/points/history [get]
+func (h *MemberProfileHandler) GetPointHistory(c *gin.Context) {
+	userID := c.Param("user_id")
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "회원 ID를 입력해 주세요", nil)
+		return
+	}
+
+	// 본인만 조회 가능
+	currentUserID := middleware.GetDamoangUserID(c)
+	if currentUserID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+	if currentUserID != userID {
+		common.ErrorResponse(c, http.StatusForbidden, "본인의 포인트 내역만 조회할 수 있습니다", nil)
+		return
+	}
+
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	history, err := h.service.GetPointHistory(userID, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "포인트 내역 조회 중 오류가 발생했습니다", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: history})
+}

--- a/internal/repository/point_repo.go
+++ b/internal/repository/point_repo.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// PointRepository point data access interface
+type PointRepository interface {
+	FindByMemberID(mbID string, limit int) ([]*domain.Point, error)
+}
+
+type pointRepository struct {
+	db *gorm.DB
+}
+
+// NewPointRepository creates a new PointRepository
+func NewPointRepository(db *gorm.DB) PointRepository {
+	return &pointRepository{db: db}
+}
+
+// FindByMemberID returns recent point history for a member
+func (r *pointRepository) FindByMemberID(mbID string, limit int) ([]*domain.Point, error) {
+	var points []*domain.Point
+	err := r.db.Where("mb_id = ?", mbID).
+		Order("po_id DESC").
+		Limit(limit).
+		Find(&points).Error
+	if err != nil {
+		return nil, err
+	}
+	return points, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -32,6 +32,7 @@ func Setup(
 	goodHandler *handler.GoodHandler,
 	recommendedHandler *handler.RecommendedHandler,
 	notificationHandler *handler.NotificationHandler,
+	memberProfileHandler *handler.MemberProfileHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -148,6 +149,10 @@ func Setup(
 	members.POST("/check-email", memberHandler.CheckEmail)       // 이메일 중복 확인
 	members.POST("/check-phone", memberHandler.CheckPhone)       // 휴대폰번호 중복 확인
 	members.GET("/:id/nickname", memberHandler.GetNickname)      // 회원 닉네임 조회
+	members.GET("/:id/profile", memberProfileHandler.GetProfile) // 회원 프로필 조회
+	members.GET("/:id/posts", memberProfileHandler.GetPosts)     // 회원 작성글 조회
+	members.GET("/:id/comments", memberProfileHandler.GetComments) // 회원 작성댓글 조회
+	members.GET("/:id/points/history", memberProfileHandler.GetPointHistory) // 포인트 내역 (본인만)
 
 	// Autosave (자동 저장 API - 로그인 필요)
 	autosave := api.Group("/autosave")

--- a/internal/service/member_profile_service.go
+++ b/internal/service/member_profile_service.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+	"gorm.io/gorm"
+)
+
+// MemberProfileService business logic for member profiles
+type MemberProfileService interface {
+	GetProfile(userID string) (*domain.MemberProfileResponse, error)
+	GetRecentPosts(userID string, limit int) ([]*domain.MemberPostSummary, error)
+	GetRecentComments(userID string, limit int) ([]*domain.MemberCommentSummary, error)
+	GetPointHistory(userID string, limit int) ([]*domain.PointHistory, error)
+}
+
+type memberProfileService struct {
+	memberRepo repository.MemberRepository
+	pointRepo  repository.PointRepository
+	db         *gorm.DB
+}
+
+// NewMemberProfileService creates a new MemberProfileService
+func NewMemberProfileService(memberRepo repository.MemberRepository, pointRepo repository.PointRepository, db *gorm.DB) MemberProfileService {
+	return &memberProfileService{
+		memberRepo: memberRepo,
+		pointRepo:  pointRepo,
+		db:         db,
+	}
+}
+
+// GetProfile returns a member's public profile
+func (s *memberProfileService) GetProfile(userID string) (*domain.MemberProfileResponse, error) {
+	member, err := s.memberRepo.FindByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
+	if member.LeaveDate != "" {
+		return nil, fmt.Errorf("탈퇴한 회원입니다")
+	}
+	return member.ToProfileResponse(), nil
+}
+
+// GetRecentPosts returns a member's recent posts across all boards
+func (s *memberProfileService) GetRecentPosts(userID string, limit int) ([]*domain.MemberPostSummary, error) {
+	if limit <= 0 || limit > 20 {
+		limit = 5
+	}
+
+	boardIDs, err := s.getAllBoardIDs()
+	if err != nil {
+		return nil, err
+	}
+	if len(boardIDs) == 0 {
+		return []*domain.MemberPostSummary{}, nil
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, bid := range boardIDs {
+		tableName := fmt.Sprintf("g5_write_%s", bid)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT wr_id, wr_subject, wr_datetime, wr_comment, wr_good, wr_hit, '%s' as bo_table FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 ORDER BY wr_id DESC LIMIT %d)",
+			bid, tableName, limit,
+		))
+		args = append(args, userID)
+	}
+
+	query := strings.Join(unions, " UNION ALL ") + fmt.Sprintf(" ORDER BY wr_datetime DESC LIMIT %d", limit)
+
+	type rawPost struct {
+		WrID       int    `gorm:"column:wr_id"`
+		WrSubject  string `gorm:"column:wr_subject"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+		WrComment  int    `gorm:"column:wr_comment"`
+		WrGood     int    `gorm:"column:wr_good"`
+		WrHit      int    `gorm:"column:wr_hit"`
+		BoTable    string `gorm:"column:bo_table"`
+	}
+
+	var results []rawPost
+	if err := s.db.Raw(query, args...).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	posts := make([]*domain.MemberPostSummary, len(results))
+	for i, r := range results {
+		posts[i] = &domain.MemberPostSummary{
+			ID:        r.WrID,
+			BoardID:   r.BoTable,
+			Title:     r.WrSubject,
+			CreatedAt: r.WrDatetime,
+			Comments:  r.WrComment,
+			Likes:     r.WrGood,
+			Views:     r.WrHit,
+		}
+	}
+	return posts, nil
+}
+
+// GetRecentComments returns a member's recent comments across all boards
+func (s *memberProfileService) GetRecentComments(userID string, limit int) ([]*domain.MemberCommentSummary, error) {
+	if limit <= 0 || limit > 20 {
+		limit = 5
+	}
+
+	boardIDs, err := s.getAllBoardIDs()
+	if err != nil {
+		return nil, err
+	}
+	if len(boardIDs) == 0 {
+		return []*domain.MemberCommentSummary{}, nil
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, bid := range boardIDs {
+		tableName := fmt.Sprintf("g5_write_%s", bid)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT wr_id, wr_content, wr_datetime, wr_parent, '%s' as bo_table FROM `%s` WHERE mb_id = ? AND wr_is_comment = 1 ORDER BY wr_id DESC LIMIT %d)",
+			bid, tableName, limit,
+		))
+		args = append(args, userID)
+	}
+
+	query := strings.Join(unions, " UNION ALL ") + fmt.Sprintf(" ORDER BY wr_datetime DESC LIMIT %d", limit)
+
+	type rawComment struct {
+		WrID       int    `gorm:"column:wr_id"`
+		WrContent  string `gorm:"column:wr_content"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+		WrParent   int    `gorm:"column:wr_parent"`
+		BoTable    string `gorm:"column:bo_table"`
+	}
+
+	var results []rawComment
+	if err := s.db.Raw(query, args...).Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	comments := make([]*domain.MemberCommentSummary, len(results))
+	for i, r := range results {
+		content := r.WrContent
+		if len(content) > 100 {
+			content = content[:100] + "..."
+		}
+		comments[i] = &domain.MemberCommentSummary{
+			ID:        r.WrID,
+			BoardID:   r.BoTable,
+			Content:   content,
+			CreatedAt: r.WrDatetime,
+			PostID:    r.WrParent,
+		}
+	}
+	return comments, nil
+}
+
+// GetPointHistory returns a member's point transaction history
+func (s *memberProfileService) GetPointHistory(userID string, limit int) ([]*domain.PointHistory, error) {
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+
+	points, err := s.pointRepo.FindByMemberID(userID, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	history := make([]*domain.PointHistory, len(points))
+	for i, p := range points {
+		relID, _ := strconv.Atoi(p.RelID)
+		history[i] = &domain.PointHistory{
+			ID:        p.ID,
+			Point:     p.Point,
+			Content:   p.Content,
+			CreatedAt: p.Datetime,
+			RelTable:  p.RelTable,
+			RelID:     relID,
+			RelAction: p.RelAction,
+		}
+	}
+	return history, nil
+}
+
+// getAllBoardIDs returns all board IDs from g5_board
+func (s *memberProfileService) getAllBoardIDs() ([]string, error) {
+	var boardIDs []string
+	err := s.db.Table("g5_board").Pluck("bo_table", &boardIDs).Error
+	if err != nil {
+		return nil, err
+	}
+	return boardIDs, nil
+}


### PR DESCRIPTION
## Summary
- 회원 프로필 조회 API (`GET /members/:id/profile`)
- 회원 작성글 조회 API (`GET /members/:id/posts`) - UNION ALL 크로스 보드 쿼리
- 회원 작성댓글 조회 API (`GET /members/:id/comments`)
- 포인트 내역 조회 API (`GET /members/:id/points/history`) - 본인만 조회 가능

## 변경 파일
- `internal/domain/member.go` - MemberProfileResponse, MemberPostSummary, MemberCommentSummary, PointHistory, Point DTO
- `internal/repository/point_repo.go` - g5_point 테이블 조회
- `internal/service/member_profile_service.go` - 프로필 비즈니스 로직
- `internal/handler/member_profile_handler.go` - 4개 엔드포인트 핸들러
- `internal/routes/routes.go` - /members 라우트 추가
- `cmd/api/main.go` - DI 추가

## Test plan
- [x] `go build ./...` 빌드 성공
- [x] `go test ./internal/...` 전체 테스트 통과