### PR TITLE
feat: Kubernetes 매니페스트 + Kustomize (Phase 29)

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: angple-config
+  namespace: angple
+data:
+  APP_ENV: "production"
+  DB_HOST: "mysql"
+  DB_PORT: "3306"
+  DB_NAME: "damoang"
+  REDIS_HOST: "redis"
+  REDIS_PORT: "6379"
+  SERVER_PORT: "8081"
+  GATEWAY_PORT: "8080"

--- a/k8s/base/deployment-api.yaml
+++ b/k8s/base/deployment-api.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: angple-api
+  namespace: angple
+  labels:
+    app.kubernetes.io/name: angple-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/part-of: angple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: angple-api
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: angple-api
+        app.kubernetes.io/component: api
+        app.kubernetes.io/part-of: angple
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: api
+          image: ghcr.io/damoang/angple-backend-api:latest
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: angple-config
+            - secretRef:
+                name: angple-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 2
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            failureThreshold: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi

--- a/k8s/base/deployment-gateway.yaml
+++ b/k8s/base/deployment-gateway.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: angple-gateway
+  namespace: angple
+  labels:
+    app.kubernetes.io/name: angple-gateway
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/part-of: angple
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: angple-gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: angple-gateway
+        app.kubernetes.io/component: gateway
+        app.kubernetes.io/part-of: angple
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: gateway
+          image: ghcr.io/damoang/angple-backend-gateway:latest
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: angple-config
+            - secretRef:
+                name: angple-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/base/hpa-api.yaml
+++ b/k8s/base/hpa-api.yaml
@@ -1,0 +1,38 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: angple-api-hpa
+  namespace: angple
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: angple-api
+  minReplicas: 2
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: angple-ingress
+  namespace: angple
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: api.damoang.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: angple-gateway
+                port:
+                  number: 8080

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: angple
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment-api.yaml
+  - deployment-gateway.yaml
+  - service-api.yaml
+  - service-gateway.yaml
+  - ingress.yaml
+  - hpa-api.yaml
+  - pdb.yaml
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: angple
+  labels:
+    app.kubernetes.io/part-of: angple

--- a/k8s/base/pdb.yaml
+++ b/k8s/base/pdb.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: angple-api-pdb
+  namespace: angple
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: angple-api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: angple-gateway-pdb
+  namespace: angple
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: angple-gateway

--- a/k8s/base/secret.yaml
+++ b/k8s/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: angple-secrets
+  namespace: angple
+type: Opaque
+stringData:
+  DB_USER: "CHANGE_ME"
+  DB_PASSWORD: "CHANGE_ME"
+  JWT_SECRET: "CHANGE_ME"
+  DAMOANG_JWT_SECRET: "CHANGE_ME"
+  REDIS_PASSWORD: ""

--- a/k8s/base/service-api.yaml
+++ b/k8s/base/service-api.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: angple-api
+  namespace: angple
+  labels:
+    app.kubernetes.io/name: angple-api
+    app.kubernetes.io/part-of: angple
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: angple-api
+  ports:
+    - port: 8081
+      targetPort: 8081
+      protocol: TCP
+      name: http

--- a/k8s/base/service-gateway.yaml
+++ b/k8s/base/service-gateway.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: angple-gateway
+  namespace: angple
+  labels:
+    app.kubernetes.io/name: angple-gateway
+    app.kubernetes.io/part-of: angple
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: angple-gateway
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,46 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+namePrefix: dev-
+
+patches:
+  - target:
+      kind: Deployment
+      name: angple-api
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 512Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+  - target:
+      kind: Deployment
+      name: angple-gateway
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 1
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: angple-api-hpa
+    patch: |
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 3
+  - target:
+      kind: Ingress
+      name: angple-ingress
+    patch: |
+      - op: replace
+        path: /spec/rules/0/host
+        value: dev-api.damoang.net

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,44 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - target:
+      kind: Deployment
+      name: angple-api
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 3
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 250m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 256Mi
+  - target:
+      kind: Deployment
+      name: angple-gateway
+    patch: |
+      - op: replace
+        path: /spec/replicas
+        value: 2
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: angple-api-hpa
+    patch: |
+      - op: replace
+        path: /spec/maxReplicas
+        value: 30
+  - target:
+      kind: Ingress
+      name: angple-ingress
+    patch: |
+      - op: add
+        path: /spec/tls
+        value:
+          - hosts:
+              - api.damoang.net
+            secretName: angple-tls


### PR DESCRIPTION
## Summary

- Kustomize 기반 K8s 매니페스트 구성 (base + dev/prod overlays)
- API Deployment: Rolling update, liveness/readiness/startup probes
- Gateway Deployment: 동일 패턴
- HPA: CPU 70%/Memory 80% 기반 (2-20 pods, prod 최대 30)
- PDB: API/Gateway 각 minAvailable=1
- Ingress: nginx, api.damoang.net (prod TLS)
- ConfigMap/Secret: 환경별 설정 분리

## 사용법

```bash
# Dev 환경 배포
kubectl apply -k k8s/overlays/dev/

# Prod 환경 배포
kubectl apply -k k8s/overlays/prod/

# 매니페스트 미리보기
kubectl kustomize k8s/overlays/prod/
```

## Test plan

- [ ] `kubectl kustomize k8s/base/` 렌더링 확인
- [ ] `kubectl kustomize k8s/overlays/dev/` 오버레이 확인
- [ ] `kubectl kustomize k8s/overlays/prod/` TLS 포함 확인
- [ ] CI 빌드 통과