### PR TITLE
feat(routing): v1/v2 URL 정리 — 레거시→v1, 신규→v2 (Phase 12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ make deps                 # 의존성 다운로드
 curl http://localhost:8081/health
 
 # 로그인 테스트
-curl -X POST http://localhost:8081/api/v2/auth/login \
+curl -X POST http://localhost:8081/api/v1/auth/login \
   -H "Content-Type: application/json" \
   -d '{"user_id":"user1","password":"test1234"}'
 ```
@@ -317,10 +317,10 @@ db.Exec("SET SESSION sql_mode = ''")
 
 ## API 버전 관리
 
-현재 버전: `/api/v2`
+v1(레거시): `/api/v1`, v2(신규): `/api/v2`
 
 ```go
-api := app.Group("/api/v2")
+api := app.Group("/api/v1")  // 레거시 (그누보드 DB)
 
 // 인증
 api.Group("/auth")
@@ -455,7 +455,7 @@ db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
 
 3. **JWT 토큰 만료**
    - 증상: 401 Unauthorized
-   - 해결: `/api/v2/auth/refresh`로 토큰 재발급
+   - 해결: `/api/v1/auth/refresh`로 토큰 재발급
 
 ## 중요 참고 문서
 
@@ -472,10 +472,10 @@ db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
 
 | 버전 | 데이터베이스 | 상태 |
 |------|-------------|------|
-| **v1** (`/api/v2/*`) | 그누보드 DB (g5_*) | 현재 개발 중 |
-| **v2** (계획) | 신규 설계 DB | 추후 구현 |
+| **v1** (`/api/v1/*`) | 그누보드 DB (g5_*) | Deprecated (Sunset: 2026-08-01) |
+| **v2** (`/api/v2/*`) | 신규 설계 DB (v2_*) | 활성 개발 중 |
 
-> **참고**: 현재 URL은 `/api/v2`이지만 실제로는 그누보드 DB를 사용하는 v1 역할입니다.
-> 추후 정리 시 `/api/v1`으로 변경 예정.
+> v1은 레거시 그누보드 DB 기반이며 deprecation 헤더가 포함됩니다.
+> 전환 가이드: `docs/v1-to-v2-migration-guide.md`
 
 자세한 내용은 `docs/specs/api-versioning.md` 참고.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -49,7 +49,7 @@ import (
 // @license.name    Proprietary
 //
 // @host            localhost:8082
-// @BasePath        /api/v2
+// @BasePath        /api/v1
 //
 // @securityDefinitions.apikey BearerAuth
 // @in header
@@ -319,23 +319,24 @@ func main() {
 	v1UsageTracker := middleware.NewAPIUsageTracker()
 
 	// v1 사용량 모니터링 엔드포인트 (관리자용)
-	router.GET("/api/v2-next/admin/v1-usage", func(c *gin.Context) {
+	router.GET("/api/v2/admin/v1-usage", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"tracking_since": v1UsageTracker.StartedAt(),
 			"total_calls":    v1UsageTracker.TotalCalls(),
 			"endpoints":      v1UsageTracker.GetStats(),
 		})
 	})
-	router.POST("/api/v2-next/admin/v1-usage/reset", func(c *gin.Context) {
+	router.POST("/api/v2/admin/v1-usage/reset", func(c *gin.Context) {
 		v1UsageTracker.Reset()
 		c.JSON(http.StatusOK, gin.H{"message": "사용량 카운터 초기화 완료"})
 	})
 
-	// API v2 라우트 (only if DB is connected)
+	// 라우트 등록 (only if DB is connected)
 	if db != nil {
+		// v1 레거시 API (그누보드 DB 기반) → /api/v1
 		routes.Setup(router, postHandler, commentHandler, authHandler, menuHandler, siteHandler, boardHandler, memberHandler, autosaveHandler, filterHandler, tokenHandler, memoHandler, reactionHandler, reportHandler, dajoongiHandler, promotionHandler, bannerHandler, jwtManager, damoangJWT, goodHandler, recommendedHandler, notificationHandler, memberProfileHandler, fileHandler, scrapHandler, blockHandler, messageHandler, wsHandler, disciplineHandler, galleryHandler, adminHandler, v1UsageTracker, cfg)
 
-		// v2 신규 API (v2_ 테이블 기반) — /api/v2-next 에서 테스트, 추후 /api/v2로 전환
+		// v2 API (v2_ 테이블 기반) → /api/v2
 		v2UserRepo := v2repo.NewUserRepository(db)
 		v2PostRepo := v2repo.NewPostRepository(db)
 		v2CommentRepo := v2repo.NewCommentRepository(db)
@@ -401,7 +402,7 @@ func main() {
 		permHandler := pluginstoreHandler.NewPermissionHandler(permSvc)
 
 		// Admin Plugin Store 라우트 등록
-		adminPlugins := router.Group("/api/v2/admin/plugins")
+		adminPlugins := router.Group("/api/v1/admin/plugins")
 		// TODO: 운영 환경에서는 admin 미들웨어 추가 필요
 		{
 			adminPlugins.GET("", storeHandler.ListPlugins)

--- a/docs/v1-to-v2-migration-guide.md
+++ b/docs/v1-to-v2-migration-guide.md
@@ -9,7 +9,7 @@
 
 | 항목 | v1 (레거시) | v2 (신규) |
 |------|------------|----------|
-| Base URL | `/api/v2` | `/api/v2-next` (테스트) → 최종 `/api/v2` |
+| Base URL | `/api/v1` (구 `/api/v2`) | `/api/v2` (구 `/api/v2`) |
 | DB | 그누보드 `g5_*` 테이블 | 신규 `v2_*` 테이블 |
 | 게시판 식별 | `board_id` (문자열, e.g. `"free"`) | `slug` (문자열, e.g. `"free"`) |
 | 응답 형식 | `{"data": ..., "meta": {...}}` | `{"success": true, "data": ..., "meta": {...}}` |
@@ -65,18 +65,18 @@
 
 | v1 | v2 | 비고 |
 |----|-----|------|
-| `GET /api/v2/boards` | `GET /api/v2-next/boards` | 응답 필드 변경 |
-| `GET /api/v2/boards/:board_id` | `GET /api/v2-next/boards/:slug` | 파라미터명 변경 |
+| `GET /api/v2/boards` | `GET /api/v2/boards` | 응답 필드 변경 |
+| `GET /api/v2/boards/:board_id` | `GET /api/v2/boards/:slug` | 파라미터명 변경 |
 
 ### 3.2 게시글
 
 | v1 | v2 | 비고 |
 |----|-----|------|
-| `GET /api/v2/boards/:board_id/posts` | `GET /api/v2-next/boards/:slug/posts` | 파라미터명 변경 |
-| `GET /api/v2/boards/:board_id/posts/:id` | `GET /api/v2-next/boards/:slug/posts/:id` | |
-| `POST /api/v2/boards/:board_id/posts` | `POST /api/v2-next/boards/:slug/posts` | |
-| `PUT /api/v2/boards/:board_id/posts/:id` | `PUT /api/v2-next/boards/:slug/posts/:id` | |
-| `DELETE /api/v2/boards/:board_id/posts/:id` | `DELETE /api/v2-next/boards/:slug/posts/:id` | |
+| `GET /api/v2/boards/:board_id/posts` | `GET /api/v2/boards/:slug/posts` | 파라미터명 변경 |
+| `GET /api/v2/boards/:board_id/posts/:id` | `GET /api/v2/boards/:slug/posts/:id` | |
+| `POST /api/v2/boards/:board_id/posts` | `POST /api/v2/boards/:slug/posts` | |
+| `PUT /api/v2/boards/:board_id/posts/:id` | `PUT /api/v2/boards/:slug/posts/:id` | |
+| `DELETE /api/v2/boards/:board_id/posts/:id` | `DELETE /api/v2/boards/:slug/posts/:id` | |
 
 ### 3.3 댓글
 
@@ -90,18 +90,18 @@
 
 | v1 | v2 | 비고 |
 |----|-----|------|
-| (없음) | `GET /api/v2-next/users` | v2 전용 |
-| (없음) | `GET /api/v2-next/users/:id` | v2 전용 |
-| (없음) | `GET /api/v2-next/users/username/:username` | v2 전용 |
+| (없음) | `GET /api/v2/users` | v2 전용 |
+| (없음) | `GET /api/v2/users/:id` | v2 전용 |
+| (없음) | `GET /api/v2/users/username/:username` | v2 전용 |
 
 ### 3.5 v2 미구현 (v1 전용, 레거시 유지)
 
 다음 API는 아직 v2로 전환되지 않았습니다. 전환 완료 전까지 v1 엔드포인트를 계속 사용하세요:
 
-- 인증: `/api/v2/auth/*`
-- 메뉴: `/api/v2/menus/*`
-- 사이트: `/api/v2/sites/*`
-- 회원 검증: `/api/v2/members/check-*`
+- 인증: `/api/v1/auth/*`
+- 메뉴: `/api/v1/menus/*`
+- 사이트: `/api/v1/sites/*`
+- 회원 검증: `/api/v1/members/check-*`
 - 스크랩, 차단, 쪽지, 메모
 - 알림, WebSocket
 - 신고, 이용제한
@@ -162,7 +162,7 @@
 
 ```typescript
 // api-client.ts
-const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION || 'v2'; // 'v2' = legacy, 'v2-next' = new
+const API_VERSION = process.env.NEXT_PUBLIC_API_VERSION || 'v1'; // 'v1' = legacy, 'v2' = new
 
 export const apiBase = `/api/${API_VERSION}`;
 
@@ -185,14 +185,13 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
 ### Step 2: 점진적 전환
 
 1. 환경변수로 API 버전 전환 가능하게 구성
-2. 페이지/컴포넌트 단위로 v2-next 테스트
-3. 전체 전환 후 `API_VERSION`을 `v2-next`로 고정
+2. 페이지/컴포넌트 단위로 v2 테스트
+3. 전체 전환 후 `API_VERSION`을 `v2`로 고정
 
-### Step 3: 최종 정리
+### Step 3: 최종 정리 (완료)
 
-프론트엔드가 100% v2-next 사용 확인 후:
-- 백엔드: 레거시 `/api/v2` → `/api/v1`으로 이동
-- 백엔드: `/api/v2-next` → `/api/v2`로 승격
+- ~~백엔드: 레거시 `/api/v2` → `/api/v1`으로 이동~~ ✅ Phase 12에서 완료
+- ~~백엔드: `/api/v2-next` → `/api/v2`로 승격~~ ✅ Phase 12에서 완료
 - 프론트엔드: `API_VERSION`을 `v2`로 변경
 
 ---

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -50,12 +50,8 @@ func Setup(
 		MigrationGuideURL: "https://github.com/damoang/angple-backend/blob/main/docs/v1-to-v2-migration-guide.md",
 	})
 
-	// 레거시 API (그누보드 DB 기반) - Deprecation 헤더 + 사용량 추적
-	api := router.Group("/api/v2", middleware.DamoangCookieAuth(damoangJWT, cfg), deprecationMW, v1UsageTracker.Track())
-
-	// /api/v1 별칭 — 레거시 g5_* DB 기반 (주요 엔드포인트만)
-	apiV1 := router.Group("/api/v1", middleware.DamoangCookieAuth(damoangJWT, cfg), deprecationMW, v1UsageTracker.Track())
-	_ = apiV1 // v1 라우트는 프론트 전환 후 등록
+	// 레거시 API (그누보드 DB 기반) → /api/v1 으로 이동, Deprecation 헤더 + 사용량 추적
+	api := router.Group("/api/v1", middleware.DamoangCookieAuth(damoangJWT, cfg), deprecationMW, v1UsageTracker.Track())
 
 	// Authentication endpoints (no auth required)
 	auth := api.Group("/auth")

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -7,7 +7,7 @@ import (
 
 // Setup configures v2 API routes (new DB schema)
 func Setup(router *gin.Engine, h *v2handler.V2Handler) {
-	api := router.Group("/api/v2-next")
+	api := router.Group("/api/v2")
 
 	// Users
 	users := api.Group("/users")


### PR DESCRIPTION
## Summary
- 레거시 API (그누보드 DB): `/api/v2` → **`/api/v1`** 으로 이동 (deprecation 헤더 유지)
- 신규 v2 API (v2_ 테이블): `/api/v2-next` → **`/api/v2`** 로 승격
- 플러그인 admin: `/api/v2/admin/plugins` → `/api/v1/admin/plugins`
- v1 사용량 모니터링: `/api/v2/admin/v1-usage`
- CLAUDE.md, migration guide 문서 URL 갱신

## Breaking Changes
- **모든 레거시 API URL이 `/api/v2/*` → `/api/v1/*` 으로 변경됨**
- 프론트엔드 API 클라이언트 base URL 업데이트 필요

## Test plan
- [ ] `go build ./...` 성공
- [ ] 레거시 API: `/api/v1/auth/me` 동작 확인
- [ ] 신규 v2 API: `/api/v2/boards` 동작 확인
- [ ] deprecation 헤더가 `/api/v1` 응답에만 포함 확인