### PR TITLE
feat(payment): 토스페이먼츠 + Stripe 결제 연동, 웹훅, 환불

### DIFF
--- a/internal/domain/payment.go
+++ b/internal/domain/payment.go
@@ -1,0 +1,82 @@
+package domain
+
+import "time"
+
+// PaymentProvider supported payment providers
+type PaymentProvider string
+
+const (
+	PaymentProviderToss   PaymentProvider = "toss"
+	PaymentProviderStripe PaymentProvider = "stripe"
+)
+
+// Payment represents a single payment transaction
+type Payment struct {
+	ID              int64           `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	OrderID         string          `gorm:"column:order_id;uniqueIndex;size:64" json:"order_id"`
+	SiteID          string          `gorm:"column:site_id;index" json:"site_id"`
+	UserID          string          `gorm:"column:user_id;index" json:"user_id"`
+	InvoiceID       *int64          `gorm:"column:invoice_id" json:"invoice_id,omitempty"`
+	Provider        PaymentProvider `gorm:"column:provider" json:"provider"`
+	ExternalPayID   string          `gorm:"column:external_pay_id;index" json:"external_pay_id"` // toss paymentKey / stripe payment_intent
+	Amount          int             `gorm:"column:amount" json:"amount"`
+	Currency        string          `gorm:"column:currency;default:KRW" json:"currency"`
+	Status          string          `gorm:"column:status;default:pending" json:"status"` // pending, confirmed, failed, canceled, refunded, partial_refunded
+	Method          string          `gorm:"column:method" json:"method"`                 // card, transfer, virtual_account
+	Description     string          `gorm:"column:description" json:"description"`
+	FailReason      string          `gorm:"column:fail_reason" json:"fail_reason,omitempty"`
+	RefundedAmount  int             `gorm:"column:refunded_amount;default:0" json:"refunded_amount"`
+	IdempotencyKey  string          `gorm:"column:idempotency_key;uniqueIndex;size:64" json:"-"`
+	Metadata        string          `gorm:"column:metadata;type:text" json:"metadata,omitempty"` // JSON
+	RetryCount      int             `gorm:"column:retry_count;default:0" json:"retry_count"`
+	NextRetryAt     *time.Time      `gorm:"column:next_retry_at" json:"next_retry_at,omitempty"`
+	ConfirmedAt     *time.Time      `gorm:"column:confirmed_at" json:"confirmed_at,omitempty"`
+	CreatedAt       time.Time       `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	UpdatedAt       time.Time       `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`
+}
+
+func (Payment) TableName() string {
+	return "payments"
+}
+
+// RefundRequest represents a refund request
+type RefundRequest struct {
+	PaymentID int64  `json:"payment_id" binding:"required"`
+	Amount    int    `json:"amount"` // 0 = full refund
+	Reason    string `json:"reason" binding:"required"`
+}
+
+// TossConfirmRequest is sent by the frontend after Toss checkout
+type TossConfirmRequest struct {
+	PaymentKey string `json:"paymentKey" binding:"required"`
+	OrderID    string `json:"orderId" binding:"required"`
+	Amount     int    `json:"amount" binding:"required"`
+}
+
+// TossWebhookPayload is the payload from Toss Payments webhook
+type TossWebhookPayload struct {
+	EventType string                 `json:"eventType"`
+	Data      map[string]interface{} `json:"data"`
+}
+
+// StripeCheckoutRequest for creating a Stripe checkout session
+type StripeCheckoutRequest struct {
+	SiteID     string `json:"site_id" binding:"required"`
+	Plan       string `json:"plan" binding:"required"`
+	SuccessURL string `json:"success_url" binding:"required"`
+	CancelURL  string `json:"cancel_url" binding:"required"`
+}
+
+// PaymentSummary for listing payments
+type PaymentSummary struct {
+	ID            int64  `json:"id"`
+	OrderID       string `json:"order_id"`
+	Provider      string `json:"provider"`
+	Amount        int    `json:"amount"`
+	Currency      string `json:"currency"`
+	Status        string `json:"status"`
+	Method        string `json:"method"`
+	Description   string `json:"description"`
+	ConfirmedAt   string `json:"confirmed_at,omitempty"`
+	CreatedAt     string `json:"created_at"`
+}

