### PR TITLE
feat: Phase 3 WebSocket 실시간 알림

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=

--- a/internal/handler/ws_handler.go
+++ b/internal/handler/ws_handler.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/ws"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		// TODO: 운영 환경에서는 origin 검증 필요
+		return true
+	},
+}
+
+// WSHandler handles WebSocket connections
+type WSHandler struct {
+	hub *ws.Hub
+}
+
+// NewWSHandler creates a new WSHandler
+func NewWSHandler(hub *ws.Hub) *WSHandler {
+	return &WSHandler{hub: hub}
+}
+
+// Connect handles GET /ws/notifications — WebSocket upgrade
+// @Summary 실시간 알림 WebSocket
+// @Tags notifications
+// @Router /ws/notifications [get]
+func (h *WSHandler) Connect(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "로그인이 필요합니다"})
+		return
+	}
+
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+
+	client := ws.NewClient(h.hub, conn, userID)
+	h.hub.Register(client)
+
+	go client.WritePump()
+	go client.ReadPump()
+}

--- a/internal/repository/notification_repo.go
+++ b/internal/repository/notification_repo.go
@@ -75,6 +75,11 @@ func (r *NotificationRepository) MarkAllAsRead(memberID string) error {
 		Update("nt_is_read", 1).Error
 }
 
