### PR TITLE
feat(v2-api): v2 신규 테이블 기반 API 레이어 구현 (Phase 9)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -18,7 +18,10 @@ import (
 	pluginstoreRepo "github.com/damoang/angple-backend/internal/pluginstore/repository"
 	pluginstoreSvc "github.com/damoang/angple-backend/internal/pluginstore/service"
 	"github.com/damoang/angple-backend/internal/repository"
+	v2handler "github.com/damoang/angple-backend/internal/handler/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/damoang/angple-backend/internal/routes"
+	v2routes "github.com/damoang/angple-backend/internal/routes/v2"
 	"github.com/damoang/angple-backend/internal/service"
 	"github.com/damoang/angple-backend/internal/ws"
 	"github.com/damoang/angple-backend/pkg/jwt"
@@ -314,6 +317,14 @@ func main() {
 	// API v2 라우트 (only if DB is connected)
 	if db != nil {
 		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, galleryHandler, adminHandler, cfg)
+
+		// v2 신규 API (v2_ 테이블 기반) — /api/v2-next 에서 테스트, 추후 /api/v2로 전환
+		v2UserRepo := v2repo.NewUserRepository(db)
+		v2PostRepo := v2repo.NewPostRepository(db)
+		v2CommentRepo := v2repo.NewCommentRepository(db)
+		v2BoardRepo := v2repo.NewBoardRepository(db)
+		v2Handler := v2handler.NewV2Handler(v2UserRepo, v2PostRepo, v2CommentRepo, v2BoardRepo)
+		v2routes.Setup(router, v2Handler)
 	} else {
 		pkglogger.Info("⚠️  Skipping API route setup (no DB connection)")
 	}

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -1,0 +1,323 @@
+package v2
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/gin-gonic/gin"
+)
+
+// V2Handler handles all v2 API endpoints
+type V2Handler struct {
+	userRepo    v2repo.UserRepository
+	postRepo    v2repo.PostRepository
+	commentRepo v2repo.CommentRepository
+	boardRepo   v2repo.BoardRepository
+}
+
+// NewV2Handler creates a new V2Handler
+func NewV2Handler(
+	userRepo v2repo.UserRepository,
+	postRepo v2repo.PostRepository,
+	commentRepo v2repo.CommentRepository,
+	boardRepo v2repo.BoardRepository,
+) *V2Handler {
+	return &V2Handler{
+		userRepo:    userRepo,
+		postRepo:    postRepo,
+		commentRepo: commentRepo,
+		boardRepo:   boardRepo,
+	}
+}
+
+// === Users ===
+
+// GetUser handles GET /api/v2/users/:id
+func (h *V2Handler) GetUser(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 사용자 ID", err)
+		return
+	}
+	user, err := h.userRepo.FindByID(id)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
+		"id": user.ID, "username": user.Username, "nickname": user.Nickname,
+		"level": user.Level, "status": user.Status, "avatar_url": user.AvatarURL,
+		"bio": user.Bio, "created_at": user.CreatedAt,
+	}})
+}
+
+// GetUserByUsername handles GET /api/v2/users/username/:username
+func (h *V2Handler) GetUserByUsername(c *gin.Context) {
+	username := c.Param("username")
+	user, err := h.userRepo.FindByUsername(username)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
+		"id": user.ID, "username": user.Username, "nickname": user.Nickname,
+		"level": user.Level, "avatar_url": user.AvatarURL, "bio": user.Bio,
+		"created_at": user.CreatedAt,
+	}})
+}
+
+// ListUsers handles GET /api/v2/users
+func (h *V2Handler) ListUsers(c *gin.Context) {
+	page, limit := parsePagination(c)
+	keyword := c.Query("keyword")
+
+	users, total, err := h.userRepo.FindAll(page, limit, keyword)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "사용자 목록 조회 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{
+		Data: users,
+		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
+	})
+}
+
+// === Boards ===
+
+// ListBoards handles GET /api/v2/boards
+func (h *V2Handler) ListBoards(c *gin.Context) {
+	boards, err := h.boardRepo.FindAll()
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: boards})
+}
+
+// GetBoard handles GET /api/v2/boards/:slug
+func (h *V2Handler) GetBoard(c *gin.Context) {
+	slug := c.Param("slug")
+	board, err := h.boardRepo.FindBySlug(slug)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: board})
+}
+
+// === Posts ===
+
+// ListPosts handles GET /api/v2/boards/:slug/posts
+func (h *V2Handler) ListPosts(c *gin.Context) {
+	slug := c.Param("slug")
+	board, err := h.boardRepo.FindBySlug(slug)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+
+	page, limit := parsePagination(c)
+	posts, total, err := h.postRepo.FindByBoard(board.ID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 목록 조회 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{
+		Data: posts,
+		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
+	})
+}
+
+// GetPost handles GET /api/v2/boards/:slug/posts/:id
+func (h *V2Handler) GetPost(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		return
+	}
+
+	post, err := h.postRepo.FindByID(id)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
+		return
+	}
+
+	_ = h.postRepo.IncrementViewCount(id) //nolint:errcheck
+	c.JSON(http.StatusOK, common.APIResponse{Data: post})
+}
+
+// CreatePost handles POST /api/v2/boards/:slug/posts
+func (h *V2Handler) CreatePost(c *gin.Context) {
+	slug := c.Param("slug")
+	board, err := h.boardRepo.FindBySlug(slug)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+
+	var req struct {
+		Title   string `json:"title" binding:"required"`
+		Content string `json:"content" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	// TODO: get user_id from JWT claims
+	userID := uint64(1) // placeholder
+
+	post := &v2domain.V2Post{
+		BoardID: board.ID,
+		UserID:  userID,
+		Title:   req.Title,
+		Content: req.Content,
+		Status:  "published",
+	}
+	if err := h.postRepo.Create(post); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 작성 실패", err)
+		return
+	}
+	c.JSON(http.StatusCreated, common.APIResponse{Data: post})
+}
+
+// UpdatePost handles PUT /api/v2/boards/:slug/posts/:id
+func (h *V2Handler) UpdatePost(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		return
+	}
+
+	post, err := h.postRepo.FindByID(id)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
+		return
+	}
+
+	var req struct {
+		Title   string `json:"title"`
+		Content string `json:"content"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	if req.Title != "" {
+		post.Title = req.Title
+	}
+	if req.Content != "" {
+		post.Content = req.Content
+	}
+	if err := h.postRepo.Update(post); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 수정 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: post})
+}
+
+// DeletePost handles DELETE /api/v2/boards/:slug/posts/:id
+func (h *V2Handler) DeletePost(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		return
+	}
+	if err := h.postRepo.Delete(id); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 삭제 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "삭제 완료"}})
+}
+
+// === Comments ===
+
+// ListComments handles GET /api/v2/boards/:slug/posts/:id/comments
+func (h *V2Handler) ListComments(c *gin.Context) {
+	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		return
+	}
+
+	page, limit := parsePagination(c)
+	comments, total, err := h.commentRepo.FindByPost(postID, page, limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 목록 조회 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{
+		Data: comments,
+		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
+	})
+}
+
+// CreateComment handles POST /api/v2/boards/:slug/posts/:id/comments
+func (h *V2Handler) CreateComment(c *gin.Context) {
+	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		return
+	}
+
+	var req struct {
+		Content  string  `json:"content" binding:"required"`
+		ParentID *uint64 `json:"parent_id,omitempty"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	// TODO: get user_id from JWT claims
+	userID := uint64(1)
+
+	comment := &v2domain.V2Comment{
+		PostID:   postID,
+		UserID:   userID,
+		ParentID: req.ParentID,
+		Content:  req.Content,
+		Status:   "active",
+	}
+	if req.ParentID != nil {
+		comment.Depth = 1
+	}
+
+	if err := h.commentRepo.Create(comment); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 작성 실패", err)
+		return
+	}
+	c.JSON(http.StatusCreated, common.APIResponse{Data: comment})
+}
+
+// DeleteComment handles DELETE /api/v2/boards/:slug/posts/:post_id/comments/:id
+func (h *V2Handler) DeleteComment(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("comment_id"), 10, 64)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 댓글 ID", err)
+		return
+	}
+	if err := h.commentRepo.Delete(id); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 삭제 실패", err)
+		return
+	}
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "삭제 완료"}})
+}
+
+// === Helpers ===
+
+func parsePagination(c *gin.Context) (int, int) {
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit := 20
+	if l, err := strconv.Atoi(c.Query("per_page")); err == nil && l > 0 && l <= 100 {
+		limit = l
+	}
+	return page, limit
+}

--- a/internal/repository/v2/board_repo.go
+++ b/internal/repository/v2/board_repo.go
@@ -1,0 +1,55 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// BoardRepository v2 board data access
+type BoardRepository interface {
+	FindByID(id uint64) (*v2.V2Board, error)
+	FindBySlug(slug string) (*v2.V2Board, error)
+	FindAll() ([]*v2.V2Board, error)
+	Create(board *v2.V2Board) error
+	Update(board *v2.V2Board) error
+	Delete(id uint64) error
+}
+
+type boardRepository struct {
+	db *gorm.DB
+}
+
+// NewBoardRepository creates a new v2 BoardRepository
+func NewBoardRepository(db *gorm.DB) BoardRepository {
+	return &boardRepository{db: db}
+}
+
+func (r *boardRepository) FindByID(id uint64) (*v2.V2Board, error) {
+	var board v2.V2Board
+	err := r.db.Where("id = ?", id).First(&board).Error
+	return &board, err
+}
+
+func (r *boardRepository) FindBySlug(slug string) (*v2.V2Board, error) {
+	var board v2.V2Board
+	err := r.db.Where("slug = ?", slug).First(&board).Error
+	return &board, err
+}
+
+func (r *boardRepository) FindAll() ([]*v2.V2Board, error) {
+	var boards []*v2.V2Board
+	err := r.db.Where("is_active = ?", true).Order("order_num ASC").Find(&boards).Error
+	return boards, err
+}
+
+func (r *boardRepository) Create(board *v2.V2Board) error {
+	return r.db.Create(board).Error
+}
+
+func (r *boardRepository) Update(board *v2.V2Board) error {
+	return r.db.Save(board).Error
+}
+
+func (r *boardRepository) Delete(id uint64) error {
+	return r.db.Delete(&v2.V2Board{}, id).Error
+}

--- a/internal/repository/v2/comment_repo.go
+++ b/internal/repository/v2/comment_repo.go
@@ -1,0 +1,57 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// CommentRepository v2 comment data access
+type CommentRepository interface {
+	FindByID(id uint64) (*v2.V2Comment, error)
+	FindByPost(postID uint64, page, limit int) ([]*v2.V2Comment, int64, error)
+	Create(comment *v2.V2Comment) error
+	Update(comment *v2.V2Comment) error
+	Delete(id uint64) error
+}
+
+type commentRepository struct {
+	db *gorm.DB
+}
+
+// NewCommentRepository creates a new v2 CommentRepository
+func NewCommentRepository(db *gorm.DB) CommentRepository {
+	return &commentRepository{db: db}
+}
+
+func (r *commentRepository) FindByID(id uint64) (*v2.V2Comment, error) {
+	var comment v2.V2Comment
+	err := r.db.Where("id = ? AND status = 'active'", id).First(&comment).Error
+	return &comment, err
+}
+
+func (r *commentRepository) FindByPost(postID uint64, page, limit int) ([]*v2.V2Comment, int64, error) {
+	var comments []*v2.V2Comment
+	var total int64
+
+	query := r.db.Model(&v2.V2Comment{}).Where("post_id = ? AND status = 'active'", postID)
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("id ASC").Offset(offset).Limit(limit).Find(&comments).Error; err != nil {
+		return nil, 0, err
+	}
+	return comments, total, nil
+}
+
+func (r *commentRepository) Create(comment *v2.V2Comment) error {
+	return r.db.Create(comment).Error
+}
+
+func (r *commentRepository) Update(comment *v2.V2Comment) error {
+	return r.db.Save(comment).Error
+}
+
+func (r *commentRepository) Delete(id uint64) error {
+	return r.db.Model(&v2.V2Comment{}).Where("id = ?", id).Update("status", "deleted").Error
+}

--- a/internal/repository/v2/post_repo.go
+++ b/internal/repository/v2/post_repo.go
@@ -1,0 +1,63 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// PostRepository v2 post data access
+type PostRepository interface {
+	FindByID(id uint64) (*v2.V2Post, error)
+	FindByBoard(boardID uint64, page, limit int) ([]*v2.V2Post, int64, error)
+	Create(post *v2.V2Post) error
+	Update(post *v2.V2Post) error
+	Delete(id uint64) error
+	IncrementViewCount(id uint64) error
+}
+
+type postRepository struct {
+	db *gorm.DB
+}
+
+// NewPostRepository creates a new v2 PostRepository
+func NewPostRepository(db *gorm.DB) PostRepository {
+	return &postRepository{db: db}
+}
+
+func (r *postRepository) FindByID(id uint64) (*v2.V2Post, error) {
+	var post v2.V2Post
+	err := r.db.Where("id = ? AND status != 'deleted'", id).First(&post).Error
+	return &post, err
+}
+
+func (r *postRepository) FindByBoard(boardID uint64, page, limit int) ([]*v2.V2Post, int64, error) {
+	var posts []*v2.V2Post
+	var total int64
+
+	query := r.db.Model(&v2.V2Post{}).Where("board_id = ? AND status = 'published'", boardID)
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("is_notice DESC, id DESC").Offset(offset).Limit(limit).Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+	return posts, total, nil
+}
+
+func (r *postRepository) Create(post *v2.V2Post) error {
+	return r.db.Create(post).Error
+}
+
+func (r *postRepository) Update(post *v2.V2Post) error {
+	return r.db.Save(post).Error
+}
+
+func (r *postRepository) Delete(id uint64) error {
+	return r.db.Model(&v2.V2Post{}).Where("id = ?", id).Update("status", "deleted").Error
+}
+
+func (r *postRepository) IncrementViewCount(id uint64) error {
+	return r.db.Model(&v2.V2Post{}).Where("id = ?", id).
+		UpdateColumn("view_count", gorm.Expr("view_count + 1")).Error
+}

--- a/internal/repository/v2/user_repo.go
+++ b/internal/repository/v2/user_repo.go
@@ -1,0 +1,70 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// UserRepository v2 user data access
+type UserRepository interface {
+	FindByID(id uint64) (*v2.V2User, error)
+	FindByUsername(username string) (*v2.V2User, error)
+	FindByEmail(email string) (*v2.V2User, error)
+	Create(user *v2.V2User) error
+	Update(user *v2.V2User) error
+	FindAll(page, limit int, keyword string) ([]*v2.V2User, int64, error)
+}
+
+type userRepository struct {
+	db *gorm.DB
+}
+
+// NewUserRepository creates a new v2 UserRepository
+func NewUserRepository(db *gorm.DB) UserRepository {
+	return &userRepository{db: db}
+}
+
+func (r *userRepository) FindByID(id uint64) (*v2.V2User, error) {
+	var user v2.V2User
+	err := r.db.Where("id = ?", id).First(&user).Error
+	return &user, err
+}
+
+func (r *userRepository) FindByUsername(username string) (*v2.V2User, error) {
+	var user v2.V2User
+	err := r.db.Where("username = ?", username).First(&user).Error
+	return &user, err
+}
+
+func (r *userRepository) FindByEmail(email string) (*v2.V2User, error) {
+	var user v2.V2User
+	err := r.db.Where("email = ?", email).First(&user).Error
+	return &user, err
+}
+
+func (r *userRepository) Create(user *v2.V2User) error {
+	return r.db.Create(user).Error
+}
+
+func (r *userRepository) Update(user *v2.V2User) error {
+	return r.db.Save(user).Error
+}
+
+func (r *userRepository) FindAll(page, limit int, keyword string) ([]*v2.V2User, int64, error) {
+	var users []*v2.V2User
+	var total int64
+
+	query := r.db.Model(&v2.V2User{})
+	if keyword != "" {
+		like := "%" + keyword + "%"
+		query = query.Where("username LIKE ? OR nickname LIKE ? OR email LIKE ?", like, like, like)
+	}
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("id DESC").Offset(offset).Limit(limit).Find(&users).Error; err != nil {
+		return nil, 0, err
+	}
+	return users, total, nil
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -43,8 +43,13 @@ func Setup(
 	adminHandler *handler.AdminHandler,
 	cfg *config.Config,
 ) {
-	// Global middleware for damoang_jwt cookie authentication
+	// 레거시 API (그누보드 DB 기반) - /api/v1 및 /api/v2 동시 서빙
+	// /api/v2는 프론트엔드 전환 완료 전까지 레거시로 유지
 	api := router.Group("/api/v2", middleware.DamoangCookieAuth(damoangJWT, cfg))
+
+	// /api/v1 별칭 — 레거시 g5_* DB 기반 (주요 엔드포인트만)
+	apiV1 := router.Group("/api/v1", middleware.DamoangCookieAuth(damoangJWT, cfg))
+	_ = apiV1 // v1 라우트는 Phase 10에서 프론트 전환 후 등록
 
 	// Authentication endpoints (no auth required)
 	auth := api.Group("/auth")

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -1,0 +1,36 @@
+package v2
+
+import (
+	v2handler "github.com/damoang/angple-backend/internal/handler/v2"
+	"github.com/gin-gonic/gin"
+)
+
+// Setup configures v2 API routes (new DB schema)
+func Setup(router *gin.Engine, h *v2handler.V2Handler) {
+	api := router.Group("/api/v2-next")
+
+	// Users
+	users := api.Group("/users")
+	users.GET("", h.ListUsers)
+	users.GET("/:id", h.GetUser)
+	users.GET("/username/:username", h.GetUserByUsername)
+
+	// Boards
+	boards := api.Group("/boards")
+	boards.GET("", h.ListBoards)
+	boards.GET("/:slug", h.GetBoard)
+
+	// Posts (nested under boards)
+	boardPosts := boards.Group("/:slug/posts")
+	boardPosts.GET("", h.ListPosts)
+	boardPosts.POST("", h.CreatePost)
+	boardPosts.GET("/:id", h.GetPost)
+	boardPosts.PUT("/:id", h.UpdatePost)
+	boardPosts.DELETE("/:id", h.DeletePost)
+
+	// Comments (nested under posts)
+	comments := boardPosts.Group("/:id/comments")
+	comments.GET("", h.ListComments)
+	comments.POST("", h.CreateComment)
+	comments.DELETE("/:comment_id", h.DeleteComment)
+}


### PR DESCRIPTION
## Summary
- v2 Repository 4종 (user, post, comment, board) — `v2_` 접두사 테이블 기반 GORM 구현
- v2 Handler: Users/Boards/Posts/Comments CRUD 전체 엔드포인트
- v2 Routes: `/api/v2-next` 경로로 레거시 `/api/v2`와 충돌 없이 공존
- 레거시 `/api/v1` 별칭 그룹 준비 (Phase 10 프론트 전환용)
- main.go DI 배선 완료

## Test plan
- [ ] `go build ./...` 성공 확인
- [ ] `/api/v2-next/boards` 조회 테스트
- [ ] `/api/v2-next/users` 조회 테스트
- [ ] 레거시 `/api/v2/boards` 기존 동작 영향 없음 확인