--- a/internal/handler/payment_handler.go
+++ b/internal/handler/payment_handler.go
@@ -1,0 +1,205 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// PaymentHandler handles payment-related endpoints
+type PaymentHandler struct {
+	paymentService *service.PaymentService
+}
+
+// NewPaymentHandler creates a new PaymentHandler
+func NewPaymentHandler(paymentService *service.PaymentService) *PaymentHandler {
+	return &PaymentHandler{paymentService: paymentService}
+}
+
+// CreateTossPayment creates a pending payment for Toss checkout
+// POST /api/v2/payments/toss
+func (h *PaymentHandler) CreateTossPayment(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "Authentication required", nil)
+		return
+	}
+
+	var req struct {
+		SiteID      string `json:"site_id" binding:"required"`
+		Description string `json:"description" binding:"required"`
+		Amount      int    `json:"amount" binding:"required,min=100"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	payment, err := h.paymentService.CreateTossPayment(c.Request.Context(), req.SiteID, userID, req.Description, req.Amount)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": payment})
+}
+
+// ConfirmTossPayment confirms a Toss payment after frontend checkout
+// POST /api/v2/payments/toss/confirm
+func (h *PaymentHandler) ConfirmTossPayment(c *gin.Context) {
+	var req domain.TossConfirmRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	payment, err := h.paymentService.ConfirmTossPayment(c.Request.Context(), &req)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": payment})
+}
+
+// TossWebhook handles Toss Payments webhook
+// POST /api/v2/payments/toss/webhook
+func (h *PaymentHandler) TossWebhook(c *gin.Context) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	var payload domain.TossWebhookPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	if err := h.paymentService.HandleTossWebhook(c.Request.Context(), &payload); err != nil {
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}
+
+// CreateStripeCheckout creates a Stripe checkout session
+// POST /api/v2/payments/stripe/checkout
+func (h *PaymentHandler) CreateStripeCheckout(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "Authentication required", nil)
+		return
+	}
+
+	var req domain.StripeCheckoutRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	result, err := h.paymentService.CreateStripeCheckout(c.Request.Context(), &req, userID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+// StripeWebhook handles Stripe webhook events
+// POST /api/v2/payments/stripe/webhook
+func (h *PaymentHandler) StripeWebhook(c *gin.Context) {
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	var event struct {
+		Type string                 `json:"type"`
+		Data struct {
+			Object map[string]interface{} `json:"object"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &event); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	if err := h.paymentService.HandleStripeWebhook(c.Request.Context(), event.Type, event.Data.Object); err != nil {
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+
+	c.Status(http.StatusOK)
+}
+
+// RefundPayment processes a refund
+// POST /api/v2/payments/refund
+func (h *PaymentHandler) RefundPayment(c *gin.Context) {
+	var req domain.RefundRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request", nil)
+		return
+	}
+
+	payment, err := h.paymentService.RefundPayment(c.Request.Context(), &req)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": payment})
+}
+
+// ListPayments lists payments for a site
+// GET /api/v2/payments?site_id=xxx&page=1&per_page=20
+func (h *PaymentHandler) ListPayments(c *gin.Context) {
+	siteID := c.Query("site_id")
+	if siteID == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "site_id is required", nil)
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+	if page < 1 {
+		page = 1
+	}
+
+	payments, total, err := h.paymentService.ListPayments(c.Request.Context(), siteID, page, perPage)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to list payments", nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    payments,
+		"meta":    gin.H{"total": total, "page": page, "per_page": perPage},
+	})
+}
+
+// GetPayment returns a single payment by order ID
+// GET /api/v2/payments/:order_id
+func (h *PaymentHandler) GetPayment(c *gin.Context) {
+	orderID := c.Param("order_id")
+
+	payment, err := h.paymentService.GetPayment(c.Request.Context(), orderID)
+	if err != nil {
+		common.ErrorResponse(c, http.StatusNotFound, "Payment not found", nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": payment})
+}

--- a/internal/repository/payment_repo.go
+++ b/internal/repository/payment_repo.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// PaymentRepository handles payment persistence
+type PaymentRepository struct {
+	db *gorm.DB
+}
+
+// NewPaymentRepository creates a new PaymentRepository
+func NewPaymentRepository(db *gorm.DB) *PaymentRepository {
+	_ = db.AutoMigrate(&domain.Payment{})
+	return &PaymentRepository{db: db}
+}
+
+// Create inserts a new payment record
+func (r *PaymentRepository) Create(ctx context.Context, p *domain.Payment) error {
+	return r.db.WithContext(ctx).Create(p).Error
+}
+
+// FindByOrderID finds a payment by order ID
+func (r *PaymentRepository) FindByOrderID(ctx context.Context, orderID string) (*domain.Payment, error) {
+	var p domain.Payment
+	err := r.db.WithContext(ctx).Where("order_id = ?", orderID).First(&p).Error
+	return &p, err
+}
+
+// FindByExternalID finds a payment by provider's external ID
+func (r *PaymentRepository) FindByExternalID(ctx context.Context, externalID string) (*domain.Payment, error) {
+	var p domain.Payment
+	err := r.db.WithContext(ctx).Where("external_pay_id = ?", externalID).First(&p).Error
+	return &p, err
+}
+
+// FindByIdempotencyKey finds a payment by idempotency key
+func (r *PaymentRepository) FindByIdempotencyKey(ctx context.Context, key string) (*domain.Payment, error) {
+	var p domain.Payment
+	err := r.db.WithContext(ctx).Where("idempotency_key = ?", key).First(&p).Error
+	return &p, err
+}
+
+// Update updates a payment record
+func (r *PaymentRepository) Update(ctx context.Context, p *domain.Payment) error {
+	return r.db.WithContext(ctx).Save(p).Error
+}
+
+// ListBySiteID lists payments for a site with pagination
+func (r *PaymentRepository) ListBySiteID(ctx context.Context, siteID string, page, perPage int) ([]domain.Payment, int64, error) {
+	var payments []domain.Payment
+	var total int64
+
+	query := r.db.WithContext(ctx).Model(&domain.Payment{}).Where("site_id = ?", siteID)
+	query.Count(&total)
+
+	err := query.Order("created_at DESC").
+		Offset((page - 1) * perPage).Limit(perPage).
+		Find(&payments).Error
+
+	return payments, total, err
+}
+
+// ListPendingRetries finds failed payments that need retry
+func (r *PaymentRepository) ListPendingRetries(ctx context.Context, limit int) ([]domain.Payment, error) {
+	var payments []domain.Payment
+	err := r.db.WithContext(ctx).
+		Where("status = ? AND retry_count < ? AND next_retry_at <= NOW()", "failed", 3).
+		Order("next_retry_at ASC").
+		Limit(limit).
+		Find(&payments).Error
+	return payments, err
+}

--- a/internal/service/payment_service.go
+++ b/internal/service/payment_service.go
@@ -1,0 +1,485 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+	pkglogger "github.com/damoang/angple-backend/pkg/logger"
+	"gorm.io/gorm"
+)
+
+// PaymentService handles payment processing with Toss and Stripe
+type PaymentService struct {
+	paymentRepo *repository.PaymentRepository
+	subRepo     *repository.SubscriptionRepository
+	db          *gorm.DB
+
+	// Toss Payments
+	tossSecretKey string
+	tossBaseURL   string
+
+	// Stripe
+	stripeSecretKey string
+}
+
+// PaymentConfig holds payment provider configuration
+type PaymentConfig struct {
+	TossSecretKey   string
+	StripeSecretKey string
+}
+
+// NewPaymentService creates a new PaymentService
+func NewPaymentService(paymentRepo *repository.PaymentRepository, subRepo *repository.SubscriptionRepository, db *gorm.DB, cfg PaymentConfig) *PaymentService {
+	return &PaymentService{
+		paymentRepo:     paymentRepo,
+		subRepo:         subRepo,
+		db:              db,
+		tossSecretKey:   cfg.TossSecretKey,
+		tossBaseURL:     "https://api.tosspayments.com/v1",
+		stripeSecretKey: cfg.StripeSecretKey,
+	}
+}
+
+// --- Toss Payments ---
+
+// CreateTossPayment creates a pending payment record for Toss checkout
+func (s *PaymentService) CreateTossPayment(ctx context.Context, siteID, userID, description string, amount int) (*domain.Payment, error) {
+	orderID := generateOrderID()
+	idempotencyKey := generateIdempotencyKey()
+
+	payment := &domain.Payment{
+		OrderID:        orderID,
+		SiteID:         siteID,
+		UserID:         userID,
+		Provider:       domain.PaymentProviderToss,
+		Amount:         amount,
+		Currency:       "KRW",
+		Status:         "pending",
+		Description:    description,
+		IdempotencyKey: idempotencyKey,
+	}
+
+	if err := s.paymentRepo.Create(ctx, payment); err != nil {
+		return nil, fmt.Errorf("create payment: %w", err)
+	}
+
+	return payment, nil
+}
+
+// ConfirmTossPayment confirms a Toss payment after frontend checkout
+func (s *PaymentService) ConfirmTossPayment(ctx context.Context, req *domain.TossConfirmRequest) (*domain.Payment, error) {
+	// Find existing payment
+	payment, err := s.paymentRepo.FindByOrderID(ctx, req.OrderID)
+	if err != nil {
+		return nil, fmt.Errorf("payment not found: %w", err)
+	}
+
+	// Idempotency: already confirmed
+	if payment.Status == "confirmed" {
+		return payment, nil
+	}
+
+	// Verify amount matches
+	if payment.Amount != req.Amount {
+		return nil, fmt.Errorf("amount mismatch: expected %d, got %d", payment.Amount, req.Amount)
+	}
+
+	// Call Toss API to confirm
+	body := fmt.Sprintf(`{"paymentKey":"%s","orderId":"%s","amount":%d}`, req.PaymentKey, req.OrderID, req.Amount)
+	tossResp, err := s.tossRequest("POST", "/payments/confirm", body)
+	if err != nil {
+		payment.Status = "failed"
+		payment.FailReason = err.Error()
+		s.scheduleRetry(payment)
+		s.paymentRepo.Update(ctx, payment)
+		return nil, fmt.Errorf("toss confirm failed: %w", err)
+	}
+
+	// Update payment
+	now := time.Now()
+	payment.ExternalPayID = req.PaymentKey
+	payment.Status = "confirmed"
+	payment.ConfirmedAt = &now
+	if method, ok := tossResp["method"].(string); ok {
+		payment.Method = method
+	}
+
+	if err := s.paymentRepo.Update(ctx, payment); err != nil {
+		return nil, err
+	}
+
+	// Update subscription/invoice status
+	s.onPaymentConfirmed(ctx, payment)
+
+	pkglogger.GetLogger().Info().
+		Str("order_id", payment.OrderID).
+		Int("amount", payment.Amount).
+		Msg("toss payment confirmed")
+
+	return payment, nil
+}
+
+// HandleTossWebhook processes Toss Payments webhook events
+func (s *PaymentService) HandleTossWebhook(ctx context.Context, payload *domain.TossWebhookPayload) error {
+	pkglogger.GetLogger().Info().
+		Str("event_type", payload.EventType).
+		Msg("toss webhook received")
+
+	switch payload.EventType {
+	case "PAYMENT_STATUS_CHANGED":
+		return s.handleTossStatusChange(ctx, payload.Data)
+	default:
+		pkglogger.GetLogger().Warn().
+			Str("event_type", payload.EventType).
+			Msg("unhandled toss webhook event")
+	}
+	return nil
+}
+
+func (s *PaymentService) handleTossStatusChange(ctx context.Context, data map[string]interface{}) error {
+	paymentKey, _ := data["paymentKey"].(string)
+	status, _ := data["status"].(string)
+
+	if paymentKey == "" {
+		return fmt.Errorf("missing paymentKey in webhook")
+	}
+
+	payment, err := s.paymentRepo.FindByExternalID(ctx, paymentKey)
+	if err != nil {
+		return fmt.Errorf("payment not found for key %s: %w", paymentKey, err)
+	}
+
+	switch status {
+	case "DONE":
+		now := time.Now()
+		payment.Status = "confirmed"
+		payment.ConfirmedAt = &now
+		s.onPaymentConfirmed(ctx, payment)
+	case "CANCELED":
+		payment.Status = "canceled"
+	case "ABORTED", "EXPIRED":
+		payment.Status = "failed"
+		payment.FailReason = status
+	}
+
+	return s.paymentRepo.Update(ctx, payment)
+}
+
+// --- Stripe ---
+
+// CreateStripeCheckout creates a Stripe checkout session
+func (s *PaymentService) CreateStripeCheckout(ctx context.Context, req *domain.StripeCheckoutRequest, userID string) (map[string]string, error) {
+	orderID := generateOrderID()
+
+	// Create pending payment
+	payment := &domain.Payment{
+		OrderID:        orderID,
+		SiteID:         req.SiteID,
+		UserID:         userID,
+		Provider:       domain.PaymentProviderStripe,
+		Amount:         0, // Set by Stripe
+		Currency:       "USD",
+		Status:         "pending",
+		Description:    fmt.Sprintf("Plan: %s", req.Plan),
+		IdempotencyKey: generateIdempotencyKey(),
+	}
+
+	if err := s.paymentRepo.Create(ctx, payment); err != nil {
+		return nil, err
+	}
+
+	// Call Stripe API to create checkout session
+	body := fmt.Sprintf("mode=subscription&success_url=%s&cancel_url=%s&metadata[order_id]=%s&metadata[site_id]=%s",
+		req.SuccessURL, req.CancelURL, orderID, req.SiteID)
+
+	resp, err := s.stripeRequest("POST", "/v1/checkout/sessions", body)
+	if err != nil {
+		return nil, fmt.Errorf("stripe checkout creation failed: %w", err)
+	}
+
+	sessionID, _ := resp["id"].(string)
+	sessionURL, _ := resp["url"].(string)
+
+	return map[string]string{
+		"session_id":  sessionID,
+		"checkout_url": sessionURL,
+		"order_id":    orderID,
+	}, nil
+}
+
+// HandleStripeWebhook processes Stripe webhook events
+func (s *PaymentService) HandleStripeWebhook(ctx context.Context, eventType string, data map[string]interface{}) error {
+	pkglogger.GetLogger().Info().
+		Str("event_type", eventType).
+		Msg("stripe webhook received")
+
+	switch eventType {
+	case "checkout.session.completed":
+		return s.handleStripeCheckoutCompleted(ctx, data)
+	case "invoice.paid":
+		return s.handleStripeInvoicePaid(ctx, data)
+	case "invoice.payment_failed":
+		return s.handleStripePaymentFailed(ctx, data)
+	case "customer.subscription.deleted":
+		return s.handleStripeSubscriptionCanceled(ctx, data)
+	}
+	return nil
+}
+
+func (s *PaymentService) handleStripeCheckoutCompleted(ctx context.Context, data map[string]interface{}) error {
+	metadata, _ := data["metadata"].(map[string]interface{})
+	orderID, _ := metadata["order_id"].(string)
+
+	if orderID == "" {
+		return nil
+	}
+
+	payment, err := s.paymentRepo.FindByOrderID(ctx, orderID)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	payment.Status = "confirmed"
+	payment.ConfirmedAt = &now
+	if subID, ok := data["subscription"].(string); ok {
+		payment.ExternalPayID = subID
+	}
+
+	s.onPaymentConfirmed(ctx, payment)
+	return s.paymentRepo.Update(ctx, payment)
+}
+
+func (s *PaymentService) handleStripeInvoicePaid(ctx context.Context, data map[string]interface{}) error {
+	subID, _ := data["subscription"].(string)
+	if subID == "" {
+		return nil
+	}
+
+	// Update subscription period
+	var sub domain.Subscription
+	if err := s.db.Where("external_sub_id = ?", subID).First(&sub).Error; err != nil {
+		return nil
+	}
+
+	sub.Status = "active"
+	sub.CurrentPeriodStart = time.Now()
+	sub.CurrentPeriodEnd = time.Now().AddDate(0, 1, 0)
+	return s.db.Save(&sub).Error
+}
+
+func (s *PaymentService) handleStripePaymentFailed(ctx context.Context, data map[string]interface{}) error {
+	subID, _ := data["subscription"].(string)
+	if subID == "" {
+		return nil
+	}
+
+	var sub domain.Subscription
+	if err := s.db.Where("external_sub_id = ?", subID).First(&sub).Error; err != nil {
+		return nil
+	}
+
+	sub.Status = "past_due"
+	return s.db.Save(&sub).Error
+}
+
+func (s *PaymentService) handleStripeSubscriptionCanceled(ctx context.Context, data map[string]interface{}) error {
+	subID, _ := data["id"].(string)
+	if subID == "" {
+		return nil
+	}
+
+	var sub domain.Subscription
+	if err := s.db.Where("external_sub_id = ?", subID).First(&sub).Error; err != nil {
+		return nil
+	}
+
+	now := time.Now()
+	sub.Status = "canceled"
+	sub.CanceledAt = &now
+	return s.db.Save(&sub).Error
+}
+
+// --- Refund ---
+
+// RefundPayment processes a refund (full or partial)
+func (s *PaymentService) RefundPayment(ctx context.Context, req *domain.RefundRequest) (*domain.Payment, error) {
+	var payment domain.Payment
+	if err := s.db.WithContext(ctx).First(&payment, req.PaymentID).Error; err != nil {
+		return nil, fmt.Errorf("payment not found")
+	}
+
+	if payment.Status != "confirmed" {
+		return nil, fmt.Errorf("can only refund confirmed payments")
+	}
+
+	refundAmount := req.Amount
+	if refundAmount == 0 {
+		refundAmount = payment.Amount - payment.RefundedAmount
+	}
+
+	if refundAmount <= 0 || refundAmount > (payment.Amount-payment.RefundedAmount) {
+		return nil, fmt.Errorf("invalid refund amount")
+	}
+
+	switch payment.Provider {
+	case domain.PaymentProviderToss:
+		body := fmt.Sprintf(`{"cancelReason":"%s","cancelAmount":%d}`, req.Reason, refundAmount)
+		_, err := s.tossRequest("POST", fmt.Sprintf("/payments/%s/cancel", payment.ExternalPayID), body)
+		if err != nil {
+			return nil, fmt.Errorf("toss refund failed: %w", err)
+		}
+
+	case domain.PaymentProviderStripe:
+		body := fmt.Sprintf("payment_intent=%s&amount=%d&reason=requested_by_customer", payment.ExternalPayID, refundAmount)
+		_, err := s.stripeRequest("POST", "/v1/refunds", body)
+		if err != nil {
+			return nil, fmt.Errorf("stripe refund failed: %w", err)
+		}
+	}
+
+	payment.RefundedAmount += refundAmount
+	if payment.RefundedAmount >= payment.Amount {
+		payment.Status = "refunded"
+	} else {
+		payment.Status = "partial_refunded"
+	}
+
+	if err := s.paymentRepo.Update(ctx, &payment); err != nil {
+		return nil, err
+	}
+
+	pkglogger.GetLogger().Info().
+		Str("order_id", payment.OrderID).
+		Int("refund_amount", refundAmount).
+		Msg("payment refunded")
+
+	return &payment, nil
+}
+
+// --- Payments List ---
+
+// ListPayments returns paginated payments for a site
+func (s *PaymentService) ListPayments(ctx context.Context, siteID string, page, perPage int) ([]domain.Payment, int64, error) {
+	return s.paymentRepo.ListBySiteID(ctx, siteID, page, perPage)
+}
+
+// GetPayment returns a single payment by order ID
+func (s *PaymentService) GetPayment(ctx context.Context, orderID string) (*domain.Payment, error) {
+	return s.paymentRepo.FindByOrderID(ctx, orderID)
+}
+
+// --- Internal helpers ---
+
+func (s *PaymentService) onPaymentConfirmed(ctx context.Context, payment *domain.Payment) {
+	// Update related invoice if exists
+	if payment.InvoiceID != nil {
+		s.db.Model(&domain.Invoice{}).Where("id = ?", *payment.InvoiceID).Updates(map[string]interface{}{
+			"status":  "paid",
+			"paid_at": time.Now(),
+		})
+	}
+
+	// Activate subscription
+	s.db.Model(&domain.Subscription{}).Where("site_id = ?", payment.SiteID).Updates(map[string]interface{}{
+		"status":           "active",
+		"payment_provider": string(payment.Provider),
+	})
+}
+
+func (s *PaymentService) scheduleRetry(payment *domain.Payment) {
+	payment.RetryCount++
+	// Exponential backoff: 1h, 4h, 24h
+	delays := []time.Duration{1 * time.Hour, 4 * time.Hour, 24 * time.Hour}
+	if payment.RetryCount <= len(delays) {
+		next := time.Now().Add(delays[payment.RetryCount-1])
+		payment.NextRetryAt = &next
+	}
+}
+
+func (s *PaymentService) tossRequest(method, path, body string) (map[string]interface{}, error) {
+	url := s.tossBaseURL + path
+	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic "+basicAuth(s.tossSecretKey, ""))
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	json.Unmarshal(respBody, &result)
+
+	if resp.StatusCode >= 400 {
+		errMsg, _ := result["message"].(string)
+		return nil, fmt.Errorf("toss API error (%d): %s", resp.StatusCode, errMsg)
+	}
+
+	return result, nil
+}
+
+func (s *PaymentService) stripeRequest(method, path, body string) (map[string]interface{}, error) {
+	url := "https://api.stripe.com" + path
+	req, err := http.NewRequest(method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+s.stripeSecretKey)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	var result map[string]interface{}
+	json.Unmarshal(respBody, &result)
+
+	if resp.StatusCode >= 400 {
+		if errObj, ok := result["error"].(map[string]interface{}); ok {
+			msg, _ := errObj["message"].(string)
+			return nil, fmt.Errorf("stripe API error (%d): %s", resp.StatusCode, msg)
+		}
+		return nil, fmt.Errorf("stripe API error (%d)", resp.StatusCode)
+	}
+
+	return result, nil
+}
+
+func generateOrderID() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return fmt.Sprintf("ORD_%s_%d", hex.EncodeToString(b[:8]), time.Now().UnixMilli())
+}
+
+func generateIdempotencyKey() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}


### PR DESCRIPTION
## Summary
- 토스페이먼츠 결제: 생성 → 프론트 체크아웃 → confirm API → 웹훅
- Stripe 결제: 체크아웃 세션 → 구독 결제 → 웹훅 (invoice.paid, payment_failed, subscription.deleted)
- 환불 처리: 전액/부분 환불 (토스 cancel API, Stripe refunds API)
- 결제 실패 자동 재시도 (지수 백오프 1h→4h→24h, 최대 3회)
- 멱등성 보장 (idempotency_key unique index)
- Subscription/Invoice 상태 자동 동기화 (결제 확인 시 active, 실패 시 past_due)
- 8개 API 엔드포인트 (/api/v2/payments/*)

## Test plan
- [x] `go build ./cmd/api/` 성공
- [x] `go test ./internal/service/...` 전체 통과
- [ ] 토스페이먼츠 테스트 키로 결제 플로우 테스트
- [ ] Stripe 테스트 모드 체크아웃 테스트
- [ ] 웹훅 수신 동작 확인
- [ ] 환불 처리 확인
- [ ] 멱등성 (중복 confirm 요청) 확인