+// Create inserts a new notification
+func (r *NotificationRepository) Create(notification *domain.Notification) error {
+	return r.db.Create(notification).Error
+}
+
 // Delete deletes a notification by ID
 func (r *NotificationRepository) Delete(id int) error {
 	return r.db.Where("nt_id = ?", id).Delete(&domain.Notification{}).Error

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -37,6 +37,7 @@ func Setup(
 	scrapHandler *handler.ScrapHandler,
 	blockHandler *handler.BlockHandler,
 	messageHandler *handler.MessageHandler,
+	wsHandler *handler.WSHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -221,6 +222,10 @@ func Setup(
 	notifications.POST("/:id/read", notificationHandler.MarkAsRead)
 	notifications.POST("/read-all", notificationHandler.MarkAllAsRead)
 	notifications.DELETE("/:id", notificationHandler.Delete)
+
+	// WebSocket (실시간 알림 스트림 - 로그인 필요)
+	wsGroup := router.Group("/ws", middleware.DamoangCookieAuth(damoangJWT, cfg))
+	wsGroup.GET("/notifications", wsHandler.Connect)
 
 	// Upload (파일 업로드 API - 로그인 필요)
 	upload := api.Group("/upload")

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -1,0 +1,90 @@
+package ws
+
+import (
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	writeWait      = 10 * time.Second
+	pongWait       = 60 * time.Second
+	pingPeriod     = (pongWait * 9) / 10
+	maxMessageSize = 512
+)
+
+// Client represents a single WebSocket connection
+type Client struct {
+	hub      *Hub
+	conn     *websocket.Conn
+	send     chan []byte
+	memberID string
+}
+
+// NewClient creates a new WebSocket client
+func NewClient(hub *Hub, conn *websocket.Conn, memberID string) *Client {
+	return &Client{
+		hub:      hub,
+		conn:     conn,
+		send:     make(chan []byte, 256),
+		memberID: memberID,
+	}
+}
+
+// ReadPump reads messages from the WebSocket (handles pong/close)
+func (c *Client) ReadPump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait)) //nolint:errcheck
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait)) //nolint:errcheck
+		return nil
+	})
+
+	for {
+		_, _, err := c.conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		// Client messages are ignored (server-push only)
+	}
+}
+
+// WritePump sends messages to the WebSocket
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait)) //nolint:errcheck
+			if !ok {
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{}) //nolint:errcheck
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			w.Write(message) //nolint:errcheck
+			if err := w.Close(); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait)) //nolint:errcheck
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -1,0 +1,160 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisPubSubChannel = "notifications"
+
+// Event represents a real-time notification event sent via WebSocket
+type Event struct {
+	Type    string      `json:"type"`    // "notification", "unread_count"
+	Payload interface{} `json:"payload"` // event-specific data
+}
+
+// Hub manages WebSocket clients and broadcasts messages
+type Hub struct {
+	// Registered clients grouped by member ID
+	clients map[string]map[*Client]bool
+
+	// Register/unregister channels
+	register   chan *Client
+	unregister chan *Client
+
+	// Broadcast to a specific member
+	broadcast chan *targetedEvent
+
+	mu          sync.RWMutex
+	redisClient *redis.Client
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+type targetedEvent struct {
+	MemberID string
+	Event    *Event
+}
+
+// NewHub creates a new Hub
+func NewHub(redisClient *redis.Client) *Hub {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Hub{
+		clients:     make(map[string]map[*Client]bool),
+		register:    make(chan *Client),
+		unregister:  make(chan *Client),
+		broadcast:   make(chan *targetedEvent, 256),
+		redisClient: redisClient,
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+// Register adds a client to the hub
+func (h *Hub) Register(client *Client) {
+	h.register <- client
+}
+
+// Run starts the hub's main loop
+func (h *Hub) Run() {
+	// Start Redis subscriber if Redis is available
+	if h.redisClient != nil {
+		go h.subscribeRedis()
+	}
+
+	for {
+		select {
+		case client := <-h.register:
+			h.mu.Lock()
+			if h.clients[client.memberID] == nil {
+				h.clients[client.memberID] = make(map[*Client]bool)
+			}
+			h.clients[client.memberID][client] = true
+			h.mu.Unlock()
+
+		case client := <-h.unregister:
+			h.mu.Lock()
+			if clients, ok := h.clients[client.memberID]; ok {
+				if _, ok := clients[client]; ok {
+					delete(clients, client)
+					close(client.send)
+					if len(clients) == 0 {
+						delete(h.clients, client.memberID)
+					}
+				}
+			}
+			h.mu.Unlock()
+
+		case msg := <-h.broadcast:
+			h.mu.RLock()
+			if clients, ok := h.clients[msg.MemberID]; ok {
+				data, err := json.Marshal(msg.Event)
+				if err == nil {
+					for client := range clients {
+						select {
+						case client.send <- data:
+						default:
+							close(client.send)
+							delete(clients, client)
+						}
+					}
+				}
+			}
+			h.mu.RUnlock()
+
+		case <-h.ctx.Done():
+			return
+		}
+	}
+}
+
+// SendToMember sends an event to a specific member (local + Redis publish)
+func (h *Hub) SendToMember(memberID string, event *Event) {
+	// Local broadcast
+	h.broadcast <- &targetedEvent{MemberID: memberID, Event: event}
+
+	// Publish to Redis for multi-instance support
+	if h.redisClient != nil {
+		msg := &redisMessage{MemberID: memberID, Event: event}
+		data, err := json.Marshal(msg)
+		if err == nil {
+			h.redisClient.Publish(h.ctx, redisPubSubChannel, data) //nolint:errcheck
+		}
+	}
+}
+
+type redisMessage struct {
+	MemberID string `json:"member_id"`
+	Event    *Event `json:"event"`
+}
+
+// subscribeRedis listens for notifications from other instances
+func (h *Hub) subscribeRedis() {
+	pubsub := h.redisClient.Subscribe(h.ctx, redisPubSubChannel)
+	defer pubsub.Close()
+
+	ch := pubsub.Channel()
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var rm redisMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &rm); err == nil {
+				// Only local broadcast (don't re-publish to Redis)
+				h.broadcast <- &targetedEvent{MemberID: rm.MemberID, Event: rm.Event}
+			}
+		case <-h.ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop gracefully shuts down the hub
+func (h *Hub) Stop() {
+	h.cancel()
+}


### PR DESCRIPTION
## Summary
- WebSocket 서버 구현 (gorilla/websocket)
- Redis Pub/Sub 기반 멀티 인스턴스 알림 전파
- `GET /ws/notifications` WebSocket 엔드포인트
- `NotificationService.CreateAndBroadcast()` — DB 저장 + WebSocket 푸시
- 기존 알림 REST API 5개 (목록, 미읽음 카운트, 읽음, 전체읽음, 삭제) 이미 완료

## New Files
- `internal/ws/hub.go` — Hub (클라이언트 관리, Redis Pub/Sub)
- `internal/ws/client.go` — Client (ping/pong, read/write pump)
- `internal/handler/ws_handler.go` — WebSocket upgrade 핸들러

## Modified Files
- `internal/service/notification_service.go` — CreateAndBroadcast 추가, Hub 연동
- `internal/repository/notification_repo.go` — Create 메서드 추가
- `cmd/api/main.go` — Hub 생성, DI 연결
- `internal/routes/routes.go` — /ws/notifications 라우트
- `go.mod`, `go.sum` — gorilla/websocket 추가