### PR TITLE
feat(v2): v2 표준 응답 형식 + 프론트엔드 전환 가이드 (Phase 10)

### DIFF
--- a/docs/v1-to-v2-migration-guide.md
+++ b/docs/v1-to-v2-migration-guide.md
@@ -1,0 +1,224 @@
+# v1 → v2 API 전환 가이드
+
+> 대상: angple 프론트엔드 개발자
+> 작성일: 2026-02-02
+
+---
+
+## 1. 개요
+
+| 항목 | v1 (레거시) | v2 (신규) |
+|------|------------|----------|
+| Base URL | `/api/v2` | `/api/v2-next` (테스트) → 최종 `/api/v2` |
+| DB | 그누보드 `g5_*` 테이블 | 신규 `v2_*` 테이블 |
+| 게시판 식별 | `board_id` (문자열, e.g. `"free"`) | `slug` (문자열, e.g. `"free"`) |
+| 응답 형식 | `{"data": ..., "meta": {...}}` | `{"success": true, "data": ..., "meta": {...}}` |
+| 페이지네이션 | `limit` | `per_page` + `total_pages` |
+| 인증 | `damoang_jwt` 쿠키 | `damoang_jwt` 쿠키 (동일) |
+
+---
+
+## 2. 응답 형식 변경
+
+### v1 성공 응답
+```json
+{
+  "data": { "id": 1, "title": "..." },
+  "meta": { "page": 1, "limit": 20, "total": 150 }
+}
+```
+
+### v2 성공 응답
+```json
+{
+  "success": true,
+  "data": { "id": 1, "title": "..." },
+  "meta": { "page": 1, "per_page": 20, "total": 150, "total_pages": 8 }
+}
+```
+
+### v1 에러 응답
+```json
+{
+  "error": { "code": "NOT_FOUND", "message": "...", "details": "..." }
+}
+```
+
+### v2 에러 응답
+```json
+{
+  "success": false,
+  "error": { "code": "NOT_FOUND", "message": "...", "details": "..." }
+}
+```
+
+**프론트엔드 변경점:**
+1. 응답에서 `success` 필드로 성공/실패 판별 가능
+2. 페이지네이션: `meta.limit` → `meta.per_page`, `meta.total_pages` 추가
+3. 에러 응답에도 `success: false` 포함
+
+---
+
+## 3. 엔드포인트 매핑
+
+### 3.1 게시판
+
+| v1 | v2 | 비고 |
+|----|-----|------|
+| `GET /api/v2/boards` | `GET /api/v2-next/boards` | 응답 필드 변경 |
+| `GET /api/v2/boards/:board_id` | `GET /api/v2-next/boards/:slug` | 파라미터명 변경 |
+
+### 3.2 게시글
+
+| v1 | v2 | 비고 |
+|----|-----|------|
+| `GET /api/v2/boards/:board_id/posts` | `GET /api/v2-next/boards/:slug/posts` | 파라미터명 변경 |
+| `GET /api/v2/boards/:board_id/posts/:id` | `GET /api/v2-next/boards/:slug/posts/:id` | |
+| `POST /api/v2/boards/:board_id/posts` | `POST /api/v2-next/boards/:slug/posts` | |
+| `PUT /api/v2/boards/:board_id/posts/:id` | `PUT /api/v2-next/boards/:slug/posts/:id` | |
+| `DELETE /api/v2/boards/:board_id/posts/:id` | `DELETE /api/v2-next/boards/:slug/posts/:id` | |
+
+### 3.3 댓글
+
+| v1 | v2 | 비고 |
+|----|-----|------|
+| `GET .../posts/:id/comments` | `GET .../posts/:id/comments` | 동일 구조 |
+| `POST .../posts/:id/comments` | `POST .../posts/:id/comments` | |
+| `DELETE .../comments/:comment_id` | `DELETE .../comments/:comment_id` | |
+
+### 3.4 사용자
+
+| v1 | v2 | 비고 |
+|----|-----|------|
+| (없음) | `GET /api/v2-next/users` | v2 전용 |
+| (없음) | `GET /api/v2-next/users/:id` | v2 전용 |
+| (없음) | `GET /api/v2-next/users/username/:username` | v2 전용 |
+
+### 3.5 v2 미구현 (v1 전용, 레거시 유지)
+
+다음 API는 아직 v2로 전환되지 않았습니다. 전환 완료 전까지 v1 엔드포인트를 계속 사용하세요:
+
+- 인증: `/api/v2/auth/*`
+- 메뉴: `/api/v2/menus/*`
+- 사이트: `/api/v2/sites/*`
+- 회원 검증: `/api/v2/members/check-*`
+- 스크랩, 차단, 쪽지, 메모
+- 알림, WebSocket
+- 신고, 이용제한
+- 추천글, 갤러리, 통합검색
+- 관리자 API
+- 플러그인 API
+
+---
+
+## 4. 데이터 모델 변경
+
+### 게시글 (Post)
+
+| v1 필드 | v2 필드 | 비고 |
+|---------|---------|------|
+| `wr_id` (int) | `id` (uint64) | |
+| `wr_subject` | `title` | |
+| `wr_content` | `content` | |
+| `mb_id` (문자열) | `user_id` (uint64) | FK → v2_users |
+| `wr_hit` | `view_count` | |
+| `wr_good` | `like_count` | |
+| `wr_nogood` | `dislike_count` | |
+| `wr_datetime` | `created_at` | ISO 8601 |
+| (없음) | `status` | `published`, `draft`, `deleted` |
+| (게시판별 동적 테이블) | `board_id` (FK) | 단일 `v2_posts` 테이블 |
+
+### 댓글 (Comment)
+
+| v1 필드 | v2 필드 | 비고 |
+|---------|---------|------|
+| `wr_id` | `id` | |
+| `wr_content` | `content` | |
+| `mb_id` | `user_id` (FK) | |
+| `wr_parent` | `post_id` (FK) | |
+| `wr_comment_reply` | `parent_id` (FK) | 대댓글 |
+| (없음) | `depth` | 댓글 깊이 |
+| (없음) | `status` | `active`, `deleted` |
+
+### 사용자 (User)
+
+| v1 필드 (g5_member) | v2 필드 (v2_users) | 비고 |
+|--------------------|-------------------|------|
+| `mb_id` (문자열 PK) | `id` (uint64 PK) | 숫자 PK로 변경 |
+| `mb_id` | `username` | |
+| `mb_nick` | `nickname` | |
+| `mb_email` | `email` | |
+| `mb_level` | `level` | |
+| `mb_point` | `points` | |
+| (없음) | `status` | `active`, `inactive`, `banned` |
+| (없음) | `avatar_url` | |
+| (없음) | `bio` | |
+
+---
+
+## 5. 전환 절차 (프론트엔드)
+
+### Step 1: API 클라이언트 추상화
+
+```typescript
+// api-client.ts
+const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION || 'v2'; // 'v2' = legacy, 'v2-next' = new
+
+export const apiBase = `/api/${API_VERSION}`;
+
+export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${apiBase}${path}`, {
+    credentials: 'include',
+    ...options,
+  });
+  const json = await res.json();
+
+  // v2-next는 success 필드 있음
+  if ('success' in json && !json.success) {
+    throw new ApiError(json.error);
+  }
+
+  return json.data;
+}
+```
+
+### Step 2: 점진적 전환
+
+1. 환경변수로 API 버전 전환 가능하게 구성
+2. 페이지/컴포넌트 단위로 v2-next 테스트
+3. 전체 전환 후 `API_VERSION`을 `v2-next`로 고정
+
+### Step 3: 최종 정리
+
+프론트엔드가 100% v2-next 사용 확인 후:
+- 백엔드: 레거시 `/api/v2` → `/api/v1`으로 이동
+- 백엔드: `/api/v2-next` → `/api/v2`로 승격
+- 프론트엔드: `API_VERSION`을 `v2`로 변경
+
+---
+
+## 6. 쿼리 파라미터 변경
+
+| 용도 | v1 | v2 |
+|------|-----|-----|
+| 페이지 번호 | `?page=1` | `?page=1` (동일) |
+| 페이지 크기 | `?per_page=20` | `?per_page=20` (동일) |
+| 검색 키워드 | `?keyword=` 또는 `?q=` | `?keyword=` (통일) |
+| 정렬 | (API마다 다름) | `?sort=created_at&order=desc` |
+
+---
+
+## 7. 에러 처리
+
+v2에서는 HTTP 상태 코드와 함께 구조화된 에러 코드를 반환합니다:
+
+| 코드 | HTTP | 의미 |
+|------|------|------|
+| `BAD_REQUEST` | 400 | 잘못된 파라미터 |
+| `UNAUTHORIZED` | 401 | 인증 필요 |
+| `FORBIDDEN` | 403 | 권한 없음 |
+| `NOT_FOUND` | 404 | 리소스 없음 |
+| `CONFLICT` | 409 | 중복 |
+| `INTERNAL_SERVER_ERROR` | 500 | 서버 오류 |
+
+프론트엔드에서 `response.success === false`일 때 `response.error.code`로 분기 처리하면 됩니다.

--- a/internal/common/v2_response.go
+++ b/internal/common/v2_response.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// V2Response v2 API 표준 응답 형식 (core-spec-v1.0.md §4.3)
+type V2Response struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Meta    *V2Meta     `json:"meta,omitempty"`
+	Error   *V2Error    `json:"error,omitempty"`
+}
+
+// V2Meta v2 페이지네이션 메타 (core-spec-v1.0.md §4.4)
+type V2Meta struct {
+	Page       int   `json:"page"`
+	PerPage    int   `json:"per_page"`
+	Total      int64 `json:"total"`
+	TotalPages int64 `json:"total_pages"`
+}
+
+// V2Error v2 에러 응답 (core-spec-v1.0.md §4.5)
+type V2Error struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+// NewV2Meta creates V2Meta with computed total_pages
+func NewV2Meta(page, perPage int, total int64) *V2Meta {
+	totalPages := total / int64(perPage)
+	if total%int64(perPage) > 0 {
+		totalPages++
+	}
+	return &V2Meta{
+		Page:       page,
+		PerPage:    perPage,
+		Total:      total,
+		TotalPages: totalPages,
+	}
+}
+
+// V2Success returns a v2 success response
+func V2Success(c *gin.Context, data interface{}) {
+	c.JSON(http.StatusOK, V2Response{
+		Success: true,
+		Data:    data,
+	})
+}
+
+// V2SuccessWithMeta returns a v2 success response with pagination
+func V2SuccessWithMeta(c *gin.Context, data interface{}, meta *V2Meta) {
+	c.JSON(http.StatusOK, V2Response{
+		Success: true,
+		Data:    data,
+		Meta:    meta,
+	})
+}
+
+// V2Created returns a v2 201 Created response
+func V2Created(c *gin.Context, data interface{}) {
+	c.JSON(http.StatusCreated, V2Response{
+		Success: true,
+		Data:    data,
+	})
+}
+
+// V2ErrorResponse returns a v2 error response
+func V2ErrorResponse(c *gin.Context, status int, message string, err error) {
+	v2Err := &V2Error{
+		Code:    getErrorCode(status),
+		Message: message,
+	}
+	if err != nil {
+		v2Err.Details = err.Error()
+	}
+	c.JSON(status, V2Response{
+		Success: false,
+		Error:   v2Err,
+	})
+}

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -35,126 +35,112 @@ func NewV2Handler(
 
 // === Users ===
 
-// GetUser handles GET /api/v2/users/:id
+// GetUser handles GET /api/v2-next/users/:id
 func (h *V2Handler) GetUser(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 사용자 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 사용자 ID", err)
 		return
 	}
 	user, err := h.userRepo.FindByID(id)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
-		"id": user.ID, "username": user.Username, "nickname": user.Nickname,
-		"level": user.Level, "status": user.Status, "avatar_url": user.AvatarURL,
-		"bio": user.Bio, "created_at": user.CreatedAt,
-	}})
+	common.V2Success(c, user)
 }
 
-// GetUserByUsername handles GET /api/v2/users/username/:username
+// GetUserByUsername handles GET /api/v2-next/users/username/:username
 func (h *V2Handler) GetUserByUsername(c *gin.Context) {
 	username := c.Param("username")
 	user, err := h.userRepo.FindByUsername(username)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{
-		"id": user.ID, "username": user.Username, "nickname": user.Nickname,
-		"level": user.Level, "avatar_url": user.AvatarURL, "bio": user.Bio,
-		"created_at": user.CreatedAt,
-	}})
+	common.V2Success(c, user)
 }
 
-// ListUsers handles GET /api/v2/users
+// ListUsers handles GET /api/v2-next/users
 func (h *V2Handler) ListUsers(c *gin.Context) {
-	page, limit := parsePagination(c)
+	page, perPage := parsePagination(c)
 	keyword := c.Query("keyword")
 
-	users, total, err := h.userRepo.FindAll(page, limit, keyword)
+	users, total, err := h.userRepo.FindAll(page, perPage, keyword)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "사용자 목록 조회 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "사용자 목록 조회 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{
-		Data: users,
-		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
-	})
+	common.V2SuccessWithMeta(c, users, common.NewV2Meta(page, perPage, total))
 }
 
 // === Boards ===
 
-// ListBoards handles GET /api/v2/boards
+// ListBoards handles GET /api/v2-next/boards
 func (h *V2Handler) ListBoards(c *gin.Context) {
 	boards, err := h.boardRepo.FindAll()
 	if err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: boards})
+	common.V2Success(c, boards)
 }
 
-// GetBoard handles GET /api/v2/boards/:slug
+// GetBoard handles GET /api/v2-next/boards/:slug
 func (h *V2Handler) GetBoard(c *gin.Context) {
 	slug := c.Param("slug")
 	board, err := h.boardRepo.FindBySlug(slug)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: board})
+	common.V2Success(c, board)
 }
 
 // === Posts ===
 
-// ListPosts handles GET /api/v2/boards/:slug/posts
+// ListPosts handles GET /api/v2-next/boards/:slug/posts
 func (h *V2Handler) ListPosts(c *gin.Context) {
 	slug := c.Param("slug")
 	board, err := h.boardRepo.FindBySlug(slug)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
 		return
 	}
 
-	page, limit := parsePagination(c)
-	posts, total, err := h.postRepo.FindByBoard(board.ID, page, limit)
+	page, perPage := parsePagination(c)
+	posts, total, err := h.postRepo.FindByBoard(board.ID, page, perPage)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 목록 조회 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 목록 조회 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{
-		Data: posts,
-		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
-	})
+	common.V2SuccessWithMeta(c, posts, common.NewV2Meta(page, perPage, total))
 }
 
-// GetPost handles GET /api/v2/boards/:slug/posts/:id
+// GetPost handles GET /api/v2-next/boards/:slug/posts/:id
 func (h *V2Handler) GetPost(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
 		return
 	}
 
 	post, err := h.postRepo.FindByID(id)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
 		return
 	}
 
 	_ = h.postRepo.IncrementViewCount(id) //nolint:errcheck
-	c.JSON(http.StatusOK, common.APIResponse{Data: post})
+	common.V2Success(c, post)
 }
 
-// CreatePost handles POST /api/v2/boards/:slug/posts
+// CreatePost handles POST /api/v2-next/boards/:slug/posts
 func (h *V2Handler) CreatePost(c *gin.Context) {
 	slug := c.Param("slug")
 	board, err := h.boardRepo.FindBySlug(slug)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
 		return
 	}
 
@@ -163,7 +149,7 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 		Content string `json:"content" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
 		return
 	}
 
