### PR TITLE
feat: Phase 2 스크랩/차단/쪽지 API (11개)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -166,6 +166,9 @@ func main() {
 	var notificationHandler *handler.NotificationHandler
 	var memberProfileHandler *handler.MemberProfileHandler
 	var fileHandler *handler.FileHandler
+	var scrapHandler *handler.ScrapHandler
+	var blockHandler *handler.BlockHandler
+	var messageHandler *handler.MessageHandler
 
 	if db != nil {
 		// Repositories
@@ -186,6 +189,9 @@ func main() {
 		notificationRepo := repository.NewNotificationRepository(db)
 		pointRepo := repository.NewPointRepository(db)
 		fileRepo := repository.NewFileRepository(db)
+		scrapRepo := repository.NewScrapRepository(db)
+		blockRepo := repository.NewBlockRepository(db)
+		messageRepo := repository.NewMessageRepository(db)
 
 		// Services
 		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
@@ -204,6 +210,10 @@ func main() {
 		goodService := service.NewGoodService(goodRepo)
 		notificationService := service.NewNotificationService(notificationRepo)
 		memberProfileService := service.NewMemberProfileService(memberRepo, pointRepo, db)
+
+		scrapService := service.NewScrapService(scrapRepo)
+		blockService := service.NewBlockService(blockRepo, memberRepo)
+		messageService := service.NewMessageService(messageRepo, memberRepo, blockRepo)
 
 		// File upload path
 		uploadPath := cfg.DataPaths.UploadPath
@@ -233,6 +243,9 @@ func main() {
 		notificationHandler = handler.NewNotificationHandler(notificationService)
 		memberProfileHandler = handler.NewMemberProfileHandler(memberProfileService)
 		fileHandler = handler.NewFileHandler(fileService)
+		scrapHandler = handler.NewScrapHandler(scrapService)
+		blockHandler = handler.NewBlockHandler(blockService)
+		messageHandler = handler.NewMessageHandler(messageService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -278,7 +291,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/domain/block.go
+++ b/internal/domain/block.go
@@ -1,0 +1,23 @@
+package domain
+
+import "time"
+
+// MemberBlock represents a member block record
+type MemberBlock struct {
+	CreatedAt    time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	MbID         string    `gorm:"column:mb_id;index" json:"mb_id"`
+	BlockedMbID  string    `gorm:"column:blocked_mb_id;index" json:"blocked_mb_id"`
+	ID           int       `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+}
+
+func (MemberBlock) TableName() string {
+	return "g5_member_block"
+}
+
+// BlockResponse represents a block item in API responses
+type BlockResponse struct {
+	UserID    string `json:"user_id"`
+	Nickname  string `json:"nickname"`
+	BlockedAt string `json:"blocked_at"`
+	BlockID   int    `json:"block_id"`
+}

--- a/internal/domain/message.go
+++ b/internal/domain/message.go
@@ -1,0 +1,52 @@
+package domain
+
+import "time"
+
+// Message represents a private message (g5_memo table)
+type Message struct {
+	SendDatetime time.Time  `gorm:"column:me_send_datetime" json:"send_datetime"`
+	ReadDatetime *time.Time `gorm:"column:me_read_datetime" json:"read_datetime,omitempty"`
+	RecvMbID     string     `gorm:"column:me_recv_mb_id;index" json:"recv_mb_id"`
+	SendMbID     string     `gorm:"column:me_send_mb_id;index" json:"send_mb_id"`
+	Memo         string     `gorm:"column:me_memo;type:text" json:"memo"`
+	SendIP       string     `gorm:"column:me_send_ip" json:"-"`
+	Type         string     `gorm:"column:me_type" json:"type"` // "recv" or "send"
+	ID           int        `gorm:"column:me_id;primaryKey;autoIncrement" json:"id"`
+}
+
+func (Message) TableName() string {
+	return "g5_memo"
+}
+
+// SendMessageRequest represents a send message request
+type SendMessageRequest struct {
+	ToUserID string `json:"to_user_id" binding:"required"`
+	Content  string `json:"content" binding:"required"`
+}
+
+// MessageResponse represents a message in API responses
+type MessageResponse struct {
+	SendDatetime string `json:"send_datetime"`
+	ReadDatetime string `json:"read_datetime,omitempty"`
+	FromUserID   string `json:"from_user_id"`
+	ToUserID     string `json:"to_user_id"`
+	Content      string `json:"content"`
+	ID           int    `json:"id"`
+	IsRead       bool   `json:"is_read"`
+}
+
+// ToResponse converts Message to MessageResponse
+func (m *Message) ToResponse() *MessageResponse {
+	resp := &MessageResponse{
+		ID:           m.ID,
+		FromUserID:   m.SendMbID,
+		ToUserID:     m.RecvMbID,
+		Content:      m.Memo,
+		SendDatetime: m.SendDatetime.Format("2006-01-02 15:04:05"),
+		IsRead:       m.ReadDatetime != nil,
+	}
+	if m.ReadDatetime != nil {
+		resp.ReadDatetime = m.ReadDatetime.Format("2006-01-02 15:04:05")
+	}
+	return resp
+}

--- a/internal/domain/scrap.go
+++ b/internal/domain/scrap.go
@@ -1,0 +1,26 @@
+package domain
+
+import "time"
+
+// Scrap represents a bookmarked post (g5_scrap table)
+type Scrap struct {
+	DateTime time.Time `gorm:"column:ms_datetime" json:"datetime"`
+	MbID     string    `gorm:"column:mb_id;index" json:"mb_id"`
+	BoTable  string    `gorm:"column:bo_table" json:"bo_table"`
+	WrID     int       `gorm:"column:wr_id" json:"wr_id"`
+	ID       int       `gorm:"column:ms_id;primaryKey;autoIncrement" json:"id"`
+}
+
+func (Scrap) TableName() string {
+	return "g5_scrap"
+}
+
+// ScrapResponse represents a scrap item in API responses
+type ScrapResponse struct {
+	CreatedAt string `json:"created_at"`
+	BoardID   string `json:"board_id"`
+	Title     string `json:"title"`
+	Author    string `json:"author"`
+	ScrapID   int    `json:"scrap_id"`
+	PostID    int    `json:"post_id"`
+}

--- a/internal/handler/block_handler.go
+++ b/internal/handler/block_handler.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// BlockHandler handles member block HTTP requests
+type BlockHandler struct {
+	service service.BlockService
+}
+
+// NewBlockHandler creates a new BlockHandler
+func NewBlockHandler(service service.BlockService) *BlockHandler {
+	return &BlockHandler{service: service}
+}
+
+// BlockMember handles POST /members/:user_id/block
+// @Summary 회원 차단
+// @Tags block
+// @Produce json
+// @Param user_id path string true "차단할 회원 ID"
+// @Success 200 {object} common.APIResponse{data=domain.BlockResponse}
+// @Router /members/{user_id}/block [post]
+func (h *BlockHandler) BlockMember(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	targetID := c.Param("user_id")
+	if targetID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "대상 회원 ID가 필요합니다", nil)
+		return
+	}
+
+	result, err := h.service.BlockMember(userID, targetID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: result})
+}
+
+// UnblockMember handles DELETE /members/:user_id/block
+// @Summary 차단 해제
+// @Tags block
+// @Produce json
+// @Param user_id path string true "차단 해제할 회원 ID"
+// @Success 204
+// @Router /members/{user_id}/block [delete]
+func (h *BlockHandler) UnblockMember(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	targetID := c.Param("user_id")
+	if err := h.service.UnblockMember(userID, targetID); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// ListBlocks handles GET /members/me/blocks
+// @Summary 차단 목록
+// @Tags block
+// @Produce json
+// @Success 200 {object} common.APIResponse{data=[]domain.BlockResponse}
+// @Router /members/me/blocks [get]
+func (h *BlockHandler) ListBlocks(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	blocks, err := h.service.ListBlocks(userID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "차단 목록 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: blocks})
+}

--- a/internal/handler/message_handler.go
+++ b/internal/handler/message_handler.go
@@ -1,0 +1,175 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// MessageHandler handles private message HTTP requests
+type MessageHandler struct {
+	service service.MessageService
+}
+
+// NewMessageHandler creates a new MessageHandler
+func NewMessageHandler(service service.MessageService) *MessageHandler {
+	return &MessageHandler{service: service}
+}
+
+// SendMessage handles POST /messages
+// @Summary 쪽지 보내기
+// @Tags messages
+// @Accept json
+// @Produce json
+// @Param request body domain.SendMessageRequest true "쪽지 내용"
+// @Success 200 {object} common.APIResponse{data=domain.MessageResponse}
+// @Router /messages [post]
+func (h *MessageHandler) SendMessage(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	var req domain.SendMessageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	result, err := h.service.SendMessage(userID, &req, c.ClientIP())
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: result})
+}
+
+// GetInbox handles GET /messages/inbox
+// @Summary 받은 쪽지함
+// @Tags messages
+// @Produce json
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.MessageResponse}
+// @Router /messages/inbox [get]
+func (h *MessageHandler) GetInbox(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	messages, meta, err := h.service.GetInbox(userID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "받은 쪽지함 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: messages, Meta: meta})
+}
+
+// GetSent handles GET /messages/sent
+// @Summary 보낸 쪽지함
+// @Tags messages
+// @Produce json
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.MessageResponse}
+// @Router /messages/sent [get]
+func (h *MessageHandler) GetSent(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	messages, meta, err := h.service.GetSent(userID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "보낸 쪽지함 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: messages, Meta: meta})
+}
+
+// GetMessage handles GET /messages/:id
+// @Summary 쪽지 상세
+// @Tags messages
+// @Produce json
+// @Param id path int true "쪽지 ID"
+// @Success 200 {object} common.APIResponse{data=domain.MessageResponse}
+// @Router /messages/{id} [get]
+func (h *MessageHandler) GetMessage(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 쪽지 ID입니다", err)
+		return
+	}
+
+	msg, err := h.service.GetMessage(id, userID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: msg})
+}
+
+// DeleteMessage handles DELETE /messages/:id
+// @Summary 쪽지 삭제
+// @Tags messages
+// @Produce json
+// @Param id path int true "쪽지 ID"
+// @Success 204
+// @Router /messages/{id} [delete]
+func (h *MessageHandler) DeleteMessage(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 쪽지 ID입니다", err)
+		return
+	}
+
+	if err := h.service.DeleteMessage(id, userID); err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "쪽지를 찾을 수 없습니다", err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handler/scrap_handler.go
+++ b/internal/handler/scrap_handler.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// ScrapHandler handles scrap HTTP requests
+type ScrapHandler struct {
+	service service.ScrapService
+}
+
+// NewScrapHandler creates a new ScrapHandler
+func NewScrapHandler(service service.ScrapService) *ScrapHandler {
+	return &ScrapHandler{service: service}
+}
+
+// AddScrap handles POST /boards/:board_id/posts/:id/scrap
+// @Summary 게시글 스크랩
+// @Tags scrap
+// @Produce json
+// @Param board_id path string true "게시판 ID"
+// @Param id path int true "게시글 ID"
+// @Success 200 {object} common.APIResponse{data=domain.ScrapResponse}
+// @Router /boards/{board_id}/posts/{id}/scrap [post]
+func (h *ScrapHandler) AddScrap(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	boardID := c.Param("board_id")
+	wrID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID입니다", err)
+		return
+	}
+
+	result, err := h.service.AddScrap(userID, boardID, wrID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: result})
+}
+
+// RemoveScrap handles DELETE /boards/:board_id/posts/:id/scrap
+// @Summary 스크랩 취소
+// @Tags scrap
+// @Produce json
+// @Param board_id path string true "게시판 ID"
+// @Param id path int true "게시글 ID"
+// @Success 204
+// @Router /boards/{board_id}/posts/{id}/scrap [delete]
+func (h *ScrapHandler) RemoveScrap(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	boardID := c.Param("board_id")
+	wrID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID입니다", err)
+		return
+	}
+
+	if err := h.service.RemoveScrap(userID, boardID, wrID); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// ListScraps handles GET /members/me/scraps
+// @Summary 내 스크랩 목록
+// @Tags scrap
+// @Produce json
+// @Param page query int false "페이지 (기본 1)"
+// @Param limit query int false "페이지 크기 (기본 20)"
+// @Success 200 {object} common.APIResponse{data=[]domain.ScrapResponse}
+// @Router /members/me/scraps [get]
+func (h *ScrapHandler) ListScraps(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	scraps, meta, err := h.service.ListScraps(userID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "스크랩 목록 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: scraps, Meta: meta})
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -9,7 +9,7 @@ import (
 // Run executes AutoMigrate for the menus table and seeds default data if empty.
 func Run(db *gorm.DB) error {
 	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
-	if err := db.AutoMigrate(&domain.Menu{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &domain.MemberBlock{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
 		return err
 	}
 

--- a/internal/repository/block_repo.go
+++ b/internal/repository/block_repo.go
@@ -1,0 +1,78 @@
+package repository
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// BlockRepository block data access interface
+type BlockRepository interface {
+	Create(mbID string, blockedMbID string) (*domain.MemberBlock, error)
+	Delete(mbID string, blockedMbID string) error
+	FindByMember(mbID string) ([]*domain.MemberBlock, error)
+	Exists(mbID string, blockedMbID string) (bool, error)
+	GetBlockedUserIDs(mbID string) ([]string, error)
+}
+
+type blockRepository struct {
+	db *gorm.DB
+}
+
+// NewBlockRepository creates a new BlockRepository
+func NewBlockRepository(db *gorm.DB) BlockRepository {
+	return &blockRepository{db: db}
+}
+
+// Create adds a block
+func (r *blockRepository) Create(mbID string, blockedMbID string) (*domain.MemberBlock, error) {
+	block := &domain.MemberBlock{
+		MbID:        mbID,
+		BlockedMbID: blockedMbID,
+		CreatedAt:   time.Now(),
+	}
+	if err := r.db.Create(block).Error; err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+// Delete removes a block
+func (r *blockRepository) Delete(mbID string, blockedMbID string) error {
+	result := r.db.Where("mb_id = ? AND blocked_mb_id = ?", mbID, blockedMbID).
+		Delete(&domain.MemberBlock{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("차단 기록을 찾을 수 없습니다")
+	}
+	return nil
+}
+
+// FindByMember returns all blocks for a member
+func (r *blockRepository) FindByMember(mbID string) ([]*domain.MemberBlock, error) {
+	var blocks []*domain.MemberBlock
+	err := r.db.Where("mb_id = ?", mbID).Order("id DESC").Find(&blocks).Error
+	return blocks, err
+}
+
+// Exists checks if a block exists
+func (r *blockRepository) Exists(mbID string, blockedMbID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&domain.MemberBlock{}).
+		Where("mb_id = ? AND blocked_mb_id = ?", mbID, blockedMbID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+// GetBlockedUserIDs returns all blocked user IDs for a member
+func (r *blockRepository) GetBlockedUserIDs(mbID string) ([]string, error) {
+	var ids []string
+	err := r.db.Model(&domain.MemberBlock{}).
+		Where("mb_id = ?", mbID).
+		Pluck("blocked_mb_id", &ids).Error
+	return ids, err
+}

--- a/internal/repository/message_repo.go
+++ b/internal/repository/message_repo.go
@@ -1,0 +1,127 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// MessageRepository message data access interface
+type MessageRepository interface {
+	Create(msg *domain.Message) error
+	FindByID(id int) (*domain.Message, error)
+	FindInbox(mbID string, page, limit int) ([]*domain.Message, int64, error)
+	FindSent(mbID string, page, limit int) ([]*domain.Message, int64, error)
+	MarkAsRead(id int) error
+	Delete(id int, mbID string) error
+}
+
+type messageRepository struct {
+	db *gorm.DB
+}
+
+// NewMessageRepository creates a new MessageRepository
+func NewMessageRepository(db *gorm.DB) MessageRepository {
+	return &messageRepository{db: db}
+}
+
+// Create creates a new message (both recv and send records)
+func (r *messageRepository) Create(msg *domain.Message) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// 수신자 레코드
+		recvMsg := &domain.Message{
+			RecvMbID:     msg.RecvMbID,
+			SendMbID:     msg.SendMbID,
+			Memo:         msg.Memo,
+			SendDatetime: msg.SendDatetime,
+			SendIP:       msg.SendIP,
+			Type:         "recv",
+		}
+		if err := tx.Create(recvMsg).Error; err != nil {
+			return err
+		}
+
+		// 발신자 레코드
+		sendMsg := &domain.Message{
+			RecvMbID:     msg.RecvMbID,
+			SendMbID:     msg.SendMbID,
+			Memo:         msg.Memo,
+			SendDatetime: msg.SendDatetime,
+			SendIP:       msg.SendIP,
+			Type:         "send",
+		}
+		if err := tx.Create(sendMsg).Error; err != nil {
+			return err
+		}
+
+		// 수신자 mb_memo_cnt 증가
+		return tx.Table("g5_member").Where("mb_id = ?", msg.RecvMbID).
+			UpdateColumn("mb_memo_cnt", gorm.Expr("mb_memo_cnt + 1")).Error
+	})
+}
+
+// FindByID finds a message by ID
+func (r *messageRepository) FindByID(id int) (*domain.Message, error) {
+	var msg domain.Message
+	err := r.db.Where("me_id = ?", id).First(&msg).Error
+	if err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// FindInbox returns received messages for a member
+func (r *messageRepository) FindInbox(mbID string, page, limit int) ([]*domain.Message, int64, error) {
+	var messages []*domain.Message
+	var total int64
+
+	r.db.Model(&domain.Message{}).
+		Where("me_recv_mb_id = ? AND me_type = ?", mbID, "recv").
+		Count(&total)
+
+	offset := (page - 1) * limit
+	err := r.db.Where("me_recv_mb_id = ? AND me_type = ?", mbID, "recv").
+		Order("me_id DESC").
+		Offset(offset).Limit(limit).
+		Find(&messages).Error
+	return messages, total, err
+}
+
+// FindSent returns sent messages for a member
+func (r *messageRepository) FindSent(mbID string, page, limit int) ([]*domain.Message, int64, error) {
+	var messages []*domain.Message
+	var total int64
+
+	r.db.Model(&domain.Message{}).
+		Where("me_send_mb_id = ? AND me_type = ?", mbID, "send").
+		Count(&total)
+
+	offset := (page - 1) * limit
+	err := r.db.Where("me_send_mb_id = ? AND me_type = ?", mbID, "send").
+		Order("me_id DESC").
+		Offset(offset).Limit(limit).
+		Find(&messages).Error
+	return messages, total, err
+}
+
+// MarkAsRead marks a message as read
+func (r *messageRepository) MarkAsRead(id int) error {
+	now := time.Now()
+	return r.db.Model(&domain.Message{}).
+		Where("me_id = ? AND me_read_datetime IS NULL", id).
+		Update("me_read_datetime", now).Error
+}
+
+// Delete deletes a message
+func (r *messageRepository) Delete(id int, mbID string) error {
+	result := r.db.Where("me_id = ? AND (me_recv_mb_id = ? OR me_send_mb_id = ?)", id, mbID, mbID).
+		Delete(&domain.Message{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}

--- a/internal/repository/scrap_repo.go
+++ b/internal/repository/scrap_repo.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// ScrapRepository scrap data access interface
+type ScrapRepository interface {
+	Create(mbID string, boTable string, wrID int) (*domain.Scrap, error)
+	Delete(mbID string, boTable string, wrID int) error
+	FindByMember(mbID string, page, limit int) ([]*domain.Scrap, int64, error)
+	Exists(mbID string, boTable string, wrID int) (bool, error)
+	GetPostTitle(boTable string, wrID int) (string, string, error) // title, author
+}
+
+type scrapRepository struct {
+	db *gorm.DB
+}
+
+// NewScrapRepository creates a new ScrapRepository
+func NewScrapRepository(db *gorm.DB) ScrapRepository {
+	return &scrapRepository{db: db}
+}
+
+// Create adds a scrap
+func (r *scrapRepository) Create(mbID string, boTable string, wrID int) (*domain.Scrap, error) {
+	scrap := &domain.Scrap{
+		MbID:     mbID,
+		BoTable:  boTable,
+		WrID:     wrID,
+		DateTime: time.Now(),
+	}
+	if err := r.db.Create(scrap).Error; err != nil {
+		return nil, err
+	}
+
+	// mb_scrap_cnt 증가
+	r.db.Table("g5_member").Where("mb_id = ?", mbID).
+		UpdateColumn("mb_scrap_cnt", gorm.Expr("mb_scrap_cnt + 1"))
+
+	return scrap, nil
+}
+
+// Delete removes a scrap
+func (r *scrapRepository) Delete(mbID string, boTable string, wrID int) error {
+	result := r.db.Where("mb_id = ? AND bo_table = ? AND wr_id = ?", mbID, boTable, wrID).
+		Delete(&domain.Scrap{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("스크랩을 찾을 수 없습니다")
+	}
+
+	// mb_scrap_cnt 감소
+	r.db.Table("g5_member").Where("mb_id = ?", mbID).
+		UpdateColumn("mb_scrap_cnt", gorm.Expr("GREATEST(mb_scrap_cnt - 1, 0)"))
+
+	return nil
+}
+
+// FindByMember returns scraps for a member with pagination
+func (r *scrapRepository) FindByMember(mbID string, page, limit int) ([]*domain.Scrap, int64, error) {
+	var scraps []*domain.Scrap
+	var total int64
+
+	r.db.Model(&domain.Scrap{}).Where("mb_id = ?", mbID).Count(&total)
+
+	offset := (page - 1) * limit
+	err := r.db.Where("mb_id = ?", mbID).
+		Order("ms_id DESC").
+		Offset(offset).Limit(limit).
+		Find(&scraps).Error
+	return scraps, total, err
+}
+
+// Exists checks if a scrap already exists
+func (r *scrapRepository) Exists(mbID string, boTable string, wrID int) (bool, error) {
+	var count int64
+	err := r.db.Model(&domain.Scrap{}).
+		Where("mb_id = ? AND bo_table = ? AND wr_id = ?", mbID, boTable, wrID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+// GetPostTitle returns the title and author from a write table
+func (r *scrapRepository) GetPostTitle(boTable string, wrID int) (string, string, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boTable)
+	var result struct {
+		Title  string `gorm:"column:wr_subject"`
+		Author string `gorm:"column:wr_name"`
+	}
+	err := r.db.Table(tableName).Select("wr_subject, wr_name").
+		Where("wr_id = ?", wrID).Scan(&result).Error
+	if err != nil {
+		return "", "", err
+	}
+	return result.Title, result.Author, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -34,6 +34,9 @@ func Setup(
 	notificationHandler *handler.NotificationHandler,
 	memberProfileHandler *handler.MemberProfileHandler,
 	fileHandler *handler.FileHandler,
+	scrapHandler *handler.ScrapHandler,
+	blockHandler *handler.BlockHandler,
+	messageHandler *handler.MessageHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -91,6 +94,10 @@ func Setup(
 		boardPosts.DELETE("/:id/recommend", goodHandler.CancelRecommendPost)
 		boardPosts.POST("/:id/downvote", goodHandler.DownvotePost)
 		boardPosts.DELETE("/:id/downvote", goodHandler.CancelDownvotePost)
+
+		// 스크랩
+		boardPosts.POST("/:id/scrap", scrapHandler.AddScrap)
+		boardPosts.DELETE("/:id/scrap", scrapHandler.RemoveScrap)
 
 		// 댓글 관련 (파라미터 이름 통일: post_id -> id)
 		comments := boardPosts.Group("/:id/comments")
@@ -156,6 +163,18 @@ func Setup(
 	members.GET("/:id/posts", memberProfileHandler.GetPosts)     // 회원 작성글 조회
 	members.GET("/:id/comments", memberProfileHandler.GetComments) // 회원 작성댓글 조회
 	members.GET("/:id/points/history", memberProfileHandler.GetPointHistory) // 포인트 내역 (본인만)
+	members.POST("/:id/block", blockHandler.BlockMember)                    // 회원 차단
+	members.DELETE("/:id/block", blockHandler.UnblockMember)                // 차단 해제
+	members.GET("/me/blocks", blockHandler.ListBlocks)                      // 차단 목록
+	members.GET("/me/scraps", scrapHandler.ListScraps)                      // 내 스크랩 목록
+
+	// Messages (쪽지 API - 로그인 필요)
+	messages := api.Group("/messages")
+	messages.POST("", messageHandler.SendMessage)        // 쪽지 보내기
+	messages.GET("/inbox", messageHandler.GetInbox)      // 받은 쪽지함
+	messages.GET("/sent", messageHandler.GetSent)        // 보낸 쪽지함
+	messages.GET("/:id", messageHandler.GetMessage)      // 쪽지 상세
+	messages.DELETE("/:id", messageHandler.DeleteMessage) // 쪽지 삭제
 
 	// Autosave (자동 저장 API - 로그인 필요)
 	autosave := api.Group("/autosave")

--- a/internal/service/block_service.go
+++ b/internal/service/block_service.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// BlockService business logic for member blocking
+type BlockService interface {
+	BlockMember(mbID string, targetMbID string) (*domain.BlockResponse, error)
+	UnblockMember(mbID string, targetMbID string) error
+	ListBlocks(mbID string) ([]*domain.BlockResponse, error)
+	GetBlockedUserIDs(mbID string) ([]string, error)
+}
+
+type blockService struct {
+	blockRepo  repository.BlockRepository
+	memberRepo repository.MemberRepository
+}
+
+// NewBlockService creates a new BlockService
+func NewBlockService(blockRepo repository.BlockRepository, memberRepo repository.MemberRepository) BlockService {
+	return &blockService{
+		blockRepo:  blockRepo,
+		memberRepo: memberRepo,
+	}
+}
+
+// BlockMember blocks a member
+func (s *blockService) BlockMember(mbID string, targetMbID string) (*domain.BlockResponse, error) {
+	if mbID == targetMbID {
+		return nil, fmt.Errorf("자기 자신을 차단할 수 없습니다")
+	}
+
+	// 대상 회원 존재 확인
+	target, err := s.memberRepo.FindByUserID(targetMbID)
+	if err != nil {
+		return nil, fmt.Errorf("회원을 찾을 수 없습니다")
+	}
+
+	exists, err := s.blockRepo.Exists(mbID, targetMbID)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, fmt.Errorf("이미 차단한 회원입니다")
+	}
+
+	block, err := s.blockRepo.Create(mbID, targetMbID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.BlockResponse{
+		BlockID:   block.ID,
+		UserID:    targetMbID,
+		Nickname:  target.Nickname,
+		BlockedAt: block.CreatedAt.Format("2006-01-02 15:04:05"),
+	}, nil
+}
+
+// UnblockMember unblocks a member
+func (s *blockService) UnblockMember(mbID string, targetMbID string) error {
+	return s.blockRepo.Delete(mbID, targetMbID)
+}
+
+// ListBlocks returns all blocked members
+func (s *blockService) ListBlocks(mbID string) ([]*domain.BlockResponse, error) {
+	blocks, err := s.blockRepo.FindByMember(mbID)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]*domain.BlockResponse, len(blocks))
+	for i, b := range blocks {
+		nickname := ""
+		if member, err := s.memberRepo.FindByUserID(b.BlockedMbID); err == nil {
+			nickname = member.Nickname
+		}
+		responses[i] = &domain.BlockResponse{
+			BlockID:   b.ID,
+			UserID:    b.BlockedMbID,
+			Nickname:  nickname,
+			BlockedAt: b.CreatedAt.Format("2006-01-02 15:04:05"),
+		}
+	}
+
+	return responses, nil
+}
+
+// GetBlockedUserIDs returns all blocked user IDs
+func (s *blockService) GetBlockedUserIDs(mbID string) ([]string, error) {
+	return s.blockRepo.GetBlockedUserIDs(mbID)
+}

--- a/internal/service/message_service.go
+++ b/internal/service/message_service.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// MessageService business logic for private messages
+type MessageService interface {
+	SendMessage(senderID string, req *domain.SendMessageRequest, senderIP string) (*domain.MessageResponse, error)
+	GetInbox(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error)
+	GetSent(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error)
+	GetMessage(id int, mbID string) (*domain.MessageResponse, error)
+	DeleteMessage(id int, mbID string) error
+}
+
+type messageService struct {
+	repo       repository.MessageRepository
+	memberRepo repository.MemberRepository
+	blockRepo  repository.BlockRepository
+}
+
+// NewMessageService creates a new MessageService
+func NewMessageService(repo repository.MessageRepository, memberRepo repository.MemberRepository, blockRepo repository.BlockRepository) MessageService {
+	return &messageService{
+		repo:       repo,
+		memberRepo: memberRepo,
+		blockRepo:  blockRepo,
+	}
+}
+
+// SendMessage sends a private message
+func (s *messageService) SendMessage(senderID string, req *domain.SendMessageRequest, senderIP string) (*domain.MessageResponse, error) {
+	if senderID == req.ToUserID {
+		return nil, fmt.Errorf("자기 자신에게 쪽지를 보낼 수 없습니다")
+	}
+
+	// 수신자 존재 확인
+	_, err := s.memberRepo.FindByUserID(req.ToUserID)
+	if err != nil {
+		return nil, fmt.Errorf("수신자를 찾을 수 없습니다")
+	}
+
+	// 차단 여부 확인 (수신자가 발신자를 차단한 경우)
+	blocked, err := s.blockRepo.Exists(req.ToUserID, senderID)
+	if err != nil {
+		return nil, err
+	}
+	if blocked {
+		return nil, fmt.Errorf("쪽지를 보낼 수 없는 회원입니다")
+	}
+
+	msg := &domain.Message{
+		RecvMbID:     req.ToUserID,
+		SendMbID:     senderID,
+		Memo:         req.Content,
+		SendDatetime: time.Now(),
+		SendIP:       senderIP,
+	}
+
+	if err := s.repo.Create(msg); err != nil {
+		return nil, err
+	}
+
+	return msg.ToResponse(), nil
+}
+
+// GetInbox returns received messages
+func (s *messageService) GetInbox(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	messages, total, err := s.repo.FindInbox(mbID, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]*domain.MessageResponse, len(messages))
+	for i, m := range messages {
+		responses[i] = m.ToResponse()
+	}
+
+	meta := &common.Meta{
+		Page:  page,
+		Limit: limit,
+		Total: total,
+	}
+
+	return responses, meta, nil
+}
+
+// GetSent returns sent messages
+func (s *messageService) GetSent(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	messages, total, err := s.repo.FindSent(mbID, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]*domain.MessageResponse, len(messages))
+	for i, m := range messages {
+		responses[i] = m.ToResponse()
+	}
+
+	meta := &common.Meta{
+		Page:  page,
+		Limit: limit,
+		Total: total,
+	}
+
+	return responses, meta, nil
+}
+
+// GetMessage returns a single message and marks as read
+func (s *messageService) GetMessage(id int, mbID string) (*domain.MessageResponse, error) {
+	msg, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("쪽지를 찾을 수 없습니다")
+	}
+
+	// 본인의 쪽지인지 확인
+	if msg.RecvMbID != mbID && msg.SendMbID != mbID {
+		return nil, fmt.Errorf("권한이 없습니다")
+	}
+
+	// 수신 쪽지이고 읽지 않은 경우 읽음 처리
+	if msg.RecvMbID == mbID && msg.ReadDatetime == nil {
+		s.repo.MarkAsRead(id) //nolint:errcheck
+		now := time.Now()
+		msg.ReadDatetime = &now
+	}
+
+	return msg.ToResponse(), nil
+}
+
+// DeleteMessage deletes a message
+func (s *messageService) DeleteMessage(id int, mbID string) error {
+	return s.repo.Delete(id, mbID)
+}

--- a/internal/service/scrap_service.go
+++ b/internal/service/scrap_service.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// ScrapService business logic for scraps
+type ScrapService interface {
+	AddScrap(mbID string, boardID string, wrID int) (*domain.ScrapResponse, error)
+	RemoveScrap(mbID string, boardID string, wrID int) error
+	ListScraps(mbID string, page, limit int) ([]*domain.ScrapResponse, *common.Meta, error)
+}
+
+type scrapService struct {
+	repo repository.ScrapRepository
+}
+
+// NewScrapService creates a new ScrapService
+func NewScrapService(repo repository.ScrapRepository) ScrapService {
+	return &scrapService{repo: repo}
+}
+
+// AddScrap adds a post to scraps
+func (s *scrapService) AddScrap(mbID string, boardID string, wrID int) (*domain.ScrapResponse, error) {
+	exists, err := s.repo.Exists(mbID, boardID, wrID)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, fmt.Errorf("이미 스크랩한 게시글입니다")
+	}
+
+	scrap, err := s.repo.Create(mbID, boardID, wrID)
+	if err != nil {
+		return nil, err
+	}
+
+	title, author, _ := s.repo.GetPostTitle(boardID, wrID)
+
+	return &domain.ScrapResponse{
+		ScrapID:   scrap.ID,
+		BoardID:   boardID,
+		PostID:    wrID,
+		Title:     title,
+		Author:    author,
+		CreatedAt: scrap.DateTime.Format("2006-01-02 15:04:05"),
+	}, nil
+}
+
+// RemoveScrap removes a post from scraps
+func (s *scrapService) RemoveScrap(mbID string, boardID string, wrID int) error {
+	return s.repo.Delete(mbID, boardID, wrID)
+}
+
+// ListScraps returns the member's scrap list
+func (s *scrapService) ListScraps(mbID string, page, limit int) ([]*domain.ScrapResponse, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	scraps, total, err := s.repo.FindByMember(mbID, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]*domain.ScrapResponse, len(scraps))
+	for i, sc := range scraps {
+		title, author, _ := s.repo.GetPostTitle(sc.BoTable, sc.WrID)
+		responses[i] = &domain.ScrapResponse{
+			ScrapID:   sc.ID,
+			BoardID:   sc.BoTable,
+			PostID:    sc.WrID,
+			Title:     title,
+			Author:    author,
+			CreatedAt: sc.DateTime.Format("2006-01-02 15:04:05"),
+		}
+	}
+
+	meta := &common.Meta{
+		Page:  page,
+		Limit: limit,
+		Total: total,
+	}
+
+	return responses, meta, nil
+}


### PR DESCRIPTION
## Summary
- 스크랩 API 3개: 스크랩 추가/삭제, 내 스크랩 목록
- 차단 API 3개: 회원 차단/해제, 차단 목록
- 쪽지 API 5개: 보내기, 받은함/보낸함, 상세, 삭제
- g5_member_block 테이블 AutoMigrate 추가
- 메모 API 4개는 이미 구현 완료 → Phase 2 전체 15개 API 완성

## New Files
- `internal/domain/{scrap,block,message}.go`
- `internal/repository/{scrap,block,message}_repo.go`
- `internal/service/{scrap,block,message}_service.go`
- `internal/handler/{scrap,block,message}_handler.go`

## Modified Files
- `cmd/api/main.go` — DI 추가
- `internal/routes/routes.go` — 라우트 등록
- `internal/migration/migrate.go` — MemberBlock AutoMigrate