### PR TITLE
feat(file): 파일 업로드/다운로드 API 3종 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -165,6 +165,7 @@ func main() {
 	var goodHandler *handler.GoodHandler
 	var notificationHandler *handler.NotificationHandler
 	var memberProfileHandler *handler.MemberProfileHandler
+	var fileHandler *handler.FileHandler
 
 	if db != nil {
 		// Repositories
@@ -184,6 +185,7 @@ func main() {
 		goodRepo := repository.NewGoodRepository(db)
 		notificationRepo := repository.NewNotificationRepository(db)
 		pointRepo := repository.NewPointRepository(db)
+		fileRepo := repository.NewFileRepository(db)
 
 		// Services
 		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
@@ -202,6 +204,13 @@ func main() {
 		goodService := service.NewGoodService(goodRepo)
 		notificationService := service.NewNotificationService(notificationRepo)
 		memberProfileService := service.NewMemberProfileService(memberRepo, pointRepo, db)
+
+		// File upload path
+		uploadPath := cfg.DataPaths.UploadPath
+		if uploadPath == "" {
+			uploadPath = "/home/damoang/www/data/file"
+		}
+		fileService := service.NewFileService(fileRepo, uploadPath)
 
 		// Handlers
 		authHandler = handler.NewAuthHandler(authService, cfg)
@@ -223,6 +232,7 @@ func main() {
 		goodHandler = handler.NewGoodHandler(goodService)
 		notificationHandler = handler.NewNotificationHandler(notificationService)
 		memberProfileHandler = handler.NewMemberProfileHandler(memberProfileService)
+		fileHandler = handler.NewFileHandler(fileService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -268,7 +278,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type CommercePluginConfig struct {
 // DataPathsConfig 데이터 경로 설정
 type DataPathsConfig struct {
 	RecommendedPath string `yaml:"recommended_path"`
+	UploadPath      string `yaml:"upload_path"`
 }
 
 // ServerConfig 서버 설정
@@ -139,6 +140,10 @@ func overrideFromEnv(cfg *Config) {
 	// 데이터 경로 설정
 	if recommendedPath := os.Getenv("RECOMMENDED_DATA_PATH"); recommendedPath != "" {
 		cfg.DataPaths.RecommendedPath = recommendedPath
+	}
+
+	if uploadPath := os.Getenv("UPLOAD_PATH"); uploadPath != "" {
+		cfg.DataPaths.UploadPath = uploadPath
 	}
 
 	// CORS 설정

--- a/internal/domain/file.go
+++ b/internal/domain/file.go
@@ -1,0 +1,39 @@
+package domain
+
+import "time"
+
+// BoardFile represents an attached file (g5_board_file table)
+type BoardFile struct {
+	DateTime time.Time `gorm:"column:bf_datetime" json:"datetime"`
+	BoardID  string    `gorm:"column:bo_table;primaryKey;size:20" json:"board_id"`
+	Source   string    `gorm:"column:bf_source;size:255" json:"source"`
+	File     string    `gorm:"column:bf_file;size:255" json:"file"`
+	Content  string    `gorm:"column:bf_content;type:text" json:"content"`
+	WriteID  int       `gorm:"column:wr_id;primaryKey" json:"write_id"`
+	FileNo   int       `gorm:"column:bf_no;primaryKey" json:"file_no"`
+	Download int       `gorm:"column:bf_download;default:0" json:"download"`
+	FileSize int       `gorm:"column:bf_filesize" json:"file_size"`
+	Width    int       `gorm:"column:bf_width;default:0" json:"width"`
+	Height   int       `gorm:"column:bf_height;default:0" json:"height"`
+	Type     int       `gorm:"column:bf_type;default:0" json:"type"`
+}
+
+func (BoardFile) TableName() string {
+	return "g5_board_file"
+}
+
+// FileUploadResponse represents the response after a file upload
+type FileUploadResponse struct {
+	URL      string `json:"url"`
+	FileName string `json:"file_name"`
+	FileSize int64  `json:"file_size"`
+	Width    int    `json:"width,omitempty"`
+	Height   int    `json:"height,omitempty"`
+}
+
+// FileDownloadInfo contains information needed for file download
+type FileDownloadInfo struct {
+	FilePath    string
+	Source      string
+	ContentType string
+}

--- a/internal/handler/file_handler.go
+++ b/internal/handler/file_handler.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// FileHandler handles file upload/download HTTP requests
+type FileHandler struct {
+	service service.FileService
+}
+
+// NewFileHandler creates a new FileHandler
+func NewFileHandler(service service.FileService) *FileHandler {
+	return &FileHandler{service: service}
+}
+
+// UploadEditorImage handles POST /api/v2/upload/editor
+// @Summary 에디터 이미지 업로드
+// @Description 게시글 에디터에 삽입할 이미지를 업로드합니다
+// @Tags upload
+// @Accept multipart/form-data
+// @Produce json
+// @Param file formance file true "이미지 파일"
+// @Param board_id formData string true "게시판 ID"
+// @Param wr_id formData int false "게시글 ID (기본 0)"
+// @Success 200 {object} common.APIResponse{data=domain.FileUploadResponse}
+// @Failure 400 {object} common.APIResponse
+// @Failure 401 {object} common.APIResponse
+// @Router /upload/editor [post]
+func (h *FileHandler) UploadEditorImage(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "파일을 선택해 주세요", err)
+		return
+	}
+
+	boardID := c.PostForm("board_id")
+	if boardID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "게시판 ID가 필요합니다", nil)
+		return
+	}
+
+	wrID := 0
+	if id := c.PostForm("wr_id"); id != "" {
+		wrID, _ = strconv.Atoi(id)
+	}
+
+	result, err := h.service.UploadEditorImage(file, boardID, wrID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: result})
+}
+
+// UploadAttachment handles POST /api/v2/upload/attachment
+// @Summary 첨부파일 업로드
+// @Description 게시글에 첨부할 파일을 업로드합니다
+// @Tags upload
+// @Accept multipart/form-data
+// @Produce json
+// @Param file formance file true "첨부 파일"
+// @Param board_id formData string true "게시판 ID"
+// @Param wr_id formData int false "게시글 ID (기본 0)"
+// @Success 200 {object} common.APIResponse{data=domain.FileUploadResponse}
+// @Failure 400 {object} common.APIResponse
+// @Failure 401 {object} common.APIResponse
+// @Router /upload/attachment [post]
+func (h *FileHandler) UploadAttachment(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "파일을 선택해 주세요", err)
+		return
+	}
+
+	boardID := c.PostForm("board_id")
+	if boardID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "게시판 ID가 필요합니다", nil)
+		return
+	}
+
+	wrID := 0
+	if id := c.PostForm("wr_id"); id != "" {
+		wrID, _ = strconv.Atoi(id)
+	}
+
+	result, err := h.service.UploadAttachment(file, boardID, wrID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: result})
+}
+
+// DownloadFile handles GET /api/v2/files/:board_id/:wr_id/:file_no/download
+// @Summary 파일 다운로드
+// @Description 첨부파일을 다운로드합니다
+// @Tags files
+// @Produce octet-stream
+// @Param board_id path string true "게시판 ID"
+// @Param wr_id path int true "게시글 ID"
+// @Param file_no path int true "파일 번호"
+// @Success 200 {file} binary
+// @Failure 404 {object} common.APIResponse
+// @Router /files/{board_id}/{wr_id}/{file_no}/download [get]
+func (h *FileHandler) DownloadFile(c *gin.Context) {
+	boardID := c.Param("board_id")
+	wrID, err := strconv.Atoi(c.Param("wr_id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID입니다", err)
+		return
+	}
+	fileNo, err := strconv.Atoi(c.Param("file_no"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 파일 번호입니다", err)
+		return
+	}
+
+	info, err := h.service.GetFileForDownload(boardID, wrID, fileNo)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "파일을 찾을 수 없습니다", err)
+		return
+	}
+
+	c.Header("Content-Disposition", "attachment; filename=\""+info.Source+"\"")
+	c.Header("Content-Type", info.ContentType)
+	c.File(info.FilePath)
+}

