### PR TITLE
feat(auth): 회원가입 및 탈퇴 API 추가

### DIFF
--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -43,6 +43,7 @@ func Setup(
 	auth.POST("/login", authHandler.Login)
 	auth.POST("/refresh", authHandler.RefreshToken)
 	auth.POST("/logout", authHandler.Logout)
+	auth.POST("/register", authHandler.Register) // 회원가입
 
 	// Current user endpoint (uses damoang_jwt cookie)
 	auth.GET("/me", authHandler.GetCurrentUser)
@@ -144,6 +145,7 @@ func Setup(
 
 	// Members (회원 검증 API - 공개)
 	members := api.Group("/members")
+	members.DELETE("/me", authHandler.Withdraw)                    // 회원 탈퇴 (본인만)
 	members.POST("/check-id", memberHandler.CheckUserID)         // 회원 ID 중복 확인
 	members.POST("/check-nickname", memberHandler.CheckNickname) // 닉네임 중복 확인
 	members.POST("/check-email", memberHandler.CheckEmail)       // 이메일 중복 확인

--- a/pkg/auth/legacy.go
+++ b/pkg/auth/legacy.go
@@ -49,6 +49,16 @@ func verifyMySQLPassword(plain, hashed string) bool {
 	return generated == hashed
 }
 
+// HashPassword hashes a password using MySQL PASSWORD() format for Gnuboard compatibility
+// Format: *<SHA1(SHA1(password))>
+//
+//nolint:gosec // G401: Gnuboard 레거시 호환을 위해 SHA1 필요
+func HashPassword(plain string) string {
+	sha1Once := sha1.Sum([]byte(plain))
+	sha1Twice := sha1.Sum(sha1Once[:])
+	return "*" + strings.ToUpper(fmt.Sprintf("%x", sha1Twice))
+}
+
 // verifySHA1 verifies against simple SHA1 hash
 //
 //nolint:gosec // G401: Gnuboard 레거시 호환을 위해 SHA1 필요


### PR DESCRIPTION
## Summary
- `POST /auth/register` - 회원가입 (ID/이메일/닉네임 중복 체크, MySQL PASSWORD() 해싱)
- `DELETE /members/me` - 회원 탈퇴 (데이터 보존, mb_leave_date에 YYYYMMDD 기록)
- `pkg/auth.HashPassword()` - MySQL PASSWORD() 호환 해싱 함수

## Test plan
- [x] `go build ./...` 빌드 성공
- [x] `go test ./internal/...` 전체 테스트 통과