### PR TITLE
feat: v2 통합 테스트 + k6 부하 테스트

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,10 +108,22 @@ test:
 	@echo "Running tests..."
 	go test -v ./...
 
+test-integration:
+	@echo "Running v2 integration tests..."
+	go test -v -count=1 ./tests/integration/...
+
 test-coverage:
 	@echo "Running tests with coverage..."
 	go test -v -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+test-load-k6:
+	@echo "Running k6 smoke test..."
+	k6 run --env BASE_URL=http://localhost:8081 tests/load/k6-load-test.js
+
+test-load-k6-ci:
+	@echo "Running k6 CI load test..."
+	k6 run --env BASE_URL=http://localhost:8081 --env SCENARIO=ci tests/load/k6-load-test.js
 
 # Docker
 docker-up:

--- a/tests/integration/v2_api_test.go
+++ b/tests/integration/v2_api_test.go
@@ -1,0 +1,322 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2handler "github.com/damoang/angple-backend/internal/handler/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	v2routes "github.com/damoang/angple-backend/internal/routes/v2"
+	v2svc "github.com/damoang/angple-backend/internal/service/v2"
+	"github.com/damoang/angple-backend/pkg/jwt"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// V2APISuite is an integration test suite for v2 API endpoints
+type V2APISuite struct {
+	suite.Suite
+	db         *gorm.DB
+	router     *gin.Engine
+	jwtManager *jwt.Manager
+}
+
+func TestV2APISuite(t *testing.T) {
+	suite.Run(t, new(V2APISuite))
+}
+
+func (s *V2APISuite) SetupSuite() {
+	gin.SetMode(gin.TestMode)
+
+	// Use SQLite for tests (no external DB dependency)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	s.Require().NoError(err)
+	s.db = db
+
+	// Migrate v2 schema (raw SQL for SQLite compatibility — no enum types)
+	for _, ddl := range []string{
+		`CREATE TABLE IF NOT EXISTS v2_users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			username VARCHAR(50) UNIQUE, email VARCHAR(255) UNIQUE,
+			password VARCHAR(255), nickname VARCHAR(100),
+			level INTEGER DEFAULT 1, status TEXT DEFAULT 'active',
+			avatar_url VARCHAR(500), bio TEXT,
+			created_at DATETIME, updated_at DATETIME)`,
+		`CREATE TABLE IF NOT EXISTS v2_boards (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			slug VARCHAR(50) UNIQUE, name VARCHAR(100),
+			description TEXT, category_id INTEGER,
+			settings TEXT, is_active BOOLEAN DEFAULT 1,
+			order_num INTEGER DEFAULT 0,
+			created_at DATETIME, updated_at DATETIME)`,
+		`CREATE TABLE IF NOT EXISTS v2_posts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			board_id INTEGER, user_id INTEGER,
+			title VARCHAR(255), content TEXT,
+			status TEXT DEFAULT 'published',
+			view_count INTEGER DEFAULT 0, comment_count INTEGER DEFAULT 0,
+			is_notice BOOLEAN DEFAULT 0,
+			created_at DATETIME, updated_at DATETIME)`,
+		`CREATE TABLE IF NOT EXISTS v2_comments (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			post_id INTEGER, user_id INTEGER,
+			parent_id INTEGER, content TEXT,
+			depth INTEGER DEFAULT 0, status TEXT DEFAULT 'active',
+			created_at DATETIME, updated_at DATETIME)`,
+	} {
+		s.Require().NoError(db.Exec(ddl).Error)
+	}
+
+	// JWT manager
+	s.jwtManager = jwt.NewManager("test-secret-key-for-integration-tests", 900, 86400)
+
+	// Setup repos, handlers, routes
+	userRepo := v2repo.NewUserRepository(db)
+	postRepo := v2repo.NewPostRepository(db)
+	commentRepo := v2repo.NewCommentRepository(db)
+	boardRepo := v2repo.NewBoardRepository(db)
+
+	v2Handler := v2handler.NewV2Handler(userRepo, postRepo, commentRepo, boardRepo)
+	authSvc := v2svc.NewV2AuthService(userRepo, s.jwtManager)
+	authHandler := v2handler.NewV2AuthHandler(authSvc)
+
+	s.router = gin.New()
+	v2routes.Setup(s.router, v2Handler, s.jwtManager)
+	v2routes.SetupAuth(s.router, authHandler, s.jwtManager)
+
+	// Seed test data
+	s.seedTestData()
+}
+
+func (s *V2APISuite) seedTestData() {
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
+
+	user := &v2domain.V2User{
+		Username: "testuser",
+		Email:    "test@example.com",
+		Password: string(hashed),
+		Nickname: "TestUser",
+		Level:    5,
+		Status:   "active",
+	}
+	s.db.Create(user)
+
+	board := &v2domain.V2Board{
+		Slug:     "free",
+		Name:     "Free Board",
+		IsActive: true,
+	}
+	s.db.Create(board)
+
+	post := &v2domain.V2Post{
+		BoardID:      board.ID,
+		UserID:       user.ID,
+		Title:        "Test Post",
+		Content:      "Test content",
+		Status:       "published",
+		ViewCount:    10,
+		CommentCount: 1,
+	}
+	s.db.Create(post)
+
+	comment := &v2domain.V2Comment{
+		PostID:  post.ID,
+		UserID:  user.ID,
+		Content: "Test comment",
+		Status:  "active",
+	}
+	s.db.Create(comment)
+}
+
+// --- Auth Tests ---
+
+func (s *V2APISuite) TestLogin_Success() {
+	body, _ := json.Marshal(map[string]string{
+		"username": "testuser",
+		"password": "password123",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), resp["success"].(bool))
+
+	data := resp["data"].(map[string]interface{})
+	assert.NotEmpty(s.T(), data["access_token"])
+	assert.NotNil(s.T(), data["user"])
+}
+
+func (s *V2APISuite) TestLogin_InvalidPassword() {
+	body, _ := json.Marshal(map[string]string{
+		"username": "testuser",
+		"password": "wrongpassword",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (s *V2APISuite) TestLogin_NonexistentUser() {
+	body, _ := json.Marshal(map[string]string{
+		"username": "nobody",
+		"password": "password123",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusUnauthorized, w.Code)
+}
+
+// --- Board Tests ---
+
+func (s *V2APISuite) TestListBoards() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+func (s *V2APISuite) TestGetBoard() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards/free", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+func (s *V2APISuite) TestGetBoard_NotFound() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards/nonexistent", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusNotFound, w.Code)
+}
+
+// --- Post Tests ---
+
+func (s *V2APISuite) TestListPosts() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards/free/posts", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+func (s *V2APISuite) TestGetPost() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards/free/posts/1", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+func (s *V2APISuite) TestCreatePost_Unauthorized() {
+	body, _ := json.Marshal(map[string]string{
+		"title":   "New Post",
+		"content": "New content",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/boards/free/posts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	// Should fail without auth
+	assert.Equal(s.T(), http.StatusUnauthorized, w.Code)
+}
+
+func (s *V2APISuite) TestCreatePost_Authenticated() {
+	// Login first
+	token := s.getAuthToken()
+
+	body, _ := json.Marshal(map[string]string{
+		"title":   "Authenticated Post",
+		"content": "Created with JWT",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/boards/free/posts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusCreated, w.Code)
+}
+
+// --- Comment Tests ---
+
+func (s *V2APISuite) TestListComments() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/boards/free/posts/1/comments", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+// --- User Tests ---
+
+func (s *V2APISuite) TestListUsers() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/users", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+func (s *V2APISuite) TestGetUserByUsername() {
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/users/username/testuser", nil)
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(s.T(), http.StatusOK, w.Code)
+}
+
+// --- Helper ---
+
+func (s *V2APISuite) getAuthToken() string {
+	body, _ := json.Marshal(map[string]string{
+		"username": "testuser",
+		"password": "password123",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	s.router.ServeHTTP(w, req)
+
+	var resp map[string]interface{}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	data := resp["data"].(map[string]interface{})
+	return data["access_token"].(string)
+}

--- a/tests/load/k6-load-test.js
+++ b/tests/load/k6-load-test.js
@@ -1,0 +1,170 @@
+/**
+ * k6 Load Test for Angple Backend
+ *
+ * Usage:
+ *   # Quick smoke test
+ *   k6 run --env BASE_URL=http://localhost:8081 tests/load/k6-load-test.js
+ *
+ *   # Full load test (20k concurrent)
+ *   k6 run --env BASE_URL=http://localhost:8081 --env SCENARIO=full tests/load/k6-load-test.js
+ *
+ *   # CI mode with thresholds
+ *   k6 run --env BASE_URL=http://localhost:8081 --env SCENARIO=ci tests/load/k6-load-test.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+// Custom metrics
+const errorRate = new Rate("errors");
+const postListDuration = new Trend("post_list_duration", true);
+const postDetailDuration = new Trend("post_detail_duration", true);
+const commentsDuration = new Trend("comments_duration", true);
+const authLoginDuration = new Trend("auth_login_duration", true);
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8081";
+const SCENARIO = __ENV.SCENARIO || "smoke";
+
+// Thresholds: P99 <= 100ms, error rate < 1%
+export const options = {
+  thresholds: {
+    http_req_duration: ["p(95)<200", "p(99)<500"],
+    post_list_duration: ["p(99)<100"],
+    post_detail_duration: ["p(99)<100"],
+    comments_duration: ["p(99)<100"],
+    errors: ["rate<0.01"],
+  },
+  scenarios: getScenarios(),
+};
+
+function getScenarios() {
+  switch (SCENARIO) {
+    case "full":
+      return {
+        ramp_up: {
+          executor: "ramping-vus",
+          startVUs: 0,
+          stages: [
+            { duration: "30s", target: 100 },
+            { duration: "1m", target: 500 },
+            { duration: "2m", target: 2000 },
+            { duration: "5m", target: 5000 },
+            { duration: "2m", target: 0 },
+          ],
+          gracefulRampDown: "30s",
+        },
+      };
+    case "ci":
+      return {
+        ci_test: {
+          executor: "ramping-vus",
+          startVUs: 0,
+          stages: [
+            { duration: "10s", target: 20 },
+            { duration: "30s", target: 50 },
+            { duration: "10s", target: 0 },
+          ],
+          gracefulRampDown: "10s",
+        },
+      };
+    default:
+      // smoke
+      return {
+        smoke: {
+          executor: "constant-vus",
+          vus: 5,
+          duration: "30s",
+        },
+      };
+  }
+}
+
+export default function () {
+  const actions = [
+    { weight: 10, fn: browsePosts },
+    { weight: 5, fn: viewPost },
+    { weight: 3, fn: viewComments },
+    { weight: 2, fn: listBoards },
+    { weight: 1, fn: listUsers },
+    { weight: 1, fn: healthCheck },
+  ];
+
+  // Weighted random selection
+  const totalWeight = actions.reduce((sum, a) => sum + a.weight, 0);
+  let rand = Math.random() * totalWeight;
+  for (const action of actions) {
+    rand -= action.weight;
+    if (rand <= 0) {
+      action.fn();
+      break;
+    }
+  }
+
+  sleep(Math.random() * 2 + 0.5); // 0.5-2.5s between requests
+}
+
+function browsePosts() {
+  const res = http.get(`${BASE_URL}/api/v2/boards/free/posts?page=1&per_page=20`);
+  postListDuration.add(res.timings.duration);
+  const ok = check(res, {
+    "post list status 200": (r) => r.status === 200,
+  });
+  errorRate.add(!ok);
+}
+
+function viewPost() {
+  const res = http.get(`${BASE_URL}/api/v2/boards/free/posts/1`);
+  postDetailDuration.add(res.timings.duration);
+  const ok = check(res, {
+    "post detail status 200 or 404": (r) => r.status === 200 || r.status === 404,
+  });
+  errorRate.add(!ok);
+}
+
+function viewComments() {
+  const res = http.get(`${BASE_URL}/api/v2/boards/free/posts/1/comments`);
+  commentsDuration.add(res.timings.duration);
+  const ok = check(res, {
+    "comments status 200 or 404": (r) => r.status === 200 || r.status === 404,
+  });
+  errorRate.add(!ok);
+}
+
+function listBoards() {
+  const res = http.get(`${BASE_URL}/api/v2/boards`);
+  const ok = check(res, {
+    "boards status 200": (r) => r.status === 200,
+  });
+  errorRate.add(!ok);
+}
+
+function listUsers() {
+  const res = http.get(`${BASE_URL}/api/v2/users`);
+  const ok = check(res, {
+    "users status 200": (r) => r.status === 200,
+  });
+  errorRate.add(!ok);
+}
+
+function healthCheck() {
+  const res = http.get(`${BASE_URL}/health`);
+  check(res, {
+    "health ok": (r) => r.status === 200,
+  });
+}
+
+// Auth login scenario (separate, only if credentials are available)
+export function authScenario() {
+  const payload = JSON.stringify({
+    username: "testuser",
+    password: "testpassword",
+  });
+  const params = { headers: { "Content-Type": "application/json" } };
+  const res = http.post(`${BASE_URL}/api/v2/auth/login`, payload, params);
+  authLoginDuration.add(res.timings.duration);
+  const ok = check(res, {
+    "login responds": (r) => r.status === 200 || r.status === 401,
+  });
+  errorRate.add(!ok);
+}


### PR DESCRIPTION
## Summary

- v2 API 통합 테스트 13개 (SQLite in-memory, httptest + testify suite)
  - 인증: 로그인 성공/실패, 존재하지 않는 유저
  - 게시판: 목록, 상세, 404
  - 게시글: 목록, 상세, 인증 없이 생성 거부, 인증 후 생성 성공
  - 댓글: 목록 조회
  - 사용자: 목록, username 조회
- k6 부하 테스트 스크립트 (smoke/ci/full 3개 시나리오)
  - P99 ≤ 100ms 임계값, 에러율 < 1% 게이트
- Makefile 타겟: `test-integration`, `test-load-k6`, `test-load-k6-ci`

## Test plan

- [x] `go test ./tests/integration/...` — 13/13 PASS
- [ ] CI 빌드 + 테스트 통과 확인
- [ ] k6 smoke 테스트 로컬 실행 확인