@@ -178,23 +164,23 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 		Status:  "published",
 	}
 	if err := h.postRepo.Create(post); err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 작성 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 작성 실패", err)
 		return
 	}
-	c.JSON(http.StatusCreated, common.APIResponse{Data: post})
+	common.V2Created(c, post)
 }
 
-// UpdatePost handles PUT /api/v2/boards/:slug/posts/:id
+// UpdatePost handles PUT /api/v2-next/boards/:slug/posts/:id
 func (h *V2Handler) UpdatePost(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
 		return
 	}
 
 	post, err := h.postRepo.FindByID(id)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
 		return
 	}
 
@@ -203,7 +189,7 @@ func (h *V2Handler) UpdatePost(c *gin.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
 		return
 	}
 
@@ -214,53 +200,50 @@ func (h *V2Handler) UpdatePost(c *gin.Context) {
 		post.Content = req.Content
 	}
 	if err := h.postRepo.Update(post); err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 수정 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 수정 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: post})
+	common.V2Success(c, post)
 }
 
-// DeletePost handles DELETE /api/v2/boards/:slug/posts/:id
+// DeletePost handles DELETE /api/v2-next/boards/:slug/posts/:id
 func (h *V2Handler) DeletePost(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
 		return
 	}
 	if err := h.postRepo.Delete(id); err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "게시글 삭제 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 삭제 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "삭제 완료"}})
