### PR TITLE
feat(search): Elasticsearch 실시간 검색, nori 분석기, 자동완성

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/damoang/angple-backend
 go 1.24.0
 
 require (
+	github.com/elastic/go-elasticsearch/v8 v8.19.1
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -34,8 +35,11 @@ require (
 	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/elastic/elastic-transport-go/v8 v8.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
@@ -66,6 +70,9 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
+	go.opentelemetry.io/otel v1.28.0 // indirect
+	go.opentelemetry.io/otel/metric v1.28.0 // indirect
+	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/arch v0.18.0 // indirect
 	golang.org/x/crypto v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
+github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
+github.com/elastic/go-elasticsearch/v8 v8.19.1 h1:0iEGt5/Ds9MNVxEp3hqLsXdbe6SjleaVHONg/FuR09Q=
+github.com/elastic/go-elasticsearch/v8 v8.19.1/go.mod h1:tHJQdInFa6abmDbDCEH2LJja07l/SIpaGpJcm13nt7s=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=
@@ -39,6 +43,11 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -162,6 +171,14 @@ github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2
 github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA=
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.opentelemetry.io/otel v1.28.0 h1:/SqNcYk+idO0CxKEUOtKQClMK/MimZihKYMruSMViUo=
+go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
+go.opentelemetry.io/otel/metric v1.28.0 h1:f0HGvSl1KRAU1DLgLGFjrwVyismPlnuU6JD6bOeuA5Q=
+go.opentelemetry.io/otel/metric v1.28.0/go.mod h1:Fb1eVBFZmLVTMb6PPohq3TO9IIhUisDsbJoL/+uQW4s=
+go.opentelemetry.io/otel/sdk v1.21.0 h1:FTt8qirL1EysG6sTQRZ5TokkU8d0ugCj8htOgThZXQ8=
+go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
+go.opentelemetry.io/otel/trace v1.28.0 h1:GhQ9cUuQGmNDd5BTCP2dAvv75RdMxEfTmYejp+lkx9g=
+go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,13 +9,22 @@ import (
 
 // Config 애플리케이션 설정 구조체
 type Config struct {
-	JWT       JWTConfig       `yaml:"jwt"`
-	Server    ServerConfig    `yaml:"server"`
-	DataPaths DataPathsConfig `yaml:"data_paths"`
-	CORS      CORSConfig      `yaml:"cors"`
-	Redis     RedisConfig     `yaml:"redis"`
-	Database  DatabaseConfig  `yaml:"database"`
-	Plugins   PluginsConfig   `yaml:"plugins"`
+	JWT           JWTConfig           `yaml:"jwt"`
+	Server        ServerConfig        `yaml:"server"`
+	DataPaths     DataPathsConfig     `yaml:"data_paths"`
+	CORS          CORSConfig          `yaml:"cors"`
+	Redis         RedisConfig         `yaml:"redis"`
+	Database      DatabaseConfig      `yaml:"database"`
+	Plugins       PluginsConfig       `yaml:"plugins"`
+	Elasticsearch ElasticsearchConfig `yaml:"elasticsearch"`
+}
+
+// ElasticsearchConfig Elasticsearch 설정
+type ElasticsearchConfig struct {
+	Addresses []string `yaml:"addresses"`
+	Username  string   `yaml:"username"`
+	Password  string   `yaml:"password"`
+	Enabled   bool     `yaml:"enabled"`
 }
 
 // PluginsConfig 플러그인 설정
@@ -149,6 +158,18 @@ func overrideFromEnv(cfg *Config) {
 	// CORS 설정
 	if corsOrigins := os.Getenv("CORS_ALLOW_ORIGINS"); corsOrigins != "" {
 		cfg.CORS.AllowOrigins = corsOrigins
+	}
+
+	// Elasticsearch 설정
+	if esURL := os.Getenv("ELASTICSEARCH_URL"); esURL != "" {
+		cfg.Elasticsearch.Addresses = []string{esURL}
+		cfg.Elasticsearch.Enabled = true
+	}
+	if esUser := os.Getenv("ELASTICSEARCH_USERNAME"); esUser != "" {
+		cfg.Elasticsearch.Username = esUser
+	}
+	if esPass := os.Getenv("ELASTICSEARCH_PASSWORD"); esPass != "" {
+		cfg.Elasticsearch.Password = esPass
 	}
 }
 

--- a/internal/handler/search_handler.go
+++ b/internal/handler/search_handler.go
@@ -1,0 +1,148 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// SearchHandler handles Elasticsearch-based search endpoints
+type SearchHandler struct {
+	searchService *service.SearchService
+}
+
+// NewSearchHandler creates a new SearchHandler
+func NewSearchHandler(searchService *service.SearchService) *SearchHandler {
+	return &SearchHandler{searchService: searchService}
+}
+
+// Search performs unified search across posts and comments
+// GET /api/v2/search?q=keyword&board_id=free&type=posts&page=1&per_page=20
+func (h *SearchHandler) Search(c *gin.Context) {
+	keyword := c.Query("q")
+	if keyword == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "Search query is required", nil)
+		return
+	}
+
+	boardID := c.Query("board_id")
+	searchType := c.DefaultQuery("type", "all") // all, posts, comments
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 || perPage > 100 {
+		perPage = 20
+	}
+
+	result, err := h.searchService.UnifiedSearch(c.Request.Context(), keyword, boardID, searchType, page, perPage)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Search failed: "+err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    result,
+		"meta": gin.H{
+			"query":    keyword,
+			"board_id": boardID,
+			"type":     searchType,
+			"page":     page,
+			"per_page": perPage,
+		},
+	})
+}
+
+// Autocomplete returns search suggestions
+// GET /api/v2/search/autocomplete?q=prefix
+func (h *SearchHandler) Autocomplete(c *gin.Context) {
+	prefix := c.Query("q")
+	if prefix == "" {
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": []string{}})
+		return
+	}
+
+	size, _ := strconv.Atoi(c.DefaultQuery("size", "10"))
+	suggestions, err := h.searchService.Autocomplete(c.Request.Context(), prefix, size)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Autocomplete failed", nil)
+		return
+	}
+
+	if suggestions == nil {
+		suggestions = []string{}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": suggestions})
+}
+
+// BulkIndex triggers bulk indexing for a board (admin)
+// POST /api/v2/admin/search/index
+func (h *SearchHandler) BulkIndex(c *gin.Context) {
+	var req struct {
+		BoardID string `json:"board_id" binding:"required"`
+		Limit   int    `json:"limit"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "board_id is required", nil)
+		return
+	}
+	if req.Limit <= 0 {
+		req.Limit = 1000
+	}
+
+	count, err := h.searchService.BulkIndexPosts(c.Request.Context(), req.BoardID, req.Limit)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Bulk indexing failed: "+err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"board_id":      req.BoardID,
+			"indexed_count": count,
+		},
+	})
+}
+
+// IndexPost indexes a single post (called after post create/update)
+// POST /api/v2/admin/search/index-post
+func (h *SearchHandler) IndexPost(c *gin.Context) {
+	var doc service.PostDocument
+	if err := c.ShouldBindJSON(&doc); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	if err := h.searchService.IndexPost(c.Request.Context(), &doc); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Indexing failed: "+err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "post indexed"})
+}
+
+// DeletePostIndex removes a post from the index
+// DELETE /api/v2/admin/search/index/:board_id/:post_id
+func (h *SearchHandler) DeletePostIndex(c *gin.Context) {
+	boardID := c.Param("board_id")
+	postID, err := strconv.Atoi(c.Param("post_id"))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid post_id", nil)
+		return
+	}
+
+	if err := h.searchService.DeletePost(c.Request.Context(), boardID, postID); err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Delete failed: "+err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "message": "post removed from index"})
+}

--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -1,0 +1,367 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pkglogger "github.com/damoang/angple-backend/pkg/logger"
+	es "github.com/damoang/angple-backend/pkg/elasticsearch"
+	"gorm.io/gorm"
+)
+
+const (
+	PostsIndex    = "angple_posts"
+	CommentsIndex = "angple_comments"
+)
+
+// PostDocument represents a post indexed in Elasticsearch
+type PostDocument struct {
+	BoardID   string `json:"board_id"`
+	PostID    int    `json:"post_id"`
+	Title     string `json:"title"`
+	Content   string `json:"content"`
+	Author    string `json:"author"`
+	AuthorID  string `json:"author_id"`
+	Category  string `json:"category"`
+	CreatedAt string `json:"created_at"`
+	Views     int    `json:"views"`
+	Good      int    `json:"good"`
+	// For autocomplete
+	TitleSuggest map[string]interface{} `json:"title_suggest,omitempty"`
+}
+
+// CommentDocument represents a comment indexed in Elasticsearch
+type CommentDocument struct {
+	BoardID   string `json:"board_id"`
+	PostID    int    `json:"post_id"`
+	CommentID int    `json:"comment_id"`
+	Content   string `json:"content"`
+	Author    string `json:"author"`
+	AuthorID  string `json:"author_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+// SearchService provides Elasticsearch-based search
+type SearchService struct {
+	esClient *es.Client
+	db       *gorm.DB
+}
+
+// NewSearchService creates a new SearchService
+func NewSearchService(esClient *es.Client, db *gorm.DB) *SearchService {
+	svc := &SearchService{esClient: esClient, db: db}
+	// Ensure indices exist
+	ctx := context.Background()
+	if err := svc.ensureIndices(ctx); err != nil {
+		pkglogger.GetLogger().Error().Err(err).Msg("failed to create ES indices")
+	}
+	return svc
+}
+
+// ensureIndices creates ES indices with Korean nori analyzer mappings
+func (s *SearchService) ensureIndices(ctx context.Context) error {
+	postMapping := map[string]interface{}{
+		"settings": map[string]interface{}{
+			"analysis": map[string]interface{}{
+				"analyzer": map[string]interface{}{
+					"korean": map[string]interface{}{
+						"type":      "custom",
+						"tokenizer": "nori_tokenizer",
+						"filter":    []string{"nori_readingform", "lowercase"},
+					},
+				},
+			},
+		},
+		"mappings": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"board_id":   map[string]interface{}{"type": "keyword"},
+				"post_id":    map[string]interface{}{"type": "integer"},
+				"title":      map[string]interface{}{"type": "text", "analyzer": "korean", "search_analyzer": "korean"},
+				"content":    map[string]interface{}{"type": "text", "analyzer": "korean", "search_analyzer": "korean"},
+				"author":     map[string]interface{}{"type": "text", "fields": map[string]interface{}{"keyword": map[string]interface{}{"type": "keyword"}}},
+				"author_id":  map[string]interface{}{"type": "keyword"},
+				"category":   map[string]interface{}{"type": "keyword"},
+				"created_at": map[string]interface{}{"type": "date"},
+				"views":      map[string]interface{}{"type": "integer"},
+				"good":       map[string]interface{}{"type": "integer"},
+				"title_suggest": map[string]interface{}{
+					"type":            "completion",
+					"analyzer":        "korean",
+					"search_analyzer": "korean",
+				},
+			},
+		},
+	}
+
+	commentMapping := map[string]interface{}{
+		"settings": map[string]interface{}{
+			"analysis": map[string]interface{}{
+				"analyzer": map[string]interface{}{
+					"korean": map[string]interface{}{
+						"type":      "custom",
+						"tokenizer": "nori_tokenizer",
+						"filter":    []string{"nori_readingform", "lowercase"},
+					},
+				},
+			},
+		},
+		"mappings": map[string]interface{}{
+			"properties": map[string]interface{}{
+				"board_id":   map[string]interface{}{"type": "keyword"},
+				"post_id":    map[string]interface{}{"type": "integer"},
+				"comment_id": map[string]interface{}{"type": "integer"},
+				"content":    map[string]interface{}{"type": "text", "analyzer": "korean", "search_analyzer": "korean"},
+				"author":     map[string]interface{}{"type": "text", "fields": map[string]interface{}{"keyword": map[string]interface{}{"type": "keyword"}}},
+				"author_id":  map[string]interface{}{"type": "keyword"},
+				"created_at": map[string]interface{}{"type": "date"},
+			},
+		},
+	}
+
+	if err := s.esClient.CreateIndex(ctx, PostsIndex, postMapping); err != nil {
+		return fmt.Errorf("create posts index: %w", err)
+	}
+	if err := s.esClient.CreateIndex(ctx, CommentsIndex, commentMapping); err != nil {
+		return fmt.Errorf("create comments index: %w", err)
+	}
+	return nil
+}
+
+// IndexPost indexes a single post
+func (s *SearchService) IndexPost(ctx context.Context, doc *PostDocument) error {
+	docID := fmt.Sprintf("%s_%d", doc.BoardID, doc.PostID)
+	doc.TitleSuggest = map[string]interface{}{
+		"input": strings.Fields(doc.Title),
+	}
+	return s.esClient.IndexDocument(ctx, PostsIndex, docID, doc)
+}
+
+// DeletePost removes a post from the index
+func (s *SearchService) DeletePost(ctx context.Context, boardID string, postID int) error {
+	docID := fmt.Sprintf("%s_%d", boardID, postID)
+	return s.esClient.DeleteDocument(ctx, PostsIndex, docID)
+}
+
+// IndexComment indexes a single comment
+func (s *SearchService) IndexComment(ctx context.Context, doc *CommentDocument) error {
+	docID := fmt.Sprintf("%s_%d_%d", doc.BoardID, doc.PostID, doc.CommentID)
+	return s.esClient.IndexDocument(ctx, CommentsIndex, docID, doc)
+}
+
+// DeleteComment removes a comment from the index
+func (s *SearchService) DeleteComment(ctx context.Context, boardID string, postID, commentID int) error {
+	docID := fmt.Sprintf("%s_%d_%d", boardID, postID, commentID)
+	return s.esClient.DeleteDocument(ctx, CommentsIndex, docID)
+}
+
+// SearchPosts searches posts with highlighting
+func (s *SearchService) SearchPosts(ctx context.Context, keyword, boardID string, page, perPage int) (*es.SearchResponse, error) {
+	must := []map[string]interface{}{
+		{
+			"multi_match": map[string]interface{}{
+				"query":  keyword,
+				"fields": []string{"title^3", "content", "author"},
+				"type":   "best_fields",
+			},
+		},
+	}
+
+	var filter []map[string]interface{}
+	if boardID != "" {
+		filter = append(filter, map[string]interface{}{
+			"term": map[string]interface{}{"board_id": boardID},
+		})
+	}
+
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must":   must,
+				"filter": filter,
+			},
+		},
+		"highlight": map[string]interface{}{
+			"fields": map[string]interface{}{
+				"title":   map[string]interface{}{"number_of_fragments": 0},
+				"content": map[string]interface{}{"fragment_size": 150, "number_of_fragments": 3},
+			},
+			"pre_tags":  []string{"<mark>"},
+			"post_tags": []string{"</mark>"},
+		},
+		"sort": []interface{}{
+			"_score",
+			map[string]interface{}{"created_at": map[string]interface{}{"order": "desc"}},
+		},
+	}
+
+	from := (page - 1) * perPage
+	return s.esClient.Search(ctx, PostsIndex, query, from, perPage)
+}
+
+// SearchComments searches comments with highlighting
+func (s *SearchService) SearchComments(ctx context.Context, keyword, boardID string, page, perPage int) (*es.SearchResponse, error) {
+	must := []map[string]interface{}{
+		{
+			"match": map[string]interface{}{
+				"content": map[string]interface{}{
+					"query":    keyword,
+					"analyzer": "korean",
+				},
+			},
+		},
+	}
+
+	var filter []map[string]interface{}
+	if boardID != "" {
+		filter = append(filter, map[string]interface{}{
+			"term": map[string]interface{}{"board_id": boardID},
+		})
+	}
+
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"must":   must,
+				"filter": filter,
+			},
+		},
+		"highlight": map[string]interface{}{
+			"fields": map[string]interface{}{
+				"content": map[string]interface{}{"fragment_size": 200, "number_of_fragments": 3},
+			},
+			"pre_tags":  []string{"<mark>"},
+			"post_tags": []string{"</mark>"},
+		},
+		"sort": []interface{}{
+			"_score",
+			map[string]interface{}{"created_at": map[string]interface{}{"order": "desc"}},
+		},
+	}
+
+	from := (page - 1) * perPage
+	return s.esClient.Search(ctx, CommentsIndex, query, from, perPage)
+}
+
+// UnifiedSearch searches across both posts and comments
+func (s *SearchService) UnifiedSearch(ctx context.Context, keyword, boardID, searchType string, page, perPage int) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
+
+	switch searchType {
+	case "posts":
+		posts, err := s.SearchPosts(ctx, keyword, boardID, page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		result["posts"] = posts
+	case "comments":
+		comments, err := s.SearchComments(ctx, keyword, boardID, page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		result["comments"] = comments
+	default:
+		// Search both
+		posts, err := s.SearchPosts(ctx, keyword, boardID, page, perPage)
+		if err != nil {
+			return nil, err
+		}
+		comments, err := s.SearchComments(ctx, keyword, boardID, 1, 5) // 댓글은 상위 5개만
+		if err != nil {
+			return nil, err
+		}
+		result["posts"] = posts
+		result["comments"] = comments
+	}
+
+	return result, nil
+}
+
+// Autocomplete returns title suggestions
+func (s *SearchService) Autocomplete(ctx context.Context, prefix string, size int) ([]string, error) {
+	if size <= 0 {
+		size = 10
+	}
+	return s.esClient.Suggest(ctx, PostsIndex, "title_suggest", prefix, size)
+}
+
+// BulkIndexPosts indexes multiple posts from the database (for initial sync)
+func (s *SearchService) BulkIndexPosts(ctx context.Context, boardID string, limit int) (int, error) {
+	if s.db == nil {
+		return 0, fmt.Errorf("database not available")
+	}
+
+	tableName := fmt.Sprintf("g5_write_%s", boardID)
+
+	var rows []struct {
+		WrID      int    `gorm:"column:wr_id"`
+		WrSubject string `gorm:"column:wr_subject"`
+		WrContent string `gorm:"column:wr_content"`
+		WrName    string `gorm:"column:wr_name"`
+		MbID      string `gorm:"column:mb_id"`
+		CaName    string `gorm:"column:ca_name"`
+		WrDatetime string `gorm:"column:wr_datetime"`
+		WrHit     int    `gorm:"column:wr_hit"`
+		WrGood    int    `gorm:"column:wr_good"`
+	}
+
+	err := s.db.Table(tableName).
+		Where("wr_is_comment = 0").
+		Order("wr_id DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return 0, err
+	}
+
+	docs := make(map[string]interface{})
+	for _, row := range rows {
+		docID := fmt.Sprintf("%s_%d", boardID, row.WrID)
+		docs[docID] = PostDocument{
+			BoardID:   boardID,
+			PostID:    row.WrID,
+			Title:     row.WrSubject,
+			Content:   stripHTML(row.WrContent),
+			Author:    row.WrName,
+			AuthorID:  row.MbID,
+			Category:  row.CaName,
+			CreatedAt: row.WrDatetime,
+			Views:     row.WrHit,
+			Good:      row.WrGood,
+			TitleSuggest: map[string]interface{}{
+				"input": strings.Fields(row.WrSubject),
+			},
+		}
+	}
+
+	if err := s.esClient.BulkIndex(ctx, PostsIndex, docs); err != nil {
+		return 0, err
+	}
+
+	pkglogger.GetLogger().Info().
+		Str("board_id", boardID).
+		Int("count", len(docs)).
+		Msg("bulk indexed posts")
+
+	return len(docs), nil
+}
+
+// stripHTML removes HTML tags (simple version)
+func stripHTML(s string) string {
+	var result strings.Builder
+	inTag := false
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}

--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -1,0 +1,308 @@
+package elasticsearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	pkglogger "github.com/damoang/angple-backend/pkg/logger"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/esapi"
+)
+
+// Client wraps the Elasticsearch client with convenience methods
+type Client struct {
+	es *elasticsearch.Client
+}
+
+// NewClient creates a new Elasticsearch client
+func NewClient(addresses []string, username, password string) (*Client, error) {
+	cfg := elasticsearch.Config{
+		Addresses: addresses,
+	}
+	if username != "" {
+		cfg.Username = username
+		cfg.Password = password
+	}
+
+	es, err := elasticsearch.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("elasticsearch client creation failed: %w", err)
+	}
+
+	// Ping
+	res, err := es.Info()
+	if err != nil {
+		return nil, fmt.Errorf("elasticsearch connection failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		return nil, fmt.Errorf("elasticsearch error: %s", res.String())
+	}
+
+	pkglogger.GetLogger().Info().Msg("connected to Elasticsearch")
+	return &Client{es: es}, nil
+}
+
+// IndexDocument indexes a single document
+func (c *Client) IndexDocument(ctx context.Context, index, docID string, body interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+
+	req := esapi.IndexRequest{
+		Index:      index,
+		DocumentID: docID,
+		Body:       bytes.NewReader(data),
+		Refresh:    "false",
+	}
+
+	res, err := req.Do(ctx, c.es)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("index error [%s]: %s", res.Status(), string(body))
+	}
+	return nil
+}
+
+// DeleteDocument removes a document from an index
+func (c *Client) DeleteDocument(ctx context.Context, index, docID string) error {
+	req := esapi.DeleteRequest{
+		Index:      index,
+		DocumentID: docID,
+	}
+
+	res, err := req.Do(ctx, c.es)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	// 404 is ok (document already gone)
+	if res.IsError() && res.StatusCode != 404 {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("delete error [%s]: %s", res.Status(), string(body))
+	}
+	return nil
+}
+
+// BulkIndex indexes multiple documents in a single request
+func (c *Client) BulkIndex(ctx context.Context, index string, docs map[string]interface{}) error {
+	if len(docs) == 0 {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for id, doc := range docs {
+		meta := map[string]interface{}{
+			"index": map[string]interface{}{
+				"_index": index,
+				"_id":    id,
+			},
+		}
+		metaLine, _ := json.Marshal(meta)
+		buf.Write(metaLine)
+		buf.WriteByte('\n')
+		dataLine, _ := json.Marshal(doc)
+		buf.Write(dataLine)
+		buf.WriteByte('\n')
+	}
+
+	res, err := c.es.Bulk(bytes.NewReader(buf.Bytes()), c.es.Bulk.WithContext(ctx), c.es.Bulk.WithRefresh("false"))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("bulk error [%s]: %s", res.Status(), string(body))
+	}
+	return nil
+}
+
+// SearchResult represents a single search hit
+type SearchResult struct {
+	ID        string                 `json:"id"`
+	Score     float64                `json:"score"`
+	Source    map[string]interface{} `json:"source"`
+	Highlight map[string][]string    `json:"highlight,omitempty"`
+}
+
+// SearchResponse holds search results
+type SearchResponse struct {
+	Total   int64          `json:"total"`
+	Results []SearchResult `json:"results"`
+	Suggest []string       `json:"suggest,omitempty"`
+}
+
+// Search performs a search query and returns results with highlights
+func (c *Client) Search(ctx context.Context, index string, query map[string]interface{}, from, size int) (*SearchResponse, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(query); err != nil {
+		return nil, err
+	}
+
+	res, err := c.es.Search(
+		c.es.Search.WithContext(ctx),
+		c.es.Search.WithIndex(index),
+		c.es.Search.WithBody(&buf),
+		c.es.Search.WithFrom(from),
+		c.es.Search.WithSize(size),
+		c.es.Search.WithTrackTotalHits(true),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("search error [%s]: %s", res.Status(), string(body))
+	}
+
+	var raw map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+
+	return parseSearchResponse(raw), nil
+}
+
+// Suggest returns autocomplete suggestions
+func (c *Client) Suggest(ctx context.Context, index, field, text string, size int) ([]string, error) {
+	query := map[string]interface{}{
+		"suggest": map[string]interface{}{
+			"autocomplete": map[string]interface{}{
+				"prefix": text,
+				"completion": map[string]interface{}{
+					"field":           field,
+					"size":            size,
+					"skip_duplicates": true,
+				},
+			},
+		},
+		"_source": false,
+	}
+
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(query)
+
+	res, err := c.es.Search(
+		c.es.Search.WithContext(ctx),
+		c.es.Search.WithIndex(index),
+		c.es.Search.WithBody(&buf),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var raw map[string]interface{}
+	json.NewDecoder(res.Body).Decode(&raw)
+
+	var suggestions []string
+	if suggest, ok := raw["suggest"].(map[string]interface{}); ok {
+		if autocomplete, ok := suggest["autocomplete"].([]interface{}); ok && len(autocomplete) > 0 {
+			if first, ok := autocomplete[0].(map[string]interface{}); ok {
+				if options, ok := first["options"].([]interface{}); ok {
+					for _, opt := range options {
+						if optMap, ok := opt.(map[string]interface{}); ok {
+							if text, ok := optMap["text"].(string); ok {
+								suggestions = append(suggestions, text)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return suggestions, nil
+}
+
+// CreateIndex creates an index with the given mapping
+func (c *Client) CreateIndex(ctx context.Context, index string, mapping map[string]interface{}) error {
+	// Check if index exists
+	res, err := c.es.Indices.Exists([]string{index})
+	if err != nil {
+		return err
+	}
+	res.Body.Close()
+	if res.StatusCode == 200 {
+		return nil // Already exists
+	}
+
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(mapping)
+
+	res, err = c.es.Indices.Create(index, c.es.Indices.Create.WithBody(&buf), c.es.Indices.Create.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.IsError() {
+		body, _ := io.ReadAll(res.Body)
+		// Ignore "already exists" error
+		if !strings.Contains(string(body), "resource_already_exists_exception") {
+			return fmt.Errorf("create index error: %s", string(body))
+		}
+	}
+	return nil
+}
+
+func parseSearchResponse(raw map[string]interface{}) *SearchResponse {
+	resp := &SearchResponse{}
+
+	if hits, ok := raw["hits"].(map[string]interface{}); ok {
+		if total, ok := hits["total"].(map[string]interface{}); ok {
+			if v, ok := total["value"].(float64); ok {
+				resp.Total = int64(v)
+			}
+		}
+
+		if hitList, ok := hits["hits"].([]interface{}); ok {
+			for _, h := range hitList {
+				hit, ok := h.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				result := SearchResult{
+					ID: fmt.Sprintf("%v", hit["_id"]),
+				}
+				if score, ok := hit["_score"].(float64); ok {
+					result.Score = score
+				}
+				if source, ok := hit["_source"].(map[string]interface{}); ok {
+					result.Source = source
+				}
+				if hl, ok := hit["highlight"].(map[string]interface{}); ok {
+					result.Highlight = make(map[string][]string)
+					for field, fragments := range hl {
+						if fragList, ok := fragments.([]interface{}); ok {
+							for _, f := range fragList {
+								if s, ok := f.(string); ok {
+									result.Highlight[field] = append(result.Highlight[field], s)
+								}
+							}
+						}
+					}
+				}
+				resp.Results = append(resp.Results, result)
+			}
+		}
+	}
+
+	return resp
+}


### PR DESCRIPTION
## Summary
- Elasticsearch Go 클라이언트 래퍼 (pkg/elasticsearch)
- 게시글/댓글 인덱스 (한국어 nori 형태소 분석기)
- 통합 검색 API (`/api/v2/search?q=keyword&type=posts`)
- 검색 자동완성 (`/api/v2/search/autocomplete?q=prefix`)
- 하이라이팅 (`<mark>` 태그)
- 벌크 인덱싱 관리자 API (`/api/v2/admin/search/index`)
- 실시간 개별 인덱스/삭제 API
- ElasticsearchConfig (YAML + `ELASTICSEARCH_URL` 환경변수)

## Test plan
- [x] `go build ./cmd/api/` 성공
- [x] `go test ./internal/service/...` 전체 통과
- [ ] Elasticsearch 로컬 설치 후 검색 테스트
- [ ] nori 분석기 한국어 형태소 분석 확인
- [ ] 자동완성 Suggest 동작 확인
- [ ] 벌크 인덱싱 (기존 게시글 → ES 동기화) 확인