### PR TITLE
feat: v1 API Sunset 준비 (v2 인증 + 리다이렉트 미들웨어)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -499,6 +499,11 @@ func main() {
 		v2Handler := v2handler.NewV2Handler(v2UserRepo, v2PostRepo, v2CommentRepo, v2BoardRepo)
 		v2routes.Setup(router, v2Handler, jwtManager)
 
+		// v2 Auth API
+		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager)
+		v2AuthHandler := v2handler.NewV2AuthHandler(v2AuthSvc)
+		v2routes.SetupAuth(router, v2AuthHandler, jwtManager)
+
 		// v2 Admin API
 		v2AdminSvc := v2svc.NewAdminService(v2UserRepo, v2BoardRepo, v2PostRepo, v2CommentRepo)
 		v2AdminHandler := v2handler.NewAdminHandler(v2AdminSvc)

--- a/internal/handler/v2/auth_handler.go
+++ b/internal/handler/v2/auth_handler.go
@@ -1,0 +1,104 @@
+package v2
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	v2svc "github.com/damoang/angple-backend/internal/service/v2"
+	"github.com/gin-gonic/gin"
+)
+
+// V2AuthHandler handles v2 authentication endpoints
+type V2AuthHandler struct {
+	authService *v2svc.V2AuthService
+}
+
+// NewV2AuthHandler creates a new V2AuthHandler
+func NewV2AuthHandler(authService *v2svc.V2AuthService) *V2AuthHandler {
+	return &V2AuthHandler{authService: authService}
+}
+
+type v2LoginRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
+type v2RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
+// Login handles POST /api/v2/auth/login
+func (h *V2AuthHandler) Login(c *gin.Context) {
+	var req v2LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청입니다", err)
+		return
+	}
+
+	resp, err := h.authService.Login(req.Username, req.Password)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "로그인에 실패했습니다", err)
+		return
+	}
+
+	// Set refresh token as httpOnly cookie
+	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", true, true)
+
+	common.V2Success(c, gin.H{
+		"access_token": resp.AccessToken,
+		"user":         resp.User,
+	})
+}
+
+// RefreshToken handles POST /api/v2/auth/refresh
+func (h *V2AuthHandler) RefreshToken(c *gin.Context) {
+	// Try cookie first, then JSON body
+	refreshToken, err := c.Cookie("refresh_token")
+	if err != nil || refreshToken == "" {
+		var req v2RefreshRequest
+		if bindErr := c.ShouldBindJSON(&req); bindErr != nil || req.RefreshToken == "" {
+			common.V2ErrorResponse(c, http.StatusUnauthorized, "리프레시 토큰이 없습니다", nil)
+			return
+		}
+		refreshToken = req.RefreshToken
+	}
+
+	resp, err := h.authService.RefreshToken(refreshToken)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "토큰 갱신에 실패했습니다", err)
+		return
+	}
+
+	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", true, true)
+
+	common.V2Success(c, gin.H{
+		"access_token": resp.AccessToken,
+		"user":         resp.User,
+	})
+}
+
+// Logout handles POST /api/v2/auth/logout
+func (h *V2AuthHandler) Logout(c *gin.Context) {
+	c.SetCookie("refresh_token", "", -1, "/", "", true, true)
+	common.V2Success(c, gin.H{"message": "로그아웃되었습니다"})
+}
+
+// GetMe handles GET /api/v2/auth/me
+func (h *V2AuthHandler) GetMe(c *gin.Context) {
+	userIDStr := middleware.GetUserID(c)
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증 정보가 올바르지 않습니다", err)
+		return
+	}
+
+	user, err := h.authService.GetCurrentUser(userID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "사용자를 찾을 수 없습니다", err)
+		return
+	}
+
+	common.V2Success(c, user)
+}

--- a/internal/handler/v2/auth_handler.go
+++ b/internal/handler/v2/auth_handler.go
@@ -11,6 +11,8 @@ import (
 )
 
 // V2AuthHandler handles v2 authentication endpoints
+//
+//nolint:revive
 type V2AuthHandler struct {
 	authService *v2svc.V2AuthService
 }

