### PR TITLE
feat(promotion): 광고주 본인 통계/잔여기간 API (Phase 7)

### DIFF
--- a/internal/domain/promotion.go
+++ b/internal/domain/promotion.go
@@ -155,6 +155,30 @@ type CreatePromotionPostRequest struct {
 	ImageURL string `json:"image_url"`
 }
 
+// AdvertiserStatsResponse represents advertiser's own statistics
+type AdvertiserStatsResponse struct {
+	AdvertiserID int64      `json:"advertiser_id"`
+	Name         string     `json:"name"`
+	TotalViews   int        `json:"total_views"`
+	TotalLikes   int        `json:"total_likes"`
+	PostCount    int        `json:"post_count"`
+	IsActive     bool       `json:"is_active"`
+	IsPinned     bool       `json:"is_pinned"`
+	StartDate    *time.Time `json:"start_date,omitempty"`
+	EndDate      *time.Time `json:"end_date,omitempty"`
+}
+
+// AdvertiserRemainingResponse represents remaining ad period
+type AdvertiserRemainingResponse struct {
+	AdvertiserID  int64      `json:"advertiser_id"`
+	Name          string     `json:"name"`
+	StartDate     *time.Time `json:"start_date,omitempty"`
+	EndDate       *time.Time `json:"end_date,omitempty"`
+	RemainingDays int        `json:"remaining_days"` // -1 if no end date (unlimited)
+	IsActive      bool       `json:"is_active"`
+	IsExpired     bool       `json:"is_expired"`
+}
+
 // UpdatePromotionPostRequest is the request body for updating a promotion post
 type UpdatePromotionPostRequest struct {
 	Title    string `json:"title"`

--- a/internal/handler/promotion_handler.go
+++ b/internal/handler/promotion_handler.go
@@ -253,6 +253,46 @@ func (h *PromotionHandler) DeletePromotionPost(c *gin.Context) {
 	common.SuccessResponse(c, gin.H{"message": "Post deleted successfully"}, nil)
 }
 
+// ============= Advertiser Self-Service Endpoints =============
+
+// GetMyStats handles GET /promotion/my/stats
+func (h *PromotionHandler) GetMyStats(c *gin.Context) {
+	memberID := middleware.GetUserID(c)
+	if memberID == "" {
+		memberID = middleware.GetDamoangUserID(c)
+	}
+	if memberID == "" {
+		common.ErrorResponse(c, 401, "Unauthorized", nil)
+		return
+	}
+
+	data, err := h.service.GetMyStats(memberID)
+	if err != nil {
+		common.ErrorResponse(c, 404, "광고주 정보를 찾을 수 없습니다", err)
+		return
+	}
+	common.SuccessResponse(c, data, nil)
+}
+
+// GetMyRemaining handles GET /promotion/my/remaining
+func (h *PromotionHandler) GetMyRemaining(c *gin.Context) {
+	memberID := middleware.GetUserID(c)
+	if memberID == "" {
+		memberID = middleware.GetDamoangUserID(c)
+	}
+	if memberID == "" {
+		common.ErrorResponse(c, 401, "Unauthorized", nil)
+		return
+	}
+
+	data, err := h.service.GetMyRemaining(memberID)
+	if err != nil {
+		common.ErrorResponse(c, 404, "광고주 정보를 찾을 수 없습니다", err)
+		return
+	}
+	common.SuccessResponse(c, data, nil)
+}
+
 // ============= Admin Endpoints =============
 
 // ListAdvertisers godoc

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -273,6 +273,10 @@ func Setup(
 
 	// Promotion Plugin (직홍게 플러그인)
 	promotion := plugins.Group("/promotion")
+	// 광고주 본인 API
+	promotion.GET("/my/stats", promotionHandler.GetMyStats)
+	promotion.GET("/my/remaining", promotionHandler.GetMyRemaining)
+
 	promotion.GET("/posts", promotionHandler.ListPromotionPosts)
 	promotion.GET("/posts/insert", promotionHandler.GetPromotionPostsForInsert)
 	promotion.GET("/posts/:id", promotionHandler.GetPromotionPost)


### PR DESCRIPTION
## Summary
- 광고주 본인 통계 조회 API (GET /promotion/my/stats): 게시글 조회수/좋아요 합산, 활성 상태, 기간 정보
- 광고주 남은 기간 조회 API (GET /promotion/my/remaining): 종료일까지 남은 일수 계산, 만료 여부
- 기존 배너 위치별 조회 + 클릭/뷰 트래킹은 이미 구현 완료

## Test plan
- [ ] `go build ./...` 빌드 확인
- [ ] GET /api/plugins/promotion/my/stats 광고주 통계 조회
- [ ] GET /api/plugins/promotion/my/remaining 남은 기간 조회
- [ ] 비광고주 접근 시 404 응답 확인