### PR TITLE
feat(security): OAuth2 소셜 로그인, API Key 인증, 보안 미들웨어

### DIFF
--- a/internal/domain/oauth.go
+++ b/internal/domain/oauth.go
@@ -1,0 +1,75 @@
+package domain
+
+import "time"
+
+// OAuthProvider represents supported OAuth providers
+type OAuthProvider string
+
+const (
+	OAuthProviderNaver  OAuthProvider = "naver"
+	OAuthProviderKakao  OAuthProvider = "kakao"
+	OAuthProviderGoogle OAuthProvider = "google"
+)
+
+// OAuthAccount links an external OAuth account to a local member
+type OAuthAccount struct {
+	ID           int64         `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	UserID       string        `gorm:"column:user_id;index" json:"user_id"`
+	Provider     OAuthProvider `gorm:"column:provider;index" json:"provider"`
+	ProviderUID  string        `gorm:"column:provider_uid" json:"provider_uid"`
+	Email        string        `gorm:"column:email" json:"email"`
+	Name         string        `gorm:"column:name" json:"name"`
+	ProfileImage string        `gorm:"column:profile_image" json:"profile_image"`
+	AccessToken  string        `gorm:"column:access_token" json:"-"`
+	RefreshToken string        `gorm:"column:refresh_token" json:"-"`
+	ExpiresAt    *time.Time    `gorm:"column:expires_at" json:"expires_at"`
+	CreatedAt    time.Time     `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	UpdatedAt    time.Time     `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`
+}
+
+func (OAuthAccount) TableName() string {
+	return "oauth_accounts"
+}
+
+// OAuthConfig holds configuration for an OAuth provider
+type OAuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Scopes       []string
+}
+
+// OAuthUserInfo represents user info retrieved from an OAuth provider
+type OAuthUserInfo struct {
+	Provider     OAuthProvider `json:"provider"`
+	ProviderUID  string        `json:"provider_uid"`
+	Email        string        `json:"email"`
+	Name         string        `json:"name"`
+	Nickname     string        `json:"nickname"`
+	ProfileImage string        `json:"profile_image"`
+}
+
+// OAuthLoginResponse is returned after successful OAuth login
+type OAuthLoginResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IsNewUser    bool   `json:"is_new_user"`
+	UserID       string `json:"user_id"`
+}
+
+// APIKey represents an API key for external integrations
+type APIKey struct {
+	ID        int64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	Key       string    `gorm:"column:api_key;uniqueIndex;size:64" json:"key"`
+	Name      string    `gorm:"column:name" json:"name"`
+	UserID    string    `gorm:"column:user_id;index" json:"user_id"`
+	Scopes    string    `gorm:"column:scopes" json:"scopes"` // comma-separated: read,write,admin
+	Active    bool      `gorm:"column:active;default:true" json:"active"`
+	ExpiresAt *time.Time `gorm:"column:expires_at" json:"expires_at"`
+	LastUsed  *time.Time `gorm:"column:last_used_at" json:"last_used_at"`
+	CreatedAt time.Time  `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+}
+
+func (APIKey) TableName() string {
+	return "api_keys"
+}

--- a/internal/handler/oauth_handler.go
+++ b/internal/handler/oauth_handler.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// OAuthHandler handles OAuth2 social login endpoints
+type OAuthHandler struct {
+	oauthService *service.OAuthService
+}
+
+// NewOAuthHandler creates a new OAuthHandler
+func NewOAuthHandler(oauthService *service.OAuthService) *OAuthHandler {
+	return &OAuthHandler{oauthService: oauthService}
+}
+
+// Redirect initiates OAuth flow by redirecting to provider's auth page
+// GET /api/v2/auth/oauth/:provider
+func (h *OAuthHandler) Redirect(c *gin.Context) {
+	provider := domain.OAuthProvider(c.Param("provider"))
+
+	// Generate random state for CSRF protection
+	stateBytes := make([]byte, 16)
+	if _, err := rand.Read(stateBytes); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to generate state", nil)
+		return
+	}
+	state := hex.EncodeToString(stateBytes)
+
+	// Store state in cookie for verification
+	c.SetCookie("oauth_state", state, 600, "/", "", true, true)
+
+	authURL, err := h.oauthService.GetAuthURL(provider, state)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	c.Redirect(http.StatusTemporaryRedirect, authURL)
+}
+
+// Callback handles the OAuth provider callback
+// GET /api/v2/auth/oauth/:provider/callback
+func (h *OAuthHandler) Callback(c *gin.Context) {
+	provider := domain.OAuthProvider(c.Param("provider"))
+
+	// Verify state
+	state := c.Query("state")
+	savedState, err := c.Cookie("oauth_state")
+	if err != nil || state == "" || state != savedState {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid OAuth state", nil)
+		return
+	}
+
+	// Clear state cookie
+	c.SetCookie("oauth_state", "", -1, "/", "", true, true)
+
+	code := c.Query("code")
+	if code == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "Missing authorization code", nil)
+		return
+	}
+
+	result, err := h.oauthService.HandleCallback(c.Request.Context(), provider, code)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "OAuth login failed: "+err.Error(), nil)
+		return
+	}
+
+	common.SuccessResponse(c, result, nil)
+}
+
+// GenerateAPIKey creates a new API key for the authenticated user
+// POST /api/v2/auth/api-keys
+func (h *OAuthHandler) GenerateAPIKey(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "Authentication required", nil)
+		return
+	}
+
+	var req struct {
+		Name   string `json:"name" binding:"required"`
+		Scopes string `json:"scopes"` // comma-separated: read,write
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	if req.Scopes == "" {
+		req.Scopes = "read"
+	}
+
+	apiKey, err := h.oauthService.GenerateAPIKey(c.Request.Context(), userID, req.Name, req.Scopes)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to generate API key", nil)
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"success": true, "data": apiKey})
+}

--- a/internal/middleware/api_key.go
+++ b/internal/middleware/api_key.go
@@ -1,0 +1,60 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/gin-gonic/gin"
+)
+
+// APIKeyValidator validates API keys (implemented by OAuthService)
+type APIKeyValidator interface {
+	ValidateAPIKey(ctx interface{}, key string) (*domain.APIKey, error)
+}
+
+// APIKeyAuth authenticates requests using an API key.
+// Checks X-API-Key header or api_key query parameter.
+func APIKeyAuth(validator APIKeyValidator, requiredScope string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := c.GetHeader("X-API-Key")
+		if key == "" {
+			key = c.Query("api_key")
+		}
+		if key == "" {
+			common.ErrorResponse(c, http.StatusUnauthorized, "API key required", nil)
+			c.Abort()
+			return
+		}
+
+		apiKey, err := validator.ValidateAPIKey(c.Request.Context(), key)
+		if err != nil {
+			common.ErrorResponse(c, http.StatusUnauthorized, err.Error(), nil)
+			c.Abort()
+			return
+		}
+
+		// Check scope
+		if requiredScope != "" {
+			scopes := strings.Split(apiKey.Scopes, ",")
+			hasScope := false
+			for _, s := range scopes {
+				if strings.TrimSpace(s) == requiredScope || strings.TrimSpace(s) == "admin" {
+					hasScope = true
+					break
+				}
+			}
+			if !hasScope {
+				common.ErrorResponse(c, http.StatusForbidden, "Insufficient API key scope", nil)
+				c.Abort()
+				return
+			}
+		}
+
+		c.Set("api_key_id", apiKey.ID)
+		c.Set("api_key_user_id", apiKey.UserID)
+		c.Set("userID", apiKey.UserID)
+		c.Next()
+	}
+}

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -1,0 +1,123 @@
+package middleware
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/gin-gonic/gin"
+)
+
+// SecurityHeaders adds common security headers to all responses
+func SecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("X-XSS-Protection", "1; mode=block")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' https:; connect-src 'self' https:; frame-ancestors 'none'")
+
+		// HSTS (only in production)
+		if c.Request.TLS != nil {
+			c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+
+		c.Next()
+	}
+}
+
+// InputSanitizer blocks requests with common XSS/injection patterns in query parameters
+func InputSanitizer() gin.HandlerFunc {
+	dangerousPatterns := []string{
+		"<script",
+		"javascript:",
+		"onerror=",
+		"onload=",
+		"onclick=",
+		"onfocus=",
+		"onmouseover=",
+		"eval(",
+		"document.cookie",
+		"window.location",
+		"String.fromCharCode",
+	}
+
+	return func(c *gin.Context) {
+		// Check query parameters
+		for _, values := range c.Request.URL.Query() {
+			for _, v := range values {
+				lower := strings.ToLower(v)
+				for _, pattern := range dangerousPatterns {
+					if strings.Contains(lower, pattern) {
+						common.ErrorResponse(c, http.StatusBadRequest, "Potentially dangerous input detected", nil)
+						c.Abort()
+						return
+					}
+				}
+			}
+		}
+		c.Next()
+	}
+}
+
+// CSRFProtection provides CSRF protection for cookie-based authentication (v1 routes).
+// It checks the X-CSRF-Token header against the csrf_token cookie on state-changing methods.
+func CSRFProtection() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Only apply to state-changing methods
+		method := c.Request.Method
+		if method == "GET" || method == "HEAD" || method == "OPTIONS" {
+			c.Next()
+			return
+		}
+
+		// Skip if using Bearer token (API clients, not browser)
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			c.Next()
+			return
+		}
+
+		// Skip if using API key
+		if c.GetHeader("X-API-Key") != "" || c.Query("api_key") != "" {
+			c.Next()
+			return
+		}
+
+		// For cookie-based auth, require CSRF token
+		csrfCookie, err := c.Cookie("csrf_token")
+		if err != nil || csrfCookie == "" {
+			common.ErrorResponse(c, http.StatusForbidden, "CSRF token missing", nil)
+			c.Abort()
+			return
+		}
+
+		csrfHeader := c.GetHeader("X-CSRF-Token")
+		if csrfHeader == "" || csrfHeader != csrfCookie {
+			common.ErrorResponse(c, http.StatusForbidden, "CSRF token mismatch", nil)
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// GenerateCSRFToken generates a new CSRF token and sets it as a cookie
+// GET /api/v1/tokens/csrf
+func GenerateCSRFToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tokenBytes := make([]byte, 32)
+		if _, err := rand.Read(tokenBytes); err != nil {
+			common.ErrorResponse(c, http.StatusInternalServerError, "Failed to generate CSRF token", nil)
+			return
+		}
+		token := hex.EncodeToString(tokenBytes)
+
+		c.SetCookie("csrf_token", token, 3600, "/", "", true, false) // HttpOnly=false so JS can read
+		c.JSON(http.StatusOK, gin.H{"csrf_token": token})
+	}
+}

--- a/internal/service/oauth_service.go
+++ b/internal/service/oauth_service.go
@@ -1,0 +1,341 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/pkg/jwt"
+	pkglogger "github.com/damoang/angple-backend/pkg/logger"
+	"gorm.io/gorm"
+)
+
+// OAuthService handles OAuth2 social login flows
+type OAuthService struct {
+	db         *gorm.DB
+	jwtManager *jwt.Manager
+	providers  map[domain.OAuthProvider]*domain.OAuthConfig
+}
+
+// NewOAuthService creates a new OAuthService
+func NewOAuthService(db *gorm.DB, jwtManager *jwt.Manager) *OAuthService {
+	if db != nil {
+		_ = db.AutoMigrate(&domain.OAuthAccount{})
+	}
+	return &OAuthService{
+		db:         db,
+		jwtManager: jwtManager,
+		providers:  make(map[domain.OAuthProvider]*domain.OAuthConfig),
+	}
+}
+
+// RegisterProvider registers an OAuth provider configuration
+func (s *OAuthService) RegisterProvider(provider domain.OAuthProvider, cfg *domain.OAuthConfig) {
+	s.providers[provider] = cfg
+}
+
+// GetAuthURL returns the OAuth authorization URL for the given provider
+func (s *OAuthService) GetAuthURL(provider domain.OAuthProvider, state string) (string, error) {
+	cfg, ok := s.providers[provider]
+	if !ok {
+		return "", fmt.Errorf("unsupported provider: %s", provider)
+	}
+
+	switch provider {
+	case domain.OAuthProviderNaver:
+		params := url.Values{
+			"response_type": {"code"},
+			"client_id":     {cfg.ClientID},
+			"redirect_uri":  {cfg.RedirectURL},
+			"state":         {state},
+		}
+		return "https://nid.naver.com/oauth2.0/authorize?" + params.Encode(), nil
+
+	case domain.OAuthProviderKakao:
+		params := url.Values{
+			"response_type": {"code"},
+			"client_id":     {cfg.ClientID},
+			"redirect_uri":  {cfg.RedirectURL},
+			"state":         {state},
+		}
+		return "https://kauth.kakao.com/oauth/authorize?" + params.Encode(), nil
+
+	case domain.OAuthProviderGoogle:
+		params := url.Values{
+			"response_type": {"code"},
+			"client_id":     {cfg.ClientID},
+			"redirect_uri":  {cfg.RedirectURL},
+			"scope":         {strings.Join(cfg.Scopes, " ")},
+			"state":         {state},
+			"access_type":   {"offline"},
+		}
+		return "https://accounts.google.com/o/oauth2/v2/auth?" + params.Encode(), nil
+
+	default:
+		return "", fmt.Errorf("unsupported provider: %s", provider)
+	}
+}
+
+// HandleCallback exchanges the authorization code for tokens and user info
+func (s *OAuthService) HandleCallback(ctx context.Context, provider domain.OAuthProvider, code string) (*domain.OAuthLoginResponse, error) {
+	cfg, ok := s.providers[provider]
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+
+	// Exchange code for access token
+	tokenResp, err := s.exchangeCode(provider, cfg, code)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange failed: %w", err)
+	}
+
+	// Get user info from provider
+	userInfo, err := s.getUserInfo(provider, tokenResp["access_token"].(string))
+	if err != nil {
+		return nil, fmt.Errorf("get user info failed: %w", err)
+	}
+
+	// Find or create OAuth account
+	var oauthAccount domain.OAuthAccount
+	result := s.db.WithContext(ctx).Where("provider = ? AND provider_uid = ?", provider, userInfo.ProviderUID).First(&oauthAccount)
+
+	isNewUser := false
+	if result.Error == gorm.ErrRecordNotFound {
+		// New OAuth user — create account
+		isNewUser = true
+		oauthAccount = domain.OAuthAccount{
+			UserID:       fmt.Sprintf("oauth_%s_%s", provider, userInfo.ProviderUID),
+			Provider:     provider,
+			ProviderUID:  userInfo.ProviderUID,
+			Email:        userInfo.Email,
+			Name:         userInfo.Name,
+			ProfileImage: userInfo.ProfileImage,
+			AccessToken:  tokenResp["access_token"].(string),
+		}
+		if rt, ok := tokenResp["refresh_token"].(string); ok {
+			oauthAccount.RefreshToken = rt
+		}
+		if err := s.db.WithContext(ctx).Create(&oauthAccount).Error; err != nil {
+			return nil, fmt.Errorf("create oauth account failed: %w", err)
+		}
+	} else if result.Error != nil {
+		return nil, result.Error
+	} else {
+		// Update tokens
+		updates := map[string]interface{}{
+			"access_token": tokenResp["access_token"],
+			"name":         userInfo.Name,
+			"email":        userInfo.Email,
+		}
+		if rt, ok := tokenResp["refresh_token"].(string); ok && rt != "" {
+			updates["refresh_token"] = rt
+		}
+		s.db.WithContext(ctx).Model(&oauthAccount).Updates(updates)
+	}
+
+	// Generate JWT tokens
+	accessToken, err := s.jwtManager.GenerateAccessToken(oauthAccount.UserID, userInfo.Name, 1)
+	if err != nil {
+		return nil, fmt.Errorf("generate access token failed: %w", err)
+	}
+	refreshToken, err := s.jwtManager.GenerateRefreshToken(oauthAccount.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("generate refresh token failed: %w", err)
+	}
+
+	return &domain.OAuthLoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		IsNewUser:    isNewUser,
+		UserID:       oauthAccount.UserID,
+	}, nil
+}
+
+// exchangeCode exchanges authorization code for access token
+func (s *OAuthService) exchangeCode(provider domain.OAuthProvider, cfg *domain.OAuthConfig, code string) (map[string]interface{}, error) {
+	var tokenURL string
+	params := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": {cfg.RedirectURL},
+	}
+
+	switch provider {
+	case domain.OAuthProviderNaver:
+		tokenURL = "https://nid.naver.com/oauth2.0/token"
+		params.Set("client_id", cfg.ClientID)
+		params.Set("client_secret", cfg.ClientSecret)
+
+	case domain.OAuthProviderKakao:
+		tokenURL = "https://kauth.kakao.com/oauth/token"
+		params.Set("client_id", cfg.ClientID)
+		params.Set("client_secret", cfg.ClientSecret)
+
+	case domain.OAuthProviderGoogle:
+		tokenURL = "https://oauth2.googleapis.com/token"
+		params.Set("client_id", cfg.ClientID)
+		params.Set("client_secret", cfg.ClientSecret)
+
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+
+	resp, err := http.PostForm(tokenURL, params)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse token response failed: %w", err)
+	}
+
+	if errMsg, ok := result["error"]; ok {
+		return nil, fmt.Errorf("oauth error: %v", errMsg)
+	}
+
+	return result, nil
+}
+
+// getUserInfo fetches user profile from the OAuth provider
+func (s *OAuthService) getUserInfo(provider domain.OAuthProvider, accessToken string) (*domain.OAuthUserInfo, error) {
+	var apiURL string
+
+	switch provider {
+	case domain.OAuthProviderNaver:
+		apiURL = "https://openapi.naver.com/v1/nid/me"
+	case domain.OAuthProviderKakao:
+		apiURL = "https://kapi.kakao.com/v2/user/me"
+	case domain.OAuthProviderGoogle:
+		apiURL = "https://www.googleapis.com/oauth2/v2/userinfo"
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", provider)
+	}
+
+	req, _ := http.NewRequest("GET", apiURL, nil)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+
+	return s.parseUserInfo(provider, raw)
+}
+
+// parseUserInfo parses provider-specific user info into a common struct
+func (s *OAuthService) parseUserInfo(provider domain.OAuthProvider, raw map[string]interface{}) (*domain.OAuthUserInfo, error) {
+	info := &domain.OAuthUserInfo{Provider: provider}
+
+	switch provider {
+	case domain.OAuthProviderNaver:
+		response, ok := raw["response"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid naver response")
+		}
+		info.ProviderUID = fmt.Sprintf("%v", response["id"])
+		info.Email, _ = response["email"].(string)
+		info.Name, _ = response["name"].(string)
+		info.Nickname, _ = response["nickname"].(string)
+		info.ProfileImage, _ = response["profile_image"].(string)
+
+	case domain.OAuthProviderKakao:
+		info.ProviderUID = fmt.Sprintf("%v", raw["id"])
+		if account, ok := raw["kakao_account"].(map[string]interface{}); ok {
+			info.Email, _ = account["email"].(string)
+			if profile, ok := account["profile"].(map[string]interface{}); ok {
+				info.Nickname, _ = profile["nickname"].(string)
+				info.ProfileImage, _ = profile["profile_image_url"].(string)
+			}
+		}
+		info.Name = info.Nickname
+
+	case domain.OAuthProviderGoogle:
+		info.ProviderUID = fmt.Sprintf("%v", raw["id"])
+		info.Email, _ = raw["email"].(string)
+		info.Name, _ = raw["name"].(string)
+		info.ProfileImage, _ = raw["picture"].(string)
+	}
+
+	if info.ProviderUID == "" {
+		return nil, fmt.Errorf("could not extract provider UID")
+	}
+
+	return info, nil
+}
+
+// --- API Key Management ---
+
+// GenerateAPIKey creates a new API key for a user
+func (s *OAuthService) GenerateAPIKey(ctx context.Context, userID, name, scopes string) (*domain.APIKey, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+	_ = s.db.AutoMigrate(&domain.APIKey{})
+
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return nil, err
+	}
+	key := "ak_" + hex.EncodeToString(keyBytes)
+
+	apiKey := &domain.APIKey{
+		Key:    key,
+		Name:   name,
+		UserID: userID,
+		Scopes: scopes,
+		Active: true,
+	}
+
+	if err := s.db.WithContext(ctx).Create(apiKey).Error; err != nil {
+		return nil, err
+	}
+
+	pkglogger.GetLogger().Info().
+		Str("user_id", userID).
+		Str("key_name", name).
+		Msg("API key generated")
+
+	return apiKey, nil
+}
+
+// ValidateAPIKey checks if a key is valid and returns the associated record
+func (s *OAuthService) ValidateAPIKey(ctx context.Context, key string) (*domain.APIKey, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database not available")
+	}
+
+	var apiKey domain.APIKey
+	err := s.db.WithContext(ctx).Where("api_key = ? AND active = ?", key, true).First(&apiKey).Error
+	if err != nil {
+		return nil, fmt.Errorf("invalid API key")
+	}
+
+	if apiKey.ExpiresAt != nil && apiKey.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("API key expired")
+	}
+
+	// Update last used
+	now := time.Now()
+	s.db.WithContext(ctx).Model(&apiKey).Update("last_used_at", now)
+
+	return &apiKey, nil
+}


### PR DESCRIPTION
## Summary
- OAuth2 소셜 로그인: 네이버, 카카오, 구글 (환경변수로 provider 등록)
- API Key 인증 미들웨어 (X-API-Key 헤더, 스코프 기반 권한 검증)
- 보안 헤더 미들웨어 (CSP, HSTS, X-Frame-Options, X-Content-Type-Options 등)
- XSS/Injection 입력 검증 미들웨어 (쿼리 파라미터 패턴 탐지)
- CSRF 보호 (쿠키 기반 v1 경로, 토큰 발급 엔드포인트)
- CORS 정책 강화 (ExposeHeaders, MaxAge 24h, X-API-Key/X-CSRF-Token 허용)

## Test plan
- [x] `go build ./cmd/api/` 성공
- [x] `go test ./internal/service/...` 전체 통과
- [ ] OAuth 플로우 테스트 (네이버/카카오/구글 환경변수 설정 후)
- [ ] API Key 발급 및 인증 테스트
- [ ] 보안 헤더 응답 확인
- [ ] XSS 패턴 차단 확인
- [ ] CSRF 토큰 발급/검증 확인