### PR TITLE
feat: Phase 4 신고/이용제한 API (7개)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -175,6 +175,7 @@ func main() {
 	var blockHandler *handler.BlockHandler
 	var messageHandler *handler.MessageHandler
 	var wsHandler *handler.WSHandler
+	var disciplineHandler *handler.DisciplineHandler
 
 	if db != nil {
 		// Repositories
@@ -198,6 +199,7 @@ func main() {
 		scrapRepo := repository.NewScrapRepository(db)
 		blockRepo := repository.NewBlockRepository(db)
 		messageRepo := repository.NewMessageRepository(db)
+		disciplineRepo := repository.NewDisciplineRepository(db)
 
 		// Services
 		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
@@ -220,6 +222,7 @@ func main() {
 		scrapService := service.NewScrapService(scrapRepo)
 		blockService := service.NewBlockService(blockRepo, memberRepo)
 		messageService := service.NewMessageService(messageRepo, memberRepo, blockRepo)
+		disciplineService := service.NewDisciplineService(disciplineRepo)
 
 		// File upload path
 		uploadPath := cfg.DataPaths.UploadPath
@@ -253,6 +256,7 @@ func main() {
 		blockHandler = handler.NewBlockHandler(blockService)
 		messageHandler = handler.NewMessageHandler(messageService)
 		wsHandler = handler.NewWSHandler(wsHub)
+		disciplineHandler = handler.NewDisciplineHandler(disciplineService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -298,7 +302,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/domain/discipline.go
+++ b/internal/domain/discipline.go
@@ -61,6 +61,22 @@ type DisciplineLogContent struct {
 	ProcessedBy    string   `json:"processed_by"`
 }
 
+// DisciplineResponse represents a discipline log entry for API response
+type DisciplineResponse struct {
+	ID          int                     `json:"id"`
+	Subject     string                  `json:"subject"`
+	Status      string                  `json:"status"`  // wr_4
+	ProcessType string                  `json:"process_type"` // wr_7
+	Content     *DisciplineLogContent   `json:"content,omitempty"`
+	CreatedAt   string                  `json:"created_at"`
+	CommentCount int                    `json:"comment_count"`
+}
+
+// AppealRequest represents a request to submit an appeal
+type AppealRequest struct {
+	Content string `json:"content" binding:"required"`
+}
+
 // G5Memo represents a message (쪽지) in g5_memo table
 type G5Memo struct {
 	ID           int       `gorm:"column:me_id;primaryKey;autoIncrement" json:"id"`

--- a/internal/domain/report.go
+++ b/internal/domain/report.go
@@ -63,6 +63,14 @@ type ReportListResponse struct {
 	CreatedAt  string `json:"created_at"`
 }
 
+// SubmitReportRequest represents a user submitting a report
+type SubmitReportRequest struct {
+	TargetID string `json:"target_id" binding:"required"` // 신고 대상 회원 ID
+	Table    string `json:"table" binding:"required"`     // 게시판 테이블명 (예: free, qa)
+	PostID   int    `json:"post_id" binding:"required"`   // 게시글 ID
+	Reason   string `json:"reason" binding:"required"`    // 신고 사유
+}
+
 // ReportActionRequest represents request for report action
 type ReportActionRequest struct {
 	Action  string   `json:"action"` // submitOpinion, cancelOpinion, adminApprove, adminDismiss

--- a/internal/handler/discipline_handler.go
+++ b/internal/handler/discipline_handler.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// DisciplineHandler handles discipline/ban HTTP requests
+type DisciplineHandler struct {
+	service service.DisciplineService
+}
+
+// NewDisciplineHandler creates a new DisciplineHandler
+func NewDisciplineHandler(service service.DisciplineService) *DisciplineHandler {
+	return &DisciplineHandler{service: service}
+}
+
+// MyDisciplines handles GET /members/me/disciplines
+// @Summary 내 이용제한 내역
+// @Tags discipline
+// @Produce json
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.DisciplineResponse}
+// @Router /members/me/disciplines [get]
+func (h *DisciplineHandler) MyDisciplines(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	disciplines, meta, err := h.service.GetMyDisciplines(userID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "이용제한 내역 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: disciplines, Meta: meta})
+}
+
+// GetDiscipline handles GET /disciplines/:id
+// @Summary 이용제한 상세 열람
+// @Tags discipline
+// @Produce json
+// @Param id path int true "이용제한 ID"
+// @Success 200 {object} common.APIResponse{data=domain.DisciplineResponse}
+// @Router /disciplines/{id} [get]
+func (h *DisciplineHandler) GetDiscipline(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 ID입니다", err)
+		return
+	}
+
+	discipline, err := h.service.GetDiscipline(id, userID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: discipline})
+}
+
+// SubmitAppeal handles POST /disciplines/:id/appeal
+// @Summary 소명 글 작성
+// @Tags discipline
+// @Accept json
+// @Produce json
+// @Param id path int true "이용제한 ID"
+// @Param request body domain.AppealRequest true "소명 내용"
+// @Success 200 {object} common.APIResponse
+// @Router /disciplines/{id}/appeal [post]
+func (h *DisciplineHandler) SubmitAppeal(c *gin.Context) {
+	userID := middleware.GetDamoangUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 ID입니다", err)
+		return
+	}
+
+	var req domain.AppealRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	nickname := middleware.GetDamoangUserName(c)
+	appealID, err := h.service.SubmitAppeal(id, userID, nickname, req.Content, c.ClientIP())
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{
+		Data: gin.H{"appeal_id": appealID, "message": "소명이 접수되었습니다"},
+	})
+}
+
+// ListBoard handles GET /disciplines/board
+// @Summary 이용제한 게시판
+// @Tags discipline
+// @Produce json
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.DisciplineResponse}
+// @Router /disciplines/board [get]
+func (h *DisciplineHandler) ListBoard(c *gin.Context) {
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	disciplines, meta, err := h.service.ListBoard(page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "이용제한 게시판 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: disciplines, Meta: meta})
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -38,6 +38,7 @@ func Setup(
 	blockHandler *handler.BlockHandler,
 	messageHandler *handler.MessageHandler,
 	wsHandler *handler.WSHandler,
+	disciplineHandler *handler.DisciplineHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -205,12 +206,22 @@ func Setup(
 	reactions.GET("", reactionHandler.GetReactions) // 반응 목록
 	reactions.POST("", reactionHandler.React)       // 반응 추가/제거
 
-	// Reports (신고 API - 관리자 전용)
+	// Reports (신고 API)
 	reports := api.Group("/reports")
-	reports.GET("", reportHandler.ListReports)             // 신고 목록
-	reports.GET("/data", reportHandler.GetReportData)      // 신고 데이터 조회
-	reports.GET("/recent", reportHandler.GetRecentReports) // 최근 신고 목록
-	reports.POST("/process", reportHandler.ProcessReport)  // 신고 처리
+	reports.POST("", reportHandler.SubmitReport)           // 신고 접수 (일반 사용자)
+	reports.GET("/mine", reportHandler.MyReports)          // 내 신고 내역
+	reports.GET("", reportHandler.ListReports)             // 신고 목록 (관리자)
+	reports.GET("/data", reportHandler.GetReportData)      // 신고 데이터 조회 (관리자)
+	reports.GET("/recent", reportHandler.GetRecentReports) // 최근 신고 목록 (관리자)
+	reports.GET("/stats", reportHandler.GetStats)          // 신고 통계 (관리자)
+	reports.POST("/process", reportHandler.ProcessReport)  // 신고 처리 (관리자)
+
+	// Disciplines (이용제한 API)
+	disciplines := api.Group("/disciplines")
+	disciplines.GET("/board", disciplineHandler.ListBoard)       // 이용제한 게시판
+	disciplines.GET("/:id", disciplineHandler.GetDiscipline)     // 이용제한 상세 열람
+	disciplines.POST("/:id/appeal", disciplineHandler.SubmitAppeal) // 소명 글 작성
+	members.GET("/me/disciplines", disciplineHandler.MyDisciplines) // 내 이용제한 내역
 
 	// Dajoongi (다중이 탐지 API - 관리자 전용)
 	api.GET("/dajoongi", dajoongiHandler.GetDuplicateAccounts)

--- a/internal/service/discipline_service.go
+++ b/internal/service/discipline_service.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// DisciplineService business logic for discipline/ban management
+type DisciplineService interface {
+	GetMyDisciplines(memberID string, page, limit int) ([]*domain.DisciplineResponse, *common.Meta, error)
+	GetDiscipline(id int, memberID string) (*domain.DisciplineResponse, error)
+	SubmitAppeal(disciplineID int, memberID, memberName, content, ip string) (int, error)
+	ListBoard(page, limit int) ([]*domain.DisciplineResponse, *common.Meta, error)
+}
+
+type disciplineService struct {
+	repo *repository.DisciplineRepository
+}
+
+// NewDisciplineService creates a new DisciplineService
+func NewDisciplineService(repo *repository.DisciplineRepository) DisciplineService {
+	return &disciplineService{repo: repo}
+}
+
+// GetMyDisciplines returns discipline logs for the given member
+func (s *disciplineService) GetMyDisciplines(memberID string, page, limit int) ([]*domain.DisciplineResponse, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	logs, total, err := s.repo.FindByTargetMember(memberID, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]*domain.DisciplineResponse, len(logs))
+	for i, log := range logs {
+		responses[i] = toDisciplineResponse(&log)
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+	return responses, meta, nil
+}
+
+// GetDiscipline returns a single discipline log (only if it belongs to the member)
+func (s *disciplineService) GetDiscipline(id int, memberID string) (*domain.DisciplineResponse, error) {
+	log, err := s.repo.GetByID(id)
+	if err != nil {
+		return nil, fmt.Errorf("이용제한 내역을 찾을 수 없습니다")
+	}
+
+	// Parse content to verify target_id matches
+	var content domain.DisciplineLogContent
+	if err := json.Unmarshal([]byte(log.Content), &content); err == nil {
+		if content.TargetID != memberID {
+			return nil, fmt.Errorf("권한이 없습니다")
+		}
+	}
+
+	return toDisciplineResponse(log), nil
+}
+
+// SubmitAppeal creates an appeal comment under a discipline log
+func (s *disciplineService) SubmitAppeal(disciplineID int, memberID, memberName, content, ip string) (int, error) {
+	// Verify the discipline log belongs to this member
+	log, err := s.repo.GetByID(disciplineID)
+	if err != nil {
+		return 0, fmt.Errorf("이용제한 내역을 찾을 수 없습니다")
+	}
+
+	var logContent domain.DisciplineLogContent
+	if err := json.Unmarshal([]byte(log.Content), &logContent); err == nil {
+		if logContent.TargetID != memberID {
+			return 0, fmt.Errorf("권한이 없습니다")
+		}
+	}
+
+	return s.repo.CreateAppeal(disciplineID, memberID, memberName, content, ip)
+}
+
+// ListBoard returns all discipline logs (이용제한 게시판)
+func (s *disciplineService) ListBoard(page, limit int) ([]*domain.DisciplineResponse, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	logs, total, err := s.repo.ListAll(page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]*domain.DisciplineResponse, len(logs))
+	for i, log := range logs {
+		responses[i] = toDisciplineResponse(&log)
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+	return responses, meta, nil
+}
+
+func toDisciplineResponse(log *domain.DisciplineLog) *domain.DisciplineResponse {
+	resp := &domain.DisciplineResponse{
+		ID:           log.ID,
+		Subject:      log.Subject,
+		Status:       log.Wr4,
+		ProcessType:  log.Wr7,
+		CreatedAt:    log.DateTime.Format("2006-01-02 15:04:05"),
+		CommentCount: log.Comment,
+	}
+
+	var content domain.DisciplineLogContent
+	if err := json.Unmarshal([]byte(log.Content), &content); err == nil {
+		resp.Content = &content
+	}
+
+	return resp
+}

--- a/internal/service/report_service.go
+++ b/internal/service/report_service.go
@@ -170,6 +170,34 @@ func (s *ReportService) Create(reporterID, targetID, table string, parent int, r
 	return report, nil
 }
 
+// GetMyReports returns reports submitted by the given user
+func (s *ReportService) GetMyReports(userID string, limit int) ([]domain.ReportListResponse, error) {
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	reports, err := s.repo.GetByReporter(userID, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	responses := make([]domain.ReportListResponse, len(reports))
+	for i, report := range reports {
+		responses[i] = domain.ReportListResponse{
+			ID:         report.ID,
+			Table:      report.Table,
+			Parent:     report.Parent,
+			ReporterID: report.ReporterID,
+			TargetID:   report.TargetID,
+			Reason:     report.Reason,
+			Status:     report.Status(),
+			CreatedAt:  report.CreatedAt.Format("2006-01-02 15:04:05"),
+		}
+	}
+
+	return responses, nil
+}
+
 // GetStats retrieves report statistics
 func (s *ReportService) GetStats() (map[string]int64, error) {
 	stats := make(map[string]int64)


### PR DESCRIPTION
## Summary
- 신고 접수 (POST /reports) — 일반 사용자 신고 기능
- 내 신고 내역 (GET /reports/mine)
- 신고 통계 (GET /reports/stats) — 기존 핸들러에 라우트 추가
- 이용제한 내역 (GET /members/me/disciplines)
- 이용제한 상세 열람 (GET /disciplines/:id)
- 소명 글 작성 (POST /disciplines/:id/appeal) — disciplinelog 댓글로 추가
- 이용제한 게시판 (GET /disciplines/board)

## New Files
- `internal/service/discipline_service.go`
- `internal/handler/discipline_handler.go`

## Modified Files
- `internal/domain/report.go` — SubmitReportRequest DTO 추가
- `internal/domain/discipline.go` — DisciplineResponse, AppealRequest DTO 추가
- `internal/repository/discipline_repo.go` — FindByTargetMember, ListAll, CreateAppeal 추가
- `internal/service/report_service.go` — GetMyReports 추가
- `internal/handler/report_handler.go` — SubmitReport, MyReports 핸들러 추가
- `cmd/api/main.go`, `internal/routes/routes.go` — DI 및 라우트