### PR TITLE
feat(admin): 회원 관리 Admin API 5개 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -177,6 +177,7 @@ func main() {
 	var wsHandler *handler.WSHandler
 	var disciplineHandler *handler.DisciplineHandler
 	var galleryHandler *handler.GalleryHandler
+	var adminHandler *handler.AdminHandler
 
 	if db != nil {
 		// Repositories
@@ -226,6 +227,7 @@ func main() {
 		messageService := service.NewMessageService(messageRepo, memberRepo, blockRepo)
 		disciplineService := service.NewDisciplineService(disciplineRepo)
 		galleryService := service.NewGalleryService(galleryRepo, redisClient)
+		adminMemberService := service.NewAdminMemberService(memberRepo, db)
 
 		// File upload path
 		uploadPath := cfg.DataPaths.UploadPath
@@ -261,6 +263,7 @@ func main() {
 		wsHandler = handler.NewWSHandler(wsHub)
 		disciplineHandler = handler.NewDisciplineHandler(disciplineService)
 		galleryHandler = handler.NewGalleryHandler(galleryService)
+		adminHandler = handler.NewAdminHandler(adminMemberService)
 	}
 
 	// Recommended Handler (파일 직접 읽기)
@@ -306,7 +309,7 @@ func main() {
 
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
-		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, galleryHandler, cfg)
+		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, galleryHandler, adminHandler, cfg)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/domain/admin_member.go
+++ b/internal/domain/admin_member.go
@@ -1,0 +1,108 @@
+package domain
+
+// AdminMemberListItem represents a member in admin list view
+type AdminMemberListItem struct {
+	UserID        string `json:"user_id"`
+	Nickname      string `json:"nickname"`
+	Name          string `json:"name"`
+	Email         string `json:"email"`
+	CreatedAt     string `json:"created_at"`
+	LoginIP       string `json:"login_ip"`
+	InterceptDate string `json:"intercept_date,omitempty"`
+	ID            int    `json:"id"`
+	Level         int    `json:"level"`
+	Point         int    `json:"point"`
+}
+
+// AdminMemberDetail represents detailed member info for admin
+type AdminMemberDetail struct {
+	UserID        string `json:"user_id"`
+	Nickname      string `json:"nickname"`
+	Name          string `json:"name"`
+	Email         string `json:"email"`
+	Phone         string `json:"phone"`
+	Birth         string `json:"birth,omitempty"`
+	Homepage      string `json:"homepage,omitempty"`
+	Profile       string `json:"profile,omitempty"`
+	Signature     string `json:"signature,omitempty"`
+	Memo          string `json:"memo,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	TodayLogin    string `json:"today_login"`
+	LoginIP       string `json:"login_ip"`
+	IP            string `json:"ip"`
+	InterceptDate string `json:"intercept_date,omitempty"`
+	LeaveDate     string `json:"leave_date,omitempty"`
+	Addr1         string `json:"addr1,omitempty"`
+	Addr2         string `json:"addr2,omitempty"`
+	ID            int    `json:"id"`
+	Level         int    `json:"level"`
+	Point         int    `json:"point"`
+	MemoCount     int    `json:"memo_count"`
+	ScrapCount    int    `json:"scrap_count"`
+}
+
+// ToAdminListItem converts Member to AdminMemberListItem
+func (m *Member) ToAdminListItem() *AdminMemberListItem {
+	return &AdminMemberListItem{
+		ID:            m.ID,
+		UserID:        m.UserID,
+		Nickname:      m.Nickname,
+		Name:          m.Name,
+		Email:         m.Email,
+		Level:         m.Level,
+		Point:         m.Point,
+		CreatedAt:     m.CreatedAt.Format("2006-01-02 15:04:05"),
+		LoginIP:       m.LoginIP,
+		InterceptDate: m.InterceptDate,
+	}
+}
+
+// ToAdminDetail converts Member to AdminMemberDetail
+func (m *Member) ToAdminDetail() *AdminMemberDetail {
+	return &AdminMemberDetail{
+		ID:            m.ID,
+		UserID:        m.UserID,
+		Nickname:      m.Nickname,
+		Name:          m.Name,
+		Email:         m.Email,
+		Phone:         m.Phone,
+		Birth:         m.Birth,
+		Homepage:      m.Homepage,
+		Profile:       m.Profile,
+		Signature:     m.Signature,
+		Memo:          m.Memo,
+		Level:         m.Level,
+		Point:         m.Point,
+		CreatedAt:     m.CreatedAt.Format("2006-01-02 15:04:05"),
+		TodayLogin:    m.TodayLogin.Format("2006-01-02 15:04:05"),
+		LoginIP:       m.LoginIP,
+		IP:            m.IP,
+		InterceptDate: m.InterceptDate,
+		LeaveDate:     m.LeaveDate,
+		Addr1:         m.Addr1,
+		Addr2:         m.Addr2,
+		MemoCount:     m.MemoCount,
+		ScrapCount:    m.ScrapCount,
+	}
+}
+
+// AdminMemberUpdateRequest request for admin member update
+type AdminMemberUpdateRequest struct {
+	Nickname *string `json:"nickname,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Email    *string `json:"email,omitempty"`
+	Level    *int    `json:"level,omitempty"`
+	Memo     *string `json:"memo,omitempty"`
+}
+
+// AdminPointAdjustRequest request for adjusting member point
+type AdminPointAdjustRequest struct {
+	Point   int    `json:"point" binding:"required"`
+	Content string `json:"content" binding:"required"`
+}
+
+// AdminRestrictRequest request for restricting/unrestricting a member
+type AdminRestrictRequest struct {
+	InterceptDate string `json:"intercept_date"` // "YYYY-MM-DD" or "" to lift
+	Reason        string `json:"reason"`
+}

--- a/internal/handler/admin_handler.go
+++ b/internal/handler/admin_handler.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// AdminHandler handles admin member management requests
+type AdminHandler struct {
+	service service.AdminMemberService
+}
+
+// NewAdminHandler creates a new AdminHandler
+func NewAdminHandler(service service.AdminMemberService) *AdminHandler {
+	return &AdminHandler{service: service}
+}
+
+// ListMembers handles GET /api/v2/admin/members
+func (h *AdminHandler) ListMembers(c *gin.Context) {
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+	keyword := c.Query("keyword")
+
+	items, meta, err := h.service.ListMembers(page, limit, keyword)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "회원 목록 조회 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: items, Meta: meta})
+}
+
+// GetMember handles GET /api/v2/admin/members/:id
+func (h *AdminHandler) GetMember(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 ID", err)
+		return
+	}
+
+	detail, err := h.service.GetMember(id)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "회원을 찾을 수 없습니다", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: detail})
+}
+
+// UpdateMember handles PUT /api/v2/admin/members/:id
+func (h *AdminHandler) UpdateMember(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 ID", err)
+		return
+	}
+
+	var req domain.AdminMemberUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	if err := h.service.UpdateMember(id, &req); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "회원 수정 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "수정 완료"}})
+}
+
+// AdjustPoint handles POST /api/v2/admin/members/:id/point
+func (h *AdminHandler) AdjustPoint(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 ID", err)
+		return
+	}
+
+	var req domain.AdminPointAdjustRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	if err := h.service.AdjustPoint(id, &req); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "포인트 조정 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "포인트 조정 완료"}})
+}
+
+// RestrictMember handles POST /api/v2/admin/members/:id/restrict
+func (h *AdminHandler) RestrictMember(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 ID", err)
+		return
+	}
+
+	var req domain.AdminRestrictRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	if err := h.service.RestrictMember(id, &req); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "이용제한 처리 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "이용제한 처리 완료"}})
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -40,6 +40,7 @@ func Setup(
 	wsHandler *handler.WSHandler,
 	disciplineHandler *handler.DisciplineHandler,
 	galleryHandler *handler.GalleryHandler,
+	adminHandler *handler.AdminHandler,
 	cfg *config.Config,
 ) {
 	// Global middleware for damoang_jwt cookie authentication
@@ -255,6 +256,15 @@ func Setup(
 	// Files (파일 다운로드 API - 공개)
 	files := api.Group("/files")
 	files.GET("/:board_id/:wr_id/:file_no/download", fileHandler.DownloadFile) // 파일 다운로드
+
+	// Admin Members (관리자 회원 관리)
+	adminMembers := api.Group("/admin/members")
+	// TODO: 운영 환경에서는 middleware.JWTAuth(jwtManager) + 관리자 권한 체크 추가 필요
+	adminMembers.GET("", adminHandler.ListMembers)
+	adminMembers.GET("/:id", adminHandler.GetMember)
+	adminMembers.PUT("/:id", adminHandler.UpdateMember)
+	adminMembers.POST("/:id/point", adminHandler.AdjustPoint)
+	adminMembers.POST("/:id/restrict", adminHandler.RestrictMember)
 
 	// ============================================
 	// Plugin Routes (/api/plugins/*)

--- a/internal/service/admin_member_service.go
+++ b/internal/service/admin_member_service.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+	"gorm.io/gorm"
+)
+
+// AdminMemberService handles admin member operations
+type AdminMemberService interface {
+	ListMembers(page, limit int, keyword string) ([]*domain.AdminMemberListItem, *common.Meta, error)
+	GetMember(id int) (*domain.AdminMemberDetail, error)
+	UpdateMember(id int, req *domain.AdminMemberUpdateRequest) error
+	AdjustPoint(id int, req *domain.AdminPointAdjustRequest) error
+	RestrictMember(id int, req *domain.AdminRestrictRequest) error
+}
+
+type adminMemberService struct {
+	memberRepo repository.MemberRepository
+	db         *gorm.DB
+}
+
+// NewAdminMemberService creates a new AdminMemberService
+func NewAdminMemberService(memberRepo repository.MemberRepository, db *gorm.DB) AdminMemberService {
+	return &adminMemberService{memberRepo: memberRepo, db: db}
+}
+
+// ListMembers returns paginated member list for admin
+func (s *adminMemberService) ListMembers(page, limit int, keyword string) ([]*domain.AdminMemberListItem, *common.Meta, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+
+	members, total, err := s.memberRepo.FindAll(page, limit, keyword)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	items := make([]*domain.AdminMemberListItem, len(members))
+	for i, m := range members {
+		items[i] = m.ToAdminListItem()
+	}
+
+	meta := &common.Meta{Page: page, Limit: limit, Total: total}
+	return items, meta, nil
+}
+
+// GetMember returns detailed member info for admin
+func (s *adminMemberService) GetMember(id int) (*domain.AdminMemberDetail, error) {
+	member, err := s.memberRepo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	return member.ToAdminDetail(), nil
+}
+
+// UpdateMember updates member fields for admin
+func (s *adminMemberService) UpdateMember(id int, req *domain.AdminMemberUpdateRequest) error {
+	fields := make(map[string]interface{})
+	if req.Nickname != nil {
+		fields["mb_nick"] = *req.Nickname
+	}
+	if req.Name != nil {
+		fields["mb_name"] = *req.Name
+	}
+	if req.Email != nil {
+		fields["mb_email"] = *req.Email
+	}
+	if req.Level != nil {
+		fields["mb_level"] = *req.Level
+	}
+	if req.Memo != nil {
+		fields["mb_memo"] = *req.Memo
+	}
+	if len(fields) == 0 {
+		return nil
+	}
+	return s.memberRepo.UpdateFields(id, fields)
+}
+
+// AdjustPoint adjusts member point and records in g5_point
+func (s *adminMemberService) AdjustPoint(id int, req *domain.AdminPointAdjustRequest) error {
+	member, err := s.memberRepo.FindByID(id)
+	if err != nil {
+		return err
+	}
+
+	newPoint := member.Point + req.Point
+	if newPoint < 0 {
+		newPoint = 0
+	}
+
+	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Update member point
+		if err := tx.Model(&domain.Member{}).Where("mb_no = ?", id).Update("mb_point", newPoint).Error; err != nil {
+			return err
+		}
+		// Record in g5_point
+		point := &domain.Point{
+			MbID:      member.UserID,
+			Point:     req.Point,
+			Content:   req.Content,
+			MbPoint:   newPoint,
+			RelTable:  "admin",
+			RelAction: "point_adjust",
+			RelID:     fmt.Sprintf("%d", id),
+			Datetime:  time.Now().Format("2006-01-02 15:04:05"),
+		}
+		return tx.Create(point).Error
+	})
+}
+
+// RestrictMember sets or clears the intercept date on a member
+func (s *adminMemberService) RestrictMember(id int, req *domain.AdminRestrictRequest) error {
+	return s.memberRepo.UpdateFields(id, map[string]interface{}{
+		"mb_intercept_date": req.InterceptDate,
+	})
+}


### PR DESCRIPTION
## Summary
- 관리자 회원 관리 API 5개 엔드포인트 구현
- 회원 목록 조회 (keyword 검색, 페이징), 상세 조회, 수정, 포인트 조정 (g5_point 기록), 이용제한/해제
- Phase 6 관리자 API 완료 (게시판/신고 관리는 기존 구현 완료)

## Test plan
- [ ] `go build ./...` 빌드 확인
- [ ] GET /api/v2/admin/members 회원 목록 조회
- [ ] GET /api/v2/admin/members/:id 회원 상세 조회
- [ ] PUT /api/v2/admin/members/:id 회원 정보 수정
- [ ] POST /api/v2/admin/members/:id/point 포인트 조정 및 g5_point 기록 확인
- [ ] POST /api/v2/admin/members/:id/restrict 이용제한 설정/해제