--- a/internal/middleware/v1_redirect.go
+++ b/internal/middleware/v1_redirect.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// V1RedirectConfig configures the v1→v2 redirect middleware
+type V1RedirectConfig struct {
+	// Enabled controls whether redirects are active (false = headers only, true = 301 redirect)
+	Enabled bool
+}
+
+// v1ToV2Route defines a mapping from v1 path pattern to v2 path pattern.
+// Placeholders like :board_id are preserved.
+type v1ToV2Route struct {
+	method string
+	v1Path string
+	v2Path string
+}
+
+// v1Redirects maps v1 endpoints to their v2 equivalents.
+// Only endpoints that have v2 implementations are listed.
+//
+//nolint:gochecknoglobals
+var v1Redirects = []v1ToV2Route{
+	// Users
+	{"GET", "/api/v1/auth/me", "/api/v2/me"},
+
+	// Boards
+	{"GET", "/api/v1/boards", "/api/v2/boards"},
+
+	// Posts — v1 uses :board_id, v2 uses :slug (same value for migrated boards)
+	{"GET", "/api/v1/boards/:board_id/posts", "/api/v2/boards/:board_id/posts"},
+	{"POST", "/api/v1/boards/:board_id/posts", "/api/v2/boards/:board_id/posts"},
+
+	// Comments
+	{"GET", "/api/v1/boards/:board_id/posts/:id/comments", "/api/v2/boards/:board_id/posts/:id/comments"},
+	{"POST", "/api/v1/boards/:board_id/posts/:id/comments", "/api/v2/boards/:board_id/posts/:id/comments"},
+
+	// Scraps
+	{"POST", "/api/v1/boards/:board_id/posts/:id/scrap", "/api/v2/posts/:id/scrap"},
+	{"DELETE", "/api/v1/boards/:board_id/posts/:id/scrap", "/api/v2/posts/:id/scrap"},
+	{"GET", "/api/v1/members/me/scraps", "/api/v2/me/scraps"},
+
+	// Memos
+	{"GET", "/api/v1/members/:id/memo", "/api/v2/members/:id/memo"},
+	{"POST", "/api/v1/members/:id/memo", "/api/v2/members/:id/memo"},
+	{"PUT", "/api/v1/members/:id/memo", "/api/v2/members/:id/memo"},
+	{"DELETE", "/api/v1/members/:id/memo", "/api/v2/members/:id/memo"},
+
+	// Messages
+	{"POST", "/api/v1/messages", "/api/v2/messages"},
+	{"GET", "/api/v1/messages/inbox", "/api/v2/messages/inbox"},
+	{"GET", "/api/v1/messages/sent", "/api/v2/messages/sent"},
+	{"GET", "/api/v1/messages/:id", "/api/v2/messages/:id"},
+	{"DELETE", "/api/v1/messages/:id", "/api/v2/messages/:id"},
+}
+
+// V1ToV2Redirect returns a middleware that adds v2 migration hints.
+// When cfg.Enabled is true, matching requests get a 301 redirect.
+// When false, only the Link header with the v2 URL is added (informational).
+func V1ToV2Redirect(cfg V1RedirectConfig) gin.HandlerFunc {
+	// Build lookup: "METHOD /api/v1/..." -> v2 pattern
+	type routeEntry struct {
+		v1Pattern string
+		v2Pattern string
+	}
+	lookup := make(map[string]routeEntry, len(v1Redirects))
+	for _, r := range v1Redirects {
+		key := r.method + " " + r.v1Path
+		lookup[key] = routeEntry{v1Pattern: r.v1Path, v2Pattern: r.v2Path}
+	}
+
+	return func(c *gin.Context) {
+		key := c.Request.Method + " " + c.FullPath()
+		entry, ok := lookup[key]
+		if !ok {
+			c.Next()
+			return
+		}
+
+		// Resolve actual URL by replacing params
+		v2URL := resolveV2URL(entry.v2Pattern, entry.v1Pattern, c)
+
+		if cfg.Enabled {
+			c.Redirect(http.StatusMovedPermanently, v2URL)
+			c.Abort()
+			return
+		}
+
+		// Informational: add Link header pointing to v2
+		c.Header("Link", `<`+v2URL+`>; rel="successor-version"`)
+		c.Next()
+	}
+}
+
+// resolveV2URL replaces gin route params in the v2 pattern using actual request values
+func resolveV2URL(v2Pattern, v1Pattern string, c *gin.Context) string {
+	result := v2Pattern
+
+	// Extract param names from v1 pattern and substitute in v2 pattern
+	v1Parts := strings.Split(v1Pattern, "/")
+	for _, part := range v1Parts {
+		if strings.HasPrefix(part, ":") {
+			paramName := part[1:]
+			paramValue := c.Param(paramName)
+			if paramValue != "" {
+				result = strings.Replace(result, part, paramValue, 1)
+			}
+		}
+	}
+
+	// Preserve query string
+	if c.Request.URL.RawQuery != "" {
+		result += "?" + c.Request.URL.RawQuery
+	}
+
+	return result
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -50,8 +50,11 @@ func Setup(
 		MigrationGuideURL: "https://github.com/damoang/angple-backend/blob/main/docs/v1-to-v2-migration-guide.md",
 	})
 