--- a/internal/repository/file_repo.go
+++ b/internal/repository/file_repo.go
@@ -1,0 +1,62 @@
+package repository
+
+import (
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// FileRepository file data access interface
+type FileRepository interface {
+	FindByID(boardID string, wrID int, fileNo int) (*domain.BoardFile, error)
+	Create(file *domain.BoardFile) error
+	IncrementDownload(boardID string, wrID int, fileNo int) error
+	GetNextFileNo(boardID string, wrID int) (int, error)
+}
+
+type fileRepository struct {
+	db *gorm.DB
+}
+
+// NewFileRepository creates a new FileRepository
+func NewFileRepository(db *gorm.DB) FileRepository {
+	return &fileRepository{db: db}
+}
+
+// FindByID finds a file by composite key
+func (r *fileRepository) FindByID(boardID string, wrID int, fileNo int) (*domain.BoardFile, error) {
+	var file domain.BoardFile
+	err := r.db.Where("bo_table = ? AND wr_id = ? AND bf_no = ?", boardID, wrID, fileNo).
+		First(&file).Error
+	if err != nil {
+		return nil, err
+	}
+	return &file, nil
+}
+
+// Create creates a new file record
+func (r *fileRepository) Create(file *domain.BoardFile) error {
+	return r.db.Create(file).Error
+}
+
+// IncrementDownload increments the download count
+func (r *fileRepository) IncrementDownload(boardID string, wrID int, fileNo int) error {
+	return r.db.Model(&domain.BoardFile{}).
+		Where("bo_table = ? AND wr_id = ? AND bf_no = ?", boardID, wrID, fileNo).
+		UpdateColumn("bf_download", gorm.Expr("bf_download + 1")).Error
+}
+
+// GetNextFileNo returns the next available file number for a post
+func (r *fileRepository) GetNextFileNo(boardID string, wrID int) (int, error) {
+	var maxNo *int
+	err := r.db.Model(&domain.BoardFile{}).
+		Where("bo_table = ? AND wr_id = ?", boardID, wrID).
+		Select("MAX(bf_no)").
+		Scan(&maxNo).Error
+	if err != nil {
+		return 0, err
+	}
+	if maxNo == nil {
+		return 0, nil
+	}
+	return *maxNo + 1, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -33,6 +33,7 @@ func Setup(
 	recommendedHandler *handler.RecommendedHandler,
 	notificationHandler *handler.NotificationHandler,
 	memberProfileHandler *handler.MemberProfileHandler,
+	fileHandler *handler.FileHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -201,6 +202,15 @@ func Setup(
 	notifications.POST("/:id/read", notificationHandler.MarkAsRead)
 	notifications.POST("/read-all", notificationHandler.MarkAllAsRead)
 	notifications.DELETE("/:id", notificationHandler.Delete)
+
+	// Upload (파일 업로드 API - 로그인 필요)
+	upload := api.Group("/upload")
+	upload.POST("/editor", fileHandler.UploadEditorImage)       // 에디터 이미지 업로드
+	upload.POST("/attachment", fileHandler.UploadAttachment)     // 첨부파일 업로드
+
+	// Files (파일 다운로드 API - 공개)
+	files := api.Group("/files")
+	files.GET("/:board_id/:wr_id/:file_no/download", fileHandler.DownloadFile) // 파일 다운로드
 
 	// ============================================
 	// Plugin Routes (/api/plugins/*)

--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// FileService business logic for file uploads/downloads
+type FileService interface {
+	UploadEditorImage(file *multipart.FileHeader, boardID string, wrID int) (*domain.FileUploadResponse, error)
+	UploadAttachment(file *multipart.FileHeader, boardID string, wrID int) (*domain.FileUploadResponse, error)
+	GetFileForDownload(boardID string, wrID int, fileNo int) (*domain.FileDownloadInfo, error)
+}
+
+type fileService struct {
+	repo       repository.FileRepository
+	uploadPath string
+}
+
+// NewFileService creates a new FileService
+func NewFileService(repo repository.FileRepository, uploadPath string) FileService {
+	return &fileService{
+		repo:       repo,
+		uploadPath: uploadPath,
+	}
+}
+
+// UploadEditorImage handles editor image uploads
+func (s *fileService) UploadEditorImage(file *multipart.FileHeader, boardID string, wrID int) (*domain.FileUploadResponse, error) {
+	// 이미지 파일 검증
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	allowedExts := map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true, ".bmp": true}
+	if !allowedExts[ext] {
+		return nil, fmt.Errorf("허용되지 않는 이미지 형식입니다: %s", ext)
+	}
+
+	// 파일 크기 제한 (10MB)
+	if file.Size > 10*1024*1024 {
+		return nil, fmt.Errorf("파일 크기가 10MB를 초과합니다")
+	}
+
+	return s.saveFile(file, boardID, wrID, true)
+}
+
+// UploadAttachment handles attachment file uploads
+func (s *fileService) UploadAttachment(file *multipart.FileHeader, boardID string, wrID int) (*domain.FileUploadResponse, error) {
+	// 파일 크기 제한 (50MB)
+	if file.Size > 50*1024*1024 {
+		return nil, fmt.Errorf("파일 크기가 50MB를 초과합니다")
+	}
+
+	// 위험한 확장자 차단
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	blockedExts := map[string]bool{".exe": true, ".bat": true, ".cmd": true, ".sh": true, ".php": true, ".jsp": true, ".asp": true}
+	if blockedExts[ext] {
+		return nil, fmt.Errorf("허용되지 않는 파일 형식입니다: %s", ext)
+	}
+
+	return s.saveFile(file, boardID, wrID, false)
+}
+
+// GetFileForDownload retrieves file info for download
+func (s *fileService) GetFileForDownload(boardID string, wrID int, fileNo int) (*domain.FileDownloadInfo, error) {
+	bf, err := s.repo.FindByID(boardID, wrID, fileNo)
+	if err != nil {
+		return nil, fmt.Errorf("파일을 찾을 수 없습니다")
+	}
+
+	// 다운로드 카운트 증가
+	go s.repo.IncrementDownload(boardID, wrID, fileNo) //nolint:errcheck // 비동기
+
+	filePath := filepath.Join(s.uploadPath, boardID, bf.File)
+	contentType := detectContentType(filepath.Ext(bf.Source))
+
+	return &domain.FileDownloadInfo{
+		FilePath:    filePath,
+		Source:      bf.Source,
+		ContentType: contentType,
+	}, nil
+}
+
+// saveFile saves an uploaded file to disk and creates DB record
+func (s *fileService) saveFile(file *multipart.FileHeader, boardID string, wrID int, isImage bool) (*domain.FileUploadResponse, error) {
+	// 다음 파일 번호
+	fileNo, err := s.repo.GetNextFileNo(boardID, wrID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 저장 디렉토리 생성
+	yearMonth := time.Now().Format("200601")
+	dirPath := filepath.Join(s.uploadPath, boardID, yearMonth)
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		return nil, fmt.Errorf("디렉토리 생성 실패: %w", err)
+	}
+
+	// 고유 파일명 생성
+	ext := filepath.Ext(file.Filename)
+	savedName := fmt.Sprintf("%d_%d_%d%s", time.Now().Unix(), wrID, fileNo, ext)
+	savePath := filepath.Join(dirPath, savedName)
+
+	// 파일 저장
+	src, err := file.Open()
+	if err != nil {
+		return nil, fmt.Errorf("파일 열기 실패: %w", err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(savePath)
+	if err != nil {
+		return nil, fmt.Errorf("파일 생성 실패: %w", err)
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return nil, fmt.Errorf("파일 저장 실패: %w", err)
+	}
+
+	// DB 저장
+	fileType := 0
+	if isImage {
+		fileType = 1
+	}
+
+	relativeFile := filepath.Join(yearMonth, savedName)
+	bf := &domain.BoardFile{
+		BoardID:  boardID,
+		WriteID:  wrID,
+		FileNo:   fileNo,
+		Source:   file.Filename,
+		File:     relativeFile,
+		FileSize: int(file.Size),
+		Type:     fileType,
+		DateTime: time.Now(),
+	}
+
+	if err := s.repo.Create(bf); err != nil {
+		// DB 실패 시 파일 삭제
+		os.Remove(savePath)
+		return nil, err
+	}
+
+	// URL 생성
+	url := fmt.Sprintf("/data/file/%s/%s", boardID, relativeFile)
+
+	return &domain.FileUploadResponse{
+		URL:      url,
+		FileName: file.Filename,
+		FileSize: file.Size,
+	}, nil
+}
+
+// detectContentType returns content type from file extension
+func detectContentType(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".pdf":
+		return "application/pdf"
+	case ".zip":
+		return "application/zip"
+	case ".txt":
+		return "text/plain"
+	default:
+		return "application/octet-stream"
+	}
+}


### PR DESCRIPTION
## Summary
- `POST /upload/editor` - 에디터 이미지 업로드 (jpg/png/gif/webp, 10MB 제한)
- `POST /upload/attachment` - 첨부파일 업로드 (위험 확장자 차단, 50MB 제한)
- `GET /files/:board_id/:wr_id/:file_no/download` - 파일 다운로드 (다운로드 카운트 자동 증가)
- g5_board_file 테이블 GORM 모델 추가
- DataPaths 설정에 UploadPath 추가 (UPLOAD_PATH 환경변수 지원)

## Test plan
- [x] `go build ./...` 빌드 성공
- [x] `go test ./internal/...` 전체 테스트 통과