### PR TITLE
feat: 멀티테넌트 지원 (Phase 14)

### DIFF
--- a/internal/handler/tenant_handler.go
+++ b/internal/handler/tenant_handler.go
@@ -1,0 +1,156 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+func parseIntQuery(c *gin.Context, key string, defaultVal int) int {
+	if v, err := strconv.Atoi(c.Query(key)); err == nil && v > 0 {
+		return v
+	}
+	return defaultVal
+}
+
+// TenantHandler handles tenant management admin API
+type TenantHandler struct {
+	tenantService *service.TenantService
+}
+
+// NewTenantHandler creates a new TenantHandler
+func NewTenantHandler(tenantService *service.TenantService) *TenantHandler {
+	return &TenantHandler{tenantService: tenantService}
+}
+
+// ListTenants godoc
+// @Summary 테넌트 목록 (관리자)
+// @Tags admin-tenants
+// @Param page query int false "페이지" default(1)
+// @Param per_page query int false "페이지당 항목" default(20)
+// @Param status query string false "상태 필터 (active, suspended, all)" default(all)
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants [get]
+func (h *TenantHandler) ListTenants(c *gin.Context) {
+	page := parseIntQuery(c, "page", 1)
+	perPage := parseIntQuery(c, "per_page", 20)
+	status := c.DefaultQuery("status", "all")
+
+	tenants, total, err := h.tenantService.ListTenants(c.Request.Context(), page, perPage, status)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "테넌트 목록 조회 실패", err)
+		return
+	}
+	common.V2SuccessWithMeta(c, tenants, common.NewV2Meta(page, perPage, total))
+}
+
+// GetTenant godoc
+// @Summary 테넌트 상세 (관리자)
+// @Tags admin-tenants
+// @Param id path string true "사이트 ID"
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/{id} [get]
+func (h *TenantHandler) GetTenant(c *gin.Context) {
+	siteID := c.Param("id")
+	tenant, err := h.tenantService.GetTenantDetail(c.Request.Context(), siteID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "테넌트를 찾을 수 없습니다", err)
+		return
+	}
+	common.V2Success(c, tenant)
+}
+
+// SuspendTenant godoc
+// @Summary 테넌트 정지 (관리자)
+// @Tags admin-tenants
+// @Param id path string true "사이트 ID"
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/{id}/suspend [post]
+func (h *TenantHandler) SuspendTenant(c *gin.Context) {
+	siteID := c.Param("id")
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	_ = c.ShouldBindJSON(&req)
+
+	if err := h.tenantService.SuspendTenant(c.Request.Context(), siteID, req.Reason); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "테넌트가 정지되었습니다"})
+}
+
+// UnsuspendTenant godoc
+// @Summary 테넌트 정지 해제 (관리자)
+// @Tags admin-tenants
+// @Param id path string true "사이트 ID"
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/{id}/unsuspend [post]
+func (h *TenantHandler) UnsuspendTenant(c *gin.Context) {
+	siteID := c.Param("id")
+	if err := h.tenantService.UnsuspendTenant(c.Request.Context(), siteID); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "테넌트 정지가 해제되었습니다"})
+}
+
+// ChangePlan godoc
+// @Summary 테넌트 플랜 변경 (관리자)
+// @Tags admin-tenants
+// @Param id path string true "사이트 ID"
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/{id}/plan [put]
+func (h *TenantHandler) ChangePlan(c *gin.Context) {
+	siteID := c.Param("id")
+	var req struct {
+		Plan string `json:"plan" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	if err := h.tenantService.ChangePlan(c.Request.Context(), siteID, req.Plan); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "플랜이 변경되었습니다", "plan": req.Plan})
+}
+
+// GetUsage godoc
+// @Summary 테넌트 사용량 조회
+// @Tags admin-tenants
+// @Param id path string true "사이트 ID"
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/{id}/usage [get]
+func (h *TenantHandler) GetUsage(c *gin.Context) {
+	siteID := c.Param("id")
+	days := parseIntQuery(c, "days", 30)
+
+	usage, err := h.tenantService.GetUsage(c.Request.Context(), siteID, days)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "사용량 조회 실패", err)
+		return
+	}
+	common.V2Success(c, usage)
+}
+
+// GetPlanLimits godoc
+// @Summary 플랜별 리소스 제한 조회
+// @Tags admin-tenants
+// @Success 200 {object} common.V2Response
+// @Router /api/v2/admin/tenants/plans [get]
+func (h *TenantHandler) GetPlanLimits(c *gin.Context) {
+	plans := map[string]middleware.PlanLimits{
+		"free":       middleware.GetPlanLimits("free"),
+		"pro":        middleware.GetPlanLimits("pro"),
+		"business":   middleware.GetPlanLimits("business"),
+		"enterprise": middleware.GetPlanLimits("enterprise"),
+	}
+	common.V2Success(c, plans)
+}

--- a/internal/middleware/tenant_db.go
+++ b/internal/middleware/tenant_db.go
@@ -1,0 +1,145 @@
+package middleware
+
+import (
+	"fmt"
+	"sync"
+
+	"gorm.io/gorm"
+)
+
+// TenantDBResolver resolves the correct database connection for a tenant
+// based on the site's DB strategy (shared, schema, dedicated)
+type TenantDBResolver struct {
+	defaultDB  *gorm.DB
+	schemaDbs  sync.Map // map[string]*gorm.DB — per-schema connections
+}
+
+// NewTenantDBResolver creates a new resolver
+func NewTenantDBResolver(defaultDB *gorm.DB) *TenantDBResolver {
+	return &TenantDBResolver{
+		defaultDB: defaultDB,
+	}
+}
+
+// ResolveDB returns the appropriate *gorm.DB for a tenant
+func (r *TenantDBResolver) ResolveDB(tenantID, dbStrategy, schemaName string) *gorm.DB {
+	switch dbStrategy {
+	case "schema":
+		return r.resolveSchema(schemaName)
+	case "dedicated":
+		// dedicated DB 연결은 별도 설정 필요 (추후)
+		return r.defaultDB
+	default: // "shared"
+		return r.defaultDB
+	}
+}
+
+// resolveSchema returns a session scoped to the given schema
+func (r *TenantDBResolver) resolveSchema(schemaName string) *gorm.DB {
+	if schemaName == "" {
+		return r.defaultDB
+	}
+
+	// 캐시된 세션 확인
+	if db, ok := r.schemaDbs.Load(schemaName); ok {
+		return db.(*gorm.DB)
+	}
+
+	// 새 세션 생성 (USE schema_name)
+	db := r.defaultDB.Session(&gorm.Session{})
+	db.Exec(fmt.Sprintf("USE `%s`", schemaName))
+	r.schemaDbs.Store(schemaName, db)
+	return db
+}
+
+// CreateSchema creates a new database schema for a tenant
+func (r *TenantDBResolver) CreateSchema(schemaName string) error {
+	sql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci", schemaName)
+	return r.defaultDB.Exec(sql).Error
+}
+
+// DropSchema drops a tenant's database schema
+func (r *TenantDBResolver) DropSchema(schemaName string) error {
+	sql := fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", schemaName)
+	r.schemaDbs.Delete(schemaName)
+	return r.defaultDB.Exec(sql).Error
+}
+
+// PlanLimits defines resource limits per plan
+type PlanLimits struct {
+	MaxStorage      int64 `json:"max_storage_mb"`       // MB
+	MaxBandwidth    int64 `json:"max_bandwidth_mb"`      // MB/month
+	MaxPosts        int   `json:"max_posts"`
+	MaxBoards       int   `json:"max_boards"`
+	MaxUsers        int   `json:"max_users"`
+	MaxAPICalls     int   `json:"max_api_calls_per_day"`
+	MaxFileSize     int64 `json:"max_file_size_mb"`      // MB per file
+	CustomDomain    bool  `json:"custom_domain"`
+	SSLEnabled      bool  `json:"ssl_enabled"`
+	PluginsAllowed  bool  `json:"plugins_allowed"`
+	MaxPlugins      int   `json:"max_plugins"`
+}
+
+// GetPlanLimits returns resource limits for a given plan
+func GetPlanLimits(plan string) PlanLimits {
+	switch plan {
+	case "free":
+		return PlanLimits{
+			MaxStorage:     500,
+			MaxBandwidth:   5000,
+			MaxPosts:       1000,
+			MaxBoards:      5,
+			MaxUsers:       100,
+			MaxAPICalls:    10000,
+			MaxFileSize:    5,
+			CustomDomain:   false,
+			SSLEnabled:     true,
+			PluginsAllowed: false,
+			MaxPlugins:     0,
+		}
+	case "pro":
+		return PlanLimits{
+			MaxStorage:     5000,
+			MaxBandwidth:   50000,
+			MaxPosts:       50000,
+			MaxBoards:      20,
+			MaxUsers:       1000,
+			MaxAPICalls:    100000,
+			MaxFileSize:    20,
+			CustomDomain:   true,
+			SSLEnabled:     true,
+			PluginsAllowed: true,
+			MaxPlugins:     5,
+		}
+	case "business":
+		return PlanLimits{
+			MaxStorage:     50000,
+			MaxBandwidth:   500000,
+			MaxPosts:       500000,
+			MaxBoards:      100,
+			MaxUsers:       10000,
+			MaxAPICalls:    1000000,
+			MaxFileSize:    50,
+			CustomDomain:   true,
+			SSLEnabled:     true,
+			PluginsAllowed: true,
+			MaxPlugins:     20,
+		}
+	case "enterprise":
+		return PlanLimits{
+			MaxStorage:     -1, // unlimited
+			MaxBandwidth:   -1,
+			MaxPosts:       -1,
+			MaxBoards:      -1,
+			MaxUsers:       -1,
+			MaxAPICalls:    -1,
+			MaxFileSize:    100,
+			CustomDomain:   true,
+			SSLEnabled:     true,
+			PluginsAllowed: true,
+			MaxPlugins:     -1,
+		}
+	default:
+		return GetPlanLimits("free")
+	}
+}

--- a/internal/service/tenant_service.go
+++ b/internal/service/tenant_service.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/repository"
+	"gorm.io/gorm"
+)
+
+// TenantService handles tenant management business logic
+type TenantService struct {
+	siteRepo *repository.SiteRepository
+	db       *gorm.DB
+	dbResolver *middleware.TenantDBResolver
+}
+
+// NewTenantService creates a new TenantService
+func NewTenantService(siteRepo *repository.SiteRepository, db *gorm.DB, dbResolver *middleware.TenantDBResolver) *TenantService {
+	return &TenantService{
+		siteRepo:   siteRepo,
+		db:         db,
+		dbResolver: dbResolver,
+	}
+}
+
+// TenantDetail tenant detail response
+type TenantDetail struct {
+	Site     *domain.SiteResponse     `json:"site"`
+	Settings *domain.SiteSettings     `json:"settings"`
+	Limits   middleware.PlanLimits     `json:"limits"`
+	Users    []domain.SiteUser        `json:"users"`
+}
+
+// ListTenants lists tenants with optional status filter
+func (s *TenantService) ListTenants(ctx context.Context, page, perPage int, status string) ([]domain.SiteResponse, int64, error) {
+	var sites []domain.Site
+	var total int64
+
+	query := s.db.WithContext(ctx).Model(&domain.Site{})
+	switch status {
+	case "active":
+		query = query.Where("active = ? AND suspended = ?", true, false)
+	case "suspended":
+		query = query.Where("suspended = ?", true)
+	case "inactive":
+		query = query.Where("active = ?", false)
+	}
+	query.Count(&total)
+
+	err := query.Order("created_at DESC").
+		Offset((page - 1) * perPage).Limit(perPage).
+		Find(&sites).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	responses := make([]domain.SiteResponse, len(sites))
+	for i, site := range sites {
+		settings, _ := s.siteRepo.FindSettingsBySiteID(ctx, site.ID)
+		responses[i] = *site.ToResponse(settings)
+	}
+	return responses, total, nil
+}
+
+// GetTenantDetail returns full tenant details with limits and users
+func (s *TenantService) GetTenantDetail(ctx context.Context, siteID string) (*TenantDetail, error) {
+	site, err := s.siteRepo.FindByID(ctx, siteID)
+	if err != nil || site == nil {
+		return nil, errors.New("테넌트를 찾을 수 없습니다")
+	}
+
+	settings, _ := s.siteRepo.FindSettingsBySiteID(ctx, siteID)
+	users, _ := s.siteRepo.ListSiteUsers(ctx, siteID)
+	limits := middleware.GetPlanLimits(site.Plan)
+
+	return &TenantDetail{
+		Site:     site.ToResponse(settings),
+		Settings: settings,
+		Limits:   limits,
+		Users:    users,
+	}, nil
+}
+
+// SuspendTenant suspends a tenant
+func (s *TenantService) SuspendTenant(ctx context.Context, siteID, reason string) error {
+	site, err := s.siteRepo.FindByID(ctx, siteID)
+	if err != nil || site == nil {
+		return errors.New("테넌트를 찾을 수 없습니다")
+	}
+	if site.Suspended {
+		return errors.New("이미 정지된 테넌트입니다")
+	}
+
+	site.Suspended = true
+	return s.siteRepo.Update(ctx, site)
+}
+
+// UnsuspendTenant unsuspends a tenant
+func (s *TenantService) UnsuspendTenant(ctx context.Context, siteID string) error {
+	site, err := s.siteRepo.FindByID(ctx, siteID)
+	if err != nil || site == nil {
+		return errors.New("테넌트를 찾을 수 없습니다")
+	}
+	if !site.Suspended {
+		return errors.New("정지 상태가 아닌 테넌트입니다")
+	}
+
+	site.Suspended = false
+	return s.siteRepo.Update(ctx, site)
+}
+
+// ChangePlan changes a tenant's subscription plan
+func (s *TenantService) ChangePlan(ctx context.Context, siteID, newPlan string) error {
+	validPlans := map[string]bool{"free": true, "pro": true, "business": true, "enterprise": true}
+	if !validPlans[newPlan] {
+		return fmt.Errorf("유효하지 않은 플랜: %s", newPlan)
+	}
+
+	site, err := s.siteRepo.FindByID(ctx, siteID)
+	if err != nil || site == nil {
+		return errors.New("테넌트를 찾을 수 없습니다")
+	}
+
+	oldPlan := site.Plan
+	if oldPlan == newPlan {
+		return errors.New("현재와 동일한 플랜입니다")
+	}
+
+	// DB 전략 변경 (플랜에 따라)
+	oldStrategy := site.DBStrategy
+	newStrategy := s.getDBStrategyByPlan(newPlan)
+	site.Plan = newPlan
+	site.DBStrategy = newStrategy
+
+	if err := s.siteRepo.Update(ctx, site); err != nil {
+		return err
+	}
+
+	// schema 전략으로 업그레이드 시 스키마 생성
+	if oldStrategy == "shared" && newStrategy == "schema" && s.dbResolver != nil {
+		schemaName := fmt.Sprintf("tenant_%s", siteID)
+		if err := s.dbResolver.CreateSchema(schemaName); err != nil {
+			return fmt.Errorf("스키마 생성 실패: %w", err)
+		}
+		// DB schema name 저장
+		site.DBSchemaName = &schemaName
+		return s.siteRepo.Update(ctx, site)
+	}
+
+	return nil
+}
+
+// UsageStats represents usage statistics for a tenant
+type UsageStats struct {
+	SiteID          string           `json:"site_id"`
+	Period          string           `json:"period"`
+	TotalPageViews  int64            `json:"total_page_views"`
+	TotalVisitors   int64            `json:"total_unique_visitors"`
+	TotalAPICalls   int64            `json:"total_api_calls"`
+	TotalPosts      int64            `json:"total_posts_created"`
+	TotalComments   int64            `json:"total_comments_created"`
+	StorageUsedMB   float64          `json:"storage_used_mb"`
+	BandwidthUsedMB float64          `json:"bandwidth_used_mb"`
+	DailyUsage      []domain.SiteUsage `json:"daily_usage"`
+}
+
+// GetUsage returns usage stats for a tenant over the given number of days
+func (s *TenantService) GetUsage(ctx context.Context, siteID string, days int) (*UsageStats, error) {
+	site, err := s.siteRepo.FindByID(ctx, siteID)
+	if err != nil || site == nil {
+		return nil, errors.New("테넌트를 찾을 수 없습니다")
+	}
+
+	since := time.Now().AddDate(0, 0, -days)
+	var usages []domain.SiteUsage
+	err = s.db.WithContext(ctx).
+		Where("site_id = ? AND date >= ?", siteID, since).
+		Order("date ASC").
+		Find(&usages).Error
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &UsageStats{
+		SiteID:     siteID,
+		Period:     fmt.Sprintf("last_%d_days", days),
+		DailyUsage: usages,
+	}
+	for _, u := range usages {
+		stats.TotalPageViews += int64(u.PageViews)
+		stats.TotalVisitors += int64(u.UniqueVisitors)
+		stats.TotalAPICalls += int64(u.APICalls)
+		stats.TotalPosts += int64(u.PostsCreated)
+		stats.TotalComments += int64(u.CommentsCreated)
+		stats.StorageUsedMB += u.StorageUsedMB
+		stats.BandwidthUsedMB += u.BandwidthUsedMB
+	}
+
+	return stats, nil
+}
+
+func (s *TenantService) getDBStrategyByPlan(plan string) string {
+	switch plan {
+	case "free":
+		return "shared"
+	case "pro", "business":
+		return "schema"
+	case "enterprise":
+		return "dedicated"
+	default:
+		return "shared"
+	}
+}

--- a/plan.md
+++ b/plan.md
@@ -21,7 +21,7 @@
 
 ## 2. 현재 상태 요약
 
-- **구현 완료**: 70/81 v1 API + v2 API 레이어 — Phase 12 완료
+- **구현 완료**: 70/81 v1 API + v2 API 레이어 — Phase 14 완료
 - **v2 전환**: `/api/v1` (레거시, deprecated) + `/api/v2` (신규 DB) 공존 중
 - **아키텍처**: Clean Architecture (Handler → Service → Repository) 확립
 - **플러그인 시스템**: 스펙 완성, 기본 구현 완료, Hook 연동 완료
@@ -208,11 +208,13 @@ Redis 캐시: 갤러리 5분, 검색 3분, 게시판ID 10분 TTL (동시접속 1
 - ⏳ 자동 보안 검사 파이프라인 (CI/CD 영역, 추후)
 - ⏳ 수익 분배 시스템 (결제 연동 필요, 추후)
 
-#### Phase 14: 멀티테넌트 지원
+#### Phase 14: 멀티테넌트 지원 ✅
 
-- 테넌트별 DB 스키마 격리
-- 테넌트 관리 API
-- 리소스 할당 및 제한
+- ✅ TenantDBResolver: shared/schema/dedicated DB 전략별 격리
+- ✅ PlanLimits: free/pro/business/enterprise 플랜별 리소스 제한
+- ✅ TenantService: 목록/상세/정지/해제/플랜변경/사용량 조회
+- ✅ Admin API 7개: `/api/v2/admin/tenants/*`
+- ✅ 플랜 업그레이드 시 자동 스키마 생성
 
 #### Phase 15: 호스팅 SaaS 백엔드
 


### PR DESCRIPTION
## Summary
- TenantDBResolver: shared/schema/dedicated DB 전략별 격리
- PlanLimits: free/pro/business/enterprise 플랜별 리소스 제한
- TenantService: 목록/상세/정지/해제/플랜변경/사용량 조회
- Admin API 7개 (`/api/v2/admin/tenants/*`)
- 플랜 업그레이드 시 자동 스키마 생성

## Test plan
- [ ] `go build ./...` 성공 확인
- [ ] 테넌트 목록 조회 API 테스트
- [ ] 플랜 변경 시 DB 전략 자동 전환 확인