-	// 레거시 API (그누보드 DB 기반) → /api/v1 으로 이동, Deprecation 헤더 + 사용량 추적
-	api := router.Group("/api/v1", middleware.DamoangCookieAuth(damoangJWT, cfg), deprecationMW, v1UsageTracker.Track())
+	// v1→v2 리다이렉트 (Enabled=false: Link 헤더만 추가, true로 변경 시 301 리다이렉트)
+	v1Redirect := middleware.V1ToV2Redirect(middleware.V1RedirectConfig{Enabled: false})
+
+	// 레거시 API (그누보드 DB 기반) → /api/v1 으로 이동, Deprecation 헤더 + 사용량 추적 + v2 리다이렉트 힌트
+	api := router.Group("/api/v1", middleware.DamoangCookieAuth(damoangJWT, cfg), deprecationMW, v1Redirect, v1UsageTracker.Track())
 
 	// Authentication endpoints (no auth required)
 	auth := api.Group("/auth")

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -7,6 +7,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// SetupAuth configures v2 authentication routes
+func SetupAuth(router *gin.Engine, h *v2handler.V2AuthHandler, jwtManager *jwt.Manager) {
+	authGroup := router.Group("/api/v2/auth")
+	authGroup.POST("/login", h.Login)
+	authGroup.POST("/refresh", h.RefreshToken)
+	authGroup.POST("/logout", h.Logout)
+	authGroup.GET("/me", middleware.JWTAuth(jwtManager), h.GetMe)
+}
+
 // Setup configures v2 API routes (new DB schema)
 func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager) {
 	api := router.Group("/api/v2")

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -1,0 +1,135 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/damoang/angple-backend/pkg/auth"
+	"github.com/damoang/angple-backend/pkg/jwt"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// V2AuthService handles v2 authentication with bcrypt + legacy password support
+type V2AuthService struct {
+	userRepo   v2repo.UserRepository
+	jwtManager *jwt.Manager
+}
+
+// NewV2AuthService creates a new V2AuthService
+func NewV2AuthService(userRepo v2repo.UserRepository, jwtManager *jwt.Manager) *V2AuthService {
+	return &V2AuthService{
+		userRepo:   userRepo,
+		jwtManager: jwtManager,
+	}
+}
+
+// V2LoginResponse represents v2 login response
+type V2LoginResponse struct {
+	User         *v2domain.V2User `json:"user"`
+	AccessToken  string           `json:"access_token"`
+	RefreshToken string           `json:"refresh_token"`
+}
+
+// Login authenticates a user against v2_users table.
+// Supports both bcrypt (new) and legacy gnuboard password hashing (migrated users).
+func (s *V2AuthService) Login(username, password string) (*V2LoginResponse, error) {
+	user, err := s.userRepo.FindByUsername(username)
+	if err != nil {
+		return nil, common.ErrInvalidCredentials
+	}
+
+	if user.Status == "banned" {
+		return nil, errors.New("account is banned")
+	}
+	if user.Status == "inactive" {
+		return nil, errors.New("account is inactive")
+	}
+
+	// Try bcrypt first (new accounts), then legacy gnuboard hashing (migrated)
+	if !verifyPassword(password, user.Password) {
+		return nil, common.ErrInvalidCredentials
+	}
+
+	// If the password is legacy format, upgrade to bcrypt
+	if !isBcryptHash(user.Password) {
+		if upgraded, hashErr := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost); hashErr == nil {
+			user.Password = string(upgraded)
+			_ = s.userRepo.Update(user)
+		}
+	}
+
+	// Generate JWT tokens
+	userIDStr := strconv.FormatUint(user.ID, 10)
+	accessToken, err := s.jwtManager.GenerateAccessToken(userIDStr, user.Nickname, int(user.Level))
+	if err != nil {
+		return nil, fmt.Errorf("generate access token: %w", err)
+	}
+	refreshToken, err := s.jwtManager.GenerateRefreshToken(userIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("generate refresh token: %w", err)
+	}
+
+	return &V2LoginResponse{
+		User:         user,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+	}, nil
+}
+
+// RefreshToken validates a refresh token and issues new token pair
+func (s *V2AuthService) RefreshToken(refreshToken string) (*V2LoginResponse, error) {
+	claims, err := s.jwtManager.VerifyToken(refreshToken)
+	if err != nil {
+		return nil, common.ErrUnauthorized
+	}
+
+	userID, err := strconv.ParseUint(claims.UserID, 10, 64)
+	if err != nil {
+		return nil, common.ErrUnauthorized
+	}
+
+	user, err := s.userRepo.FindByID(userID)
+	if err != nil {
+		return nil, common.ErrUnauthorized
+	}
+
+	userIDStr := strconv.FormatUint(user.ID, 10)
+	newAccess, err := s.jwtManager.GenerateAccessToken(userIDStr, user.Nickname, int(user.Level))
+	if err != nil {
+		return nil, fmt.Errorf("generate access token: %w", err)
+	}
+	newRefresh, err := s.jwtManager.GenerateRefreshToken(userIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("generate refresh token: %w", err)
+	}
+
+	return &V2LoginResponse{
+		User:         user,
+		AccessToken:  newAccess,
+		RefreshToken: newRefresh,
+	}, nil
+}
+
+// GetCurrentUser returns the user for the given ID
+func (s *V2AuthService) GetCurrentUser(userID uint64) (*v2domain.V2User, error) {
+	return s.userRepo.FindByID(userID)
+}
+
+// verifyPassword checks password against bcrypt or legacy gnuboard hash
+func verifyPassword(plain, hashed string) bool {
+	// Try bcrypt first
+	if isBcryptHash(hashed) {
+		return bcrypt.CompareHashAndPassword([]byte(hashed), []byte(plain)) == nil
+	}
+	// Fallback to legacy gnuboard password verification
+	return auth.VerifyGnuboardPassword(plain, hashed)
+}
+
+// isBcryptHash checks if the hash is bcrypt format ($2a$, $2b$, $2y$)
+func isBcryptHash(hash string) bool {
+	return len(hash) == 60 && (hash[:4] == "$2a$" || hash[:4] == "$2b$" || hash[:4] == "$2y$")
+}


### PR DESCRIPTION
## Summary

- v2 인증 API 추가: `POST /api/v2/auth/login`, `/refresh`, `/logout`, `GET /me`
  - bcrypt + 레거시 그누보드 패스워드 동시 지원, 로그인 시 자동 bcrypt 업그레이드
- v1→v2 리다이렉트 미들웨어: v2 대응 URL을 `Link` 헤더로 안내
  - `Enabled=false` (현재): 헤더 안내만, `true` 전환 시 301 리다이렉트
  - boards, posts, comments, scraps, memos, messages 매핑
- v1 전체 라우트에 Sunset + Deprecation + v2 Link 헤더 동시 적용

## Test plan

- [ ] `go build ./...` 빌드 확인
- [ ] v2 로그인 API 동작 확인 (bcrypt + legacy password)
- [ ] v1 API 호출 시 `Link` 헤더에 v2 URL 포함 확인
- [ ] v1 Sunset/Deprecation 헤더 유지 확인