+	common.V2Success(c, gin.H{"message": "삭제 완료"})
 }
 
 // === Comments ===
 
-// ListComments handles GET /api/v2/boards/:slug/posts/:id/comments
+// ListComments handles GET /api/v2-next/boards/:slug/posts/:id/comments
 func (h *V2Handler) ListComments(c *gin.Context) {
 	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
 		return
 	}
 
-	page, limit := parsePagination(c)
-	comments, total, err := h.commentRepo.FindByPost(postID, page, limit)
+	page, perPage := parsePagination(c)
+	comments, total, err := h.commentRepo.FindByPost(postID, page, perPage)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 목록 조회 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 목록 조회 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{
-		Data: comments,
-		Meta: &common.Meta{Page: page, Limit: limit, Total: total},
-	})
+	common.V2SuccessWithMeta(c, comments, common.NewV2Meta(page, perPage, total))
 }
 
-// CreateComment handles POST /api/v2/boards/:slug/posts/:id/comments
+// CreateComment handles POST /api/v2-next/boards/:slug/posts/:id/comments
 func (h *V2Handler) CreateComment(c *gin.Context) {
 	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
 		return
 	}
 
@@ -269,7 +252,7 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		ParentID *uint64 `json:"parent_id,omitempty"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
 		return
 	}
 
@@ -288,24 +271,24 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 	}
 
 	if err := h.commentRepo.Create(comment); err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 작성 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 작성 실패", err)
 		return
 	}
-	c.JSON(http.StatusCreated, common.APIResponse{Data: comment})
+	common.V2Created(c, comment)
 }
 
-// DeleteComment handles DELETE /api/v2/boards/:slug/posts/:post_id/comments/:id
+// DeleteComment handles DELETE /api/v2-next/boards/:slug/posts/:post_id/comments/:comment_id
 func (h *V2Handler) DeleteComment(c *gin.Context) {
 	id, err := strconv.ParseUint(c.Param("comment_id"), 10, 64)
 	if err != nil {
-		common.ErrorResponse(c, http.StatusBadRequest, "잘못된 댓글 ID", err)
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 댓글 ID", err)
 		return
 	}
 	if err := h.commentRepo.Delete(id); err != nil {
-		common.ErrorResponse(c, http.StatusInternalServerError, "댓글 삭제 실패", err)
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 삭제 실패", err)
 		return
 	}
-	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "삭제 완료"}})
+	common.V2Success(c, gin.H{"message": "삭제 완료"})
 }
 
 // === Helpers ===
@@ -315,9 +298,9 @@ func parsePagination(c *gin.Context) (int, int) {
 	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
 		page = p
 	}
-	limit := 20
+	perPage := 20
 	if l, err := strconv.Atoi(c.Query("per_page")); err == nil && l > 0 && l <= 100 {
-		limit = l
+		perPage = l
 	}
-	return page, limit
+	return page, perPage
 }


### PR DESCRIPTION
## Summary
- `common.V2Response` 표준 응답 형식 추가 (`success` 필드, `per_page`, `total_pages`)
- v2 Handler를 V2Response/V2ErrorResponse로 전환 (core-spec-v1.0.md §4.3 준수)
- `docs/v1-to-v2-migration-guide.md` — 프론트엔드 전환 가이드 (엔드포인트 매핑, 데이터 모델 변경, 전환 절차)

## Test plan
- [ ] `go build ./...` 성공 확인
- [ ] v2-next API 응답에 `success: true` 필드 포함 확인
- [ ] v2-next 목록 API 응답에 `total_pages` 포함 확인
- [ ] 레거시 `/api/v2` 응답 형식 변경 없음 확인