### PR TITLE
feat: Phase 5 갤러리/통합검색 + Redis 캐시

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -176,6 +176,7 @@ func main() {
 	var messageHandler *handler.MessageHandler
 	var wsHandler *handler.WSHandler
 	var disciplineHandler *handler.DisciplineHandler
+	var galleryHandler *handler.GalleryHandler
 
 	if db != nil {
 		// Repositories
@@ -200,6 +201,7 @@ func main() {
 		blockRepo := repository.NewBlockRepository(db)
 		messageRepo := repository.NewMessageRepository(db)
 		disciplineRepo := repository.NewDisciplineRepository(db)
+		galleryRepo := repository.NewGalleryRepository(db)
 
 		// Services
 		authService := service.NewAuthService(memberRepo, jwtManager, hookManager)
@@ -223,6 +225,7 @@ func main() {
 		blockService := service.NewBlockService(blockRepo, memberRepo)
 		messageService := service.NewMessageService(messageRepo, memberRepo, blockRepo)
 		disciplineService := service.NewDisciplineService(disciplineRepo)
+		galleryService := service.NewGalleryService(galleryRepo, redisClient)
 
 		// File upload path
 		uploadPath := cfg.DataPaths.UploadPath
@@ -257,6 +260,7 @@ func main() {
 		messageHandler = handler.NewMessageHandler(messageService)
 		wsHandler = handler.NewWSHandler(wsHub)
 		disciplineHandler = handler.NewDisciplineHandler(disciplineService)
+		galleryHandler = handler.NewGalleryHandler(galleryService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -302,7 +306,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, galleryHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/domain/gallery.go
+++ b/internal/domain/gallery.go
@@ -1,0 +1,29 @@
+package domain
+
+// GalleryItem represents a gallery post with thumbnail
+type GalleryItem struct {
+	BoardID      string `json:"board_id"`
+	PostID       int    `json:"post_id"`
+	Title        string `json:"title"`
+	Author       string `json:"author"`
+	AuthorID     string `json:"author_id"`
+	ThumbnailURL string `json:"thumbnail_url"`
+	Views        int    `json:"views"`
+	Likes        int    `json:"likes"`
+	CommentCount int    `json:"comment_count"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// UnifiedSearchResult represents a search result across all boards
+type UnifiedSearchResult struct {
+	BoardID   string `json:"board_id"`
+	BoardName string `json:"board_name,omitempty"`
+	PostID    int    `json:"post_id"`
+	Title     string `json:"title"`
+	Content   string `json:"content"` // snippet
+	Author    string `json:"author"`
+	AuthorID  string `json:"author_id"`
+	Views     int    `json:"views"`
+	Likes     int    `json:"likes"`
+	CreatedAt string `json:"created_at"`
+}

--- a/internal/handler/gallery_handler.go
+++ b/internal/handler/gallery_handler.go
@@ -1,0 +1,115 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// GalleryHandler handles gallery and unified search requests
+type GalleryHandler struct {
+	service service.GalleryService
+}
+
+// NewGalleryHandler creates a new GalleryHandler
+func NewGalleryHandler(service service.GalleryService) *GalleryHandler {
+	return &GalleryHandler{service: service}
+}
+
+// GetGallery handles GET /gallery/:board_id
+// @Summary 게시판 갤러리
+// @Tags gallery
+// @Produce json
+// @Param board_id path string true "게시판 ID"
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.GalleryItem}
+// @Router /gallery/{board_id} [get]
+func (h *GalleryHandler) GetGallery(c *gin.Context) {
+	boardID := c.Param("board_id")
+	if boardID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "게시판 ID가 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	items, meta, err := h.service.GetGallery(boardID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "갤러리 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: items, Meta: meta})
+}
+
+// GetGalleryAll handles GET /gallery
+// @Summary 전체 갤러리
+// @Tags gallery
+// @Produce json
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.GalleryItem}
+// @Router /gallery [get]
+func (h *GalleryHandler) GetGalleryAll(c *gin.Context) {
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	items, meta, err := h.service.GetGalleryAll(page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "갤러리 조회 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: items, Meta: meta})
+}
+
+// UnifiedSearch handles GET /search
+// @Summary 통합 검색
+// @Tags search
+// @Produce json
+// @Param q query string true "검색어"
+// @Param page query int false "페이지"
+// @Param limit query int false "페이지 크기"
+// @Success 200 {object} common.APIResponse{data=[]domain.UnifiedSearchResult}
+// @Router /search [get]
+func (h *GalleryHandler) UnifiedSearch(c *gin.Context) {
+	keyword := c.Query("q")
+	if keyword == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "검색어가 필요합니다", nil)
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+
+	results, meta, err := h.service.UnifiedSearch(keyword, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "검색 실패", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: results, Meta: meta})
+}

--- a/internal/repository/gallery_repo.go
+++ b/internal/repository/gallery_repo.go
@@ -1,0 +1,260 @@
+package repository
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// GalleryRepository handles gallery and unified search queries
+type GalleryRepository struct {
+	db *gorm.DB
+}
+
+// NewGalleryRepository creates a new GalleryRepository
+func NewGalleryRepository(db *gorm.DB) *GalleryRepository {
+	return &GalleryRepository{db: db}
+}
+
+// FindGalleryPosts returns posts with images from the specified board
+func (r *GalleryRepository) FindGalleryPosts(boardID string, page, limit int) ([]*domain.GalleryItem, int64, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardID)
+	offset := (page - 1) * limit
+
+	var total int64
+	countSQL := fmt.Sprintf(
+		"SELECT COUNT(*) FROM `%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND wr_file > 0",
+		tableName,
+	)
+	if err := r.db.Raw(countSQL).Scan(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	type postRow struct {
+		WrID       int    `gorm:"column:wr_id"`
+		WrSubject  string `gorm:"column:wr_subject"`
+		WrName     string `gorm:"column:wr_name"`
+		MbID       string `gorm:"column:mb_id"`
+		WrHit      int    `gorm:"column:wr_hit"`
+		WrGood     int    `gorm:"column:wr_good"`
+		WrComment  int    `gorm:"column:wr_comment"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+	}
+
+	var rows []postRow
+	sql := fmt.Sprintf(
+		"SELECT wr_id, wr_subject, wr_name, mb_id, wr_hit, wr_good, wr_comment, wr_datetime "+
+			"FROM `%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND wr_file > 0 "+
+			"ORDER BY wr_datetime DESC LIMIT ? OFFSET ?",
+		tableName,
+	)
+	if err := r.db.Raw(sql, limit, offset).Scan(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*domain.GalleryItem, len(rows))
+	for i, row := range rows {
+		// Get first image file for thumbnail
+		thumbnail := r.getFirstImage(boardID, row.WrID)
+		items[i] = &domain.GalleryItem{
+			BoardID:      boardID,
+			PostID:       row.WrID,
+			Title:        row.WrSubject,
+			Author:       row.WrName,
+			AuthorID:     row.MbID,
+			ThumbnailURL: thumbnail,
+			Views:        row.WrHit,
+			Likes:        row.WrGood,
+			CommentCount: row.WrComment,
+			CreatedAt:    row.WrDatetime,
+		}
+	}
+
+	return items, total, nil
+}
+
+// FindGalleryAll returns image posts across all boards (최신순)
+func (r *GalleryRepository) FindGalleryAll(boardIDs []string, page, limit int) ([]*domain.GalleryItem, int64, error) {
+	if len(boardIDs) == 0 {
+		return nil, 0, nil
+	}
+
+	offset := (page - 1) * limit
+
+	// Build UNION ALL for count
+	var countParts []string
+	for _, bid := range boardIDs {
+		countParts = append(countParts, fmt.Sprintf(
+			"SELECT wr_id FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND wr_file > 0",
+			bid,
+		))
+	}
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS t", strings.Join(countParts, " UNION ALL "))
+	var total int64
+	if err := r.db.Raw(countSQL).Scan(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Build UNION ALL for data
+	var dataParts []string
+	for _, bid := range boardIDs {
+		dataParts = append(dataParts, fmt.Sprintf(
+			"SELECT '%s' AS bo_table, wr_id, wr_subject, wr_name, mb_id, wr_hit, wr_good, wr_comment, wr_datetime "+
+				"FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND wr_file > 0",
+			bid, bid,
+		))
+	}
+	dataSQL := fmt.Sprintf(
+		"SELECT * FROM (%s) AS t ORDER BY wr_datetime DESC LIMIT ? OFFSET ?",
+		strings.Join(dataParts, " UNION ALL "),
+	)
+
+	type galleryRow struct {
+		BoTable    string `gorm:"column:bo_table"`
+		WrID       int    `gorm:"column:wr_id"`
+		WrSubject  string `gorm:"column:wr_subject"`
+		WrName     string `gorm:"column:wr_name"`
+		MbID       string `gorm:"column:mb_id"`
+		WrHit      int    `gorm:"column:wr_hit"`
+		WrGood     int    `gorm:"column:wr_good"`
+		WrComment  int    `gorm:"column:wr_comment"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+	}
+
+	var rows []galleryRow
+	if err := r.db.Raw(dataSQL, limit, offset).Scan(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+
+	items := make([]*domain.GalleryItem, len(rows))
+	for i, row := range rows {
+		thumbnail := r.getFirstImage(row.BoTable, row.WrID)
+		items[i] = &domain.GalleryItem{
+			BoardID:      row.BoTable,
+			PostID:       row.WrID,
+			Title:        row.WrSubject,
+			Author:       row.WrName,
+			AuthorID:     row.MbID,
+			ThumbnailURL: thumbnail,
+			Views:        row.WrHit,
+			Likes:        row.WrGood,
+			CommentCount: row.WrComment,
+			CreatedAt:    row.WrDatetime,
+		}
+	}
+
+	return items, total, nil
+}
+
+// UnifiedSearch searches across all boards with UNION ALL
+func (r *GalleryRepository) UnifiedSearch(boardIDs []string, keyword string, page, limit int) ([]*domain.UnifiedSearchResult, int64, error) {
+	if len(boardIDs) == 0 || keyword == "" {
+		return nil, 0, nil
+	}
+
+	offset := (page - 1) * limit
+	likeKeyword := "%" + keyword + "%"
+
+	// Count
+	var countParts []string
+	for _, bid := range boardIDs {
+		countParts = append(countParts, fmt.Sprintf(
+			"SELECT wr_id FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND (wr_subject LIKE ? OR wr_content LIKE ?)",
+			bid,
+		))
+	}
+	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS t", strings.Join(countParts, " UNION ALL "))
+
+	// Build args for count (2 args per board)
+	countArgs := make([]interface{}, 0, len(boardIDs)*2)
+	for range boardIDs {
+		countArgs = append(countArgs, likeKeyword, likeKeyword)
+	}
+
+	var total int64
+	if err := r.db.Raw(countSQL, countArgs...).Scan(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Data
+	var dataParts []string
+	for _, bid := range boardIDs {
+		dataParts = append(dataParts, fmt.Sprintf(
+			"SELECT '%s' AS bo_table, wr_id, wr_subject, SUBSTRING(wr_content, 1, 200) AS wr_content, wr_name, mb_id, wr_hit, wr_good, wr_datetime "+
+				"FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND (wr_subject LIKE ? OR wr_content LIKE ?)",
+			bid, bid,
+		))
+	}
+	dataSQL := fmt.Sprintf(
+		"SELECT * FROM (%s) AS t ORDER BY wr_datetime DESC LIMIT ? OFFSET ?",
+		strings.Join(dataParts, " UNION ALL "),
+	)
+
+	dataArgs := make([]interface{}, 0, len(boardIDs)*2+2)
+	for range boardIDs {
+		dataArgs = append(dataArgs, likeKeyword, likeKeyword)
+	}
+	dataArgs = append(dataArgs, limit, offset)
+
+	type searchRow struct {
+		BoTable    string `gorm:"column:bo_table"`
+		WrID       int    `gorm:"column:wr_id"`
+		WrSubject  string `gorm:"column:wr_subject"`
+		WrContent  string `gorm:"column:wr_content"`
+		WrName     string `gorm:"column:wr_name"`
+		MbID       string `gorm:"column:mb_id"`
+		WrHit      int    `gorm:"column:wr_hit"`
+		WrGood     int    `gorm:"column:wr_good"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+	}
+
+	var rows []searchRow
+	if err := r.db.Raw(dataSQL, dataArgs...).Scan(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+
+	results := make([]*domain.UnifiedSearchResult, len(rows))
+	for i, row := range rows {
+		results[i] = &domain.UnifiedSearchResult{
+			BoardID:   row.BoTable,
+			PostID:    row.WrID,
+			Title:     row.WrSubject,
+			Content:   row.WrContent,
+			Author:    row.WrName,
+			AuthorID:  row.MbID,
+			Views:     row.WrHit,
+			Likes:     row.WrGood,
+			CreatedAt: row.WrDatetime,
+		}
+	}
+
+	return results, total, nil
+}
+
+// getFirstImage returns the URL of the first image file for a post
+func (r *GalleryRepository) getFirstImage(boardID string, wrID int) string {
+	var file domain.BoardFile
+	err := r.db.Where("bo_table = ? AND wr_id = ? AND bf_no = 0", boardID, wrID).
+		First(&file).Error
+	if err != nil {
+		return ""
+	}
+	if file.File != "" {
+		return fmt.Sprintf("/data/file/%s/%s", boardID, file.File)
+	}
+	return ""
+}
+
+// GetAllBoardIDs returns all active board IDs
+func (r *GalleryRepository) GetAllBoardIDs() ([]string, error) {
+	var boardIDs []string
+	if err := r.db.Table("g5_board").
+		Select("bo_table").
+		Where("bo_use = 1").
+		Pluck("bo_table", &boardIDs).Error; err != nil {
+		return nil, err
+	}
+	return boardIDs, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -39,6 +39,7 @@ func Setup(
 	messageHandler *handler.MessageHandler,
 	wsHandler *handler.WSHandler,
 	disciplineHandler *handler.DisciplineHandler,
+	galleryHandler *handler.GalleryHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -222,6 +223,14 @@ func Setup(
 	disciplines.GET("/:id", disciplineHandler.GetDiscipline)     // 이용제한 상세 열람
 	disciplines.POST("/:id/appeal", disciplineHandler.SubmitAppeal) // 소명 글 작성
 	members.GET("/me/disciplines", disciplineHandler.MyDisciplines) // 내 이용제한 내역
+
+	// Gallery (갤러리 API - 공개, Redis 캐시)
+	gallery := api.Group("/gallery")
+	gallery.GET("", galleryHandler.GetGalleryAll)          // 전체 갤러리
+	gallery.GET("/:board_id", galleryHandler.GetGallery)   // 게시판별 갤러리
+
+	// Unified Search (통합 검색 API - 공개, Redis 캐시)
+	api.GET("/search", galleryHandler.UnifiedSearch)
 
 	// Dajoongi (다중이 탐지 API - 관리자 전용)
 	api.GET("/dajoongi", dajoongiHandler.GetDuplicateAccounts)

--- a/internal/service/gallery_service.go
+++ b/internal/service/gallery_service.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	galleryCacheTTL = 5 * time.Minute  // 갤러리 캐시 5분
+	searchCacheTTL  = 3 * time.Minute  // 검색 캐시 3분
+	boardIDsCacheTTL = 10 * time.Minute // 게시판 ID 목록 캐시 10분
+)
+
+// GalleryService handles gallery and unified search
+type GalleryService interface {
+	GetGallery(boardID string, page, limit int) ([]*domain.GalleryItem, *common.Meta, error)
+	GetGalleryAll(page, limit int) ([]*domain.GalleryItem, *common.Meta, error)
+	UnifiedSearch(keyword string, page, limit int) ([]*domain.UnifiedSearchResult, *common.Meta, error)
+}
+
+type galleryService struct {
+	repo  *repository.GalleryRepository
+	redis *redis.Client
+}
+
+// NewGalleryService creates a new GalleryService
+func NewGalleryService(repo *repository.GalleryRepository, redisClient *redis.Client) GalleryService {
+	return &galleryService{repo: repo, redis: redisClient}
+}
+
+// GetGallery returns gallery posts for a specific board
+func (s *galleryService) GetGallery(boardID string, page, limit int) ([]*domain.GalleryItem, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	cacheKey := fmt.Sprintf("gallery:%s:%d:%d", boardID, page, limit)
+
+	// Try Redis cache
+	if cached := s.getFromCache(cacheKey); cached != nil {
+		var result struct {
+			Items []*domain.GalleryItem `json:"items"`
+			Meta  *common.Meta          `json:"meta"`
+		}
+		if err := json.Unmarshal(cached, &result); err == nil {
+			return result.Items, result.Meta, nil
+		}
+	}
+
+	items, total, err := s.repo.FindGalleryPosts(boardID, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+
+	// Cache result
+	s.setToCache(cacheKey, galleryCacheTTL, map[string]interface{}{
+		"items": items,
+		"meta":  meta,
+	})
+
+	return items, meta, nil
+}
+
+// GetGalleryAll returns gallery posts across all boards
+func (s *galleryService) GetGalleryAll(page, limit int) ([]*domain.GalleryItem, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	cacheKey := fmt.Sprintf("gallery:all:%d:%d", page, limit)
+
+	// Try Redis cache
+	if cached := s.getFromCache(cacheKey); cached != nil {
+		var result struct {
+			Items []*domain.GalleryItem `json:"items"`
+			Meta  *common.Meta          `json:"meta"`
+		}
+		if err := json.Unmarshal(cached, &result); err == nil {
+			return result.Items, result.Meta, nil
+		}
+	}
+
+	boardIDs, err := s.getBoardIDs()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	items, total, err := s.repo.FindGalleryAll(boardIDs, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+
+	s.setToCache(cacheKey, galleryCacheTTL, map[string]interface{}{
+		"items": items,
+		"meta":  meta,
+	})
+
+	return items, meta, nil
+}
+
+// UnifiedSearch searches across all boards with caching
+func (s *galleryService) UnifiedSearch(keyword string, page, limit int) ([]*domain.UnifiedSearchResult, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+
+	cacheKey := fmt.Sprintf("search:%s:%d:%d", keyword, page, limit)
+
+	// Try Redis cache (동시접속 1만명 대비, 동일 검색어 캐싱)
+	if cached := s.getFromCache(cacheKey); cached != nil {
+		var result struct {
+			Items []*domain.UnifiedSearchResult `json:"items"`
+			Meta  *common.Meta                  `json:"meta"`
+		}
+		if err := json.Unmarshal(cached, &result); err == nil {
+			return result.Items, result.Meta, nil
+		}
+	}
+
+	boardIDs, err := s.getBoardIDs()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	results, total, err := s.repo.UnifiedSearch(boardIDs, keyword, page, limit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+
+	s.setToCache(cacheKey, searchCacheTTL, map[string]interface{}{
+		"items": results,
+		"meta":  meta,
+	})
+
+	return results, meta, nil
+}
+
+// getBoardIDs returns all board IDs with caching
+func (s *galleryService) getBoardIDs() ([]string, error) {
+	cacheKey := "board_ids:active"
+
+	if cached := s.getFromCache(cacheKey); cached != nil {
+		var ids []string
+		if err := json.Unmarshal(cached, &ids); err == nil {
+			return ids, nil
+		}
+	}
+
+	ids, err := s.repo.GetAllBoardIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	s.setToCache(cacheKey, boardIDsCacheTTL, ids)
+	return ids, nil
+}
+
+// getFromCache reads from Redis (returns nil if not available)
+func (s *galleryService) getFromCache(key string) []byte {
+	if s.redis == nil {
+		return nil
+	}
+	val, err := s.redis.Get(context.Background(), key).Bytes()
+	if err != nil {
+		return nil
+	}
+	return val
+}
+
+// setToCache writes to Redis (ignores errors)
+func (s *galleryService) setToCache(key string, ttl time.Duration, value interface{}) {
+	if s.redis == nil {
+		return
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	s.redis.Set(context.Background(), key, data, ttl) //nolint:errcheck
+}


### PR DESCRIPTION
## Summary
- 전체 갤러리 (`GET /gallery`) — 모든 게시판 이미지 게시글, UNION ALL
- 게시판별 갤러리 (`GET /gallery/:board_id`) — 특정 게시판 이미지 게시글
- 통합 검색 (`GET /search?q=`) — 모든 게시판 대상 키워드 검색, UNION ALL
- Redis 캐시 적용 (동시접속 1만명 대비):
  - 갤러리: 5분 TTL
  - 검색 결과: 3분 TTL (동일 검색어 캐싱)
  - 게시판 ID 목록: 10분 TTL
  - Redis 미연결 시 DB 직접 조회 (graceful fallback)
- 추천글/AI추천글은 기존 file-based ETag 캐시로 이미 구현 완료

## New Files
- `internal/domain/gallery.go` — GalleryItem, UnifiedSearchResult DTO
- `internal/repository/gallery_repo.go` — UNION ALL 쿼리, 썸네일 조회
- `internal/service/gallery_service.go` — Redis 캐시 레이어
- `internal/handler/gallery_handler.go` — 3개 엔드포인트

## Cache Strategy (동시접속 1만명)
| 항목 | TTL | 이유 |
|------|-----|------|
| 갤러리 | 5분 | 게시글 빈도 낮음, DB 부하 감소 |
| 검색 결과 | 3분 | 인기 검색어 중복 요청 방지 |
| 게시판 ID | 10분 | 거의 변경 없음 |