### PR TITLE
feat: Phase 30 — 운영 안정화 모니터링/알림/백업

### DIFF
--- a/k8s/base/backup-cronjob.yaml
+++ b/k8s/base/backup-cronjob.yaml
@@ -1,0 +1,65 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mysql-backup
+  namespace: angple
+spec:
+  schedule: "0 3 * * *"  # 매일 03:00 UTC (한국시간 12:00)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backupOffLimitSeconds: 600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: mysql:8.0
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+                  BACKUP_FILE="/backup/damoang_${TIMESTAMP}.sql.gz"
+                  echo "[backup] Starting MySQL backup at $(date)"
+                  mysqldump -h ${DB_HOST} -u ${DB_USER} -p${DB_PASSWORD} \
+                    --single-transaction --routines --triggers --events \
+                    ${DB_NAME} | gzip > ${BACKUP_FILE}
+                  if [ $? -eq 0 ]; then
+                    echo "[backup] Backup created: ${BACKUP_FILE} ($(du -h ${BACKUP_FILE} | cut -f1))"
+                    # S3 업로드 (AWS CLI 사용 시)
+                    # aws s3 cp ${BACKUP_FILE} s3://${S3_BUCKET}/mysql-backups/${BACKUP_FILE}
+                    # 7일 이상 된 로컬 백업 삭제
+                    find /backup -name "*.sql.gz" -mtime +7 -delete
+                    echo "[backup] Cleanup done. Remaining backups:"
+                    ls -lh /backup/
+                  else
+                    echo "[backup] FAILED"
+                    exit 1
+                  fi
+              envFrom:
+                - configMapRef:
+                    name: angple-config
+                - secretRef:
+                    name: angple-secrets
+              volumeMounts:
+                - name: backup-volume
+                  mountPath: /backup
+          volumes:
+            - name: backup-volume
+              persistentVolumeClaim:
+                claimName: mysql-backup-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-backup-pvc
+  namespace: angple
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ingress.yaml
   - hpa-api.yaml
   - pdb.yaml
+  - backup-cronjob.yaml
 
 commonLabels:
   app.kubernetes.io/managed-by: kustomize

--- a/monitoring/grafana/angple-dashboard.json
+++ b/monitoring/grafana/angple-dashboard.json
@@ -1,0 +1,153 @@
+{
+  "dashboard": {
+    "title": "Angple Backend - Golden Signals",
+    "uid": "angple-golden-signals",
+    "timezone": "Asia/Seoul",
+    "refresh": "10s",
+    "time": { "from": "now-1h", "to": "now" },
+    "panels": [
+      {
+        "title": "Request Rate (RPS)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total[1m]))",
+            "legendFormat": "Total RPS"
+          },
+          {
+            "expr": "sum(rate(http_requests_total{status=~\"5..\"}[1m]))",
+            "legendFormat": "5xx RPS"
+          }
+        ]
+      },
+      {
+        "title": "Error Rate (%)",
+        "type": "gauge",
+        "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) * 100"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "value": 0, "color": "green" },
+                { "value": 1, "color": "yellow" },
+                { "value": 5, "color": "red" }
+              ]
+            },
+            "unit": "percent",
+            "max": 10
+          }
+        }
+      },
+      {
+        "title": "SLA Uptime (30d)",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+        "targets": [
+          {
+            "expr": "(1 - sum(rate(http_requests_total{status=~\"5..\"}[30d])) / sum(rate(http_requests_total[30d]))) * 100"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "value": 0, "color": "red" },
+                { "value": 99, "color": "yellow" },
+                { "value": 99.9, "color": "green" }
+              ]
+            },
+            "unit": "percent",
+            "decimals": 3
+          }
+        }
+      },
+      {
+        "title": "Latency (P50 / P95 / P99)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "P50"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "P95"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))",
+            "legendFormat": "P99"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "s" }
+        }
+      },
+      {
+        "title": "Active Requests",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+        "targets": [
+          {
+            "expr": "http_active_requests",
+            "legendFormat": "Active"
+          }
+        ]
+      },
+      {
+        "title": "DB Connections",
+        "type": "gauge",
+        "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+        "targets": [
+          {
+            "expr": "db_connections_active"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "steps": [
+                { "value": 0, "color": "green" },
+                { "value": 60, "color": "yellow" },
+                { "value": 80, "color": "red" }
+              ]
+            },
+            "max": 100
+          }
+        }
+      },
+      {
+        "title": "Response Size (bytes)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_response_size_bytes_bucket[5m])) by (le))",
+            "legendFormat": "P95 Response Size"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": { "unit": "bytes" }
+        }
+      },
+      {
+        "title": "Top Endpoints by RPS",
+        "type": "table",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+        "targets": [
+          {
+            "expr": "topk(10, sum(rate(http_requests_total[5m])) by (method, path))",
+            "format": "table",
+            "instant": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,0 +1,107 @@
+groups:
+  - name: angple-sla
+    rules:
+      # P99 응답 시간 > 200ms (5분간)
+      - alert: HighP99Latency
+        expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P99 latency above 200ms"
+          description: "P99 latency is {{ $value | humanizeDuration }} (threshold: 200ms)"
+
+      # P99 응답 시간 > 500ms (5분간) — Critical
+      - alert: CriticalP99Latency
+        expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 0.5
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "P99 latency above 500ms"
+          description: "P99 latency is {{ $value | humanizeDuration }}"
+
+      # 에러율 > 1% (5분간)
+      - alert: HighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+          > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Error rate above 1%"
+          description: "Error rate is {{ $value | humanizePercentage }}"
+
+      # 에러율 > 5% — Critical
+      - alert: CriticalErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m]))
+          /
+          sum(rate(http_requests_total[5m]))
+          > 0.05
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate above 5%"
+          description: "Error rate is {{ $value | humanizePercentage }}"
+
+      # API 다운 (health check 실패)
+      - alert: APIDown
+        expr: up{job="angple-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Angple API is down"
+          description: "API instance {{ $labels.instance }} is unreachable"
+
+      # 활성 DB 커넥션 > 80
+      - alert: HighDBConnections
+        expr: db_connections_active > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High DB connection count"
+          description: "Active DB connections: {{ $value }} (max: 100)"
+
+      # Pod 재시작 반복
+      - alert: PodCrashLooping
+        expr: rate(kube_pod_container_status_restarts_total{namespace="angple"}[15m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Pod {{ $labels.pod }} is crash looping"
+
+  - name: angple-capacity
+    rules:
+      # CPU 사용률 > 80%
+      - alert: HighCPUUsage
+        expr: |
+          sum(rate(container_cpu_usage_seconds_total{namespace="angple"}[5m])) by (pod)
+          /
+          sum(kube_pod_container_resource_limits{namespace="angple", resource="cpu"}) by (pod)
+          > 0.8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Pod {{ $labels.pod }} CPU usage above 80%"
+
+      # 메모리 사용률 > 85%
+      - alert: HighMemoryUsage
+        expr: |
+          sum(container_memory_working_set_bytes{namespace="angple"}) by (pod)
+          /
+          sum(kube_pod_container_resource_limits{namespace="angple", resource="memory"}) by (pod)
+          > 0.85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Pod {{ $labels.pod }} memory usage above 85%"

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,32 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - "alerts.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: "angple-api"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["angple-api:8081"]
+    # K8s 환경에서는 아래 사용
+    # kubernetes_sd_configs:
+    #   - role: pod
+    #     namespaces:
+    #       names: ["angple"]
+    # relabel_configs:
+    #   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+    #     regex: angple-api
+    #     action: keep
+
+  - job_name: "angple-gateway"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["angple-gateway:8080"]


### PR DESCRIPTION
## Summary
- Prometheus 알림 규칙: P99 latency, error rate, API down, DB connections, pod crash loop, CPU/Memory
- Prometheus scrape config for API(8081) + Gateway(8080)
- Grafana Golden Signals 대시보드 (RPS, Error Rate, SLA Uptime, Latency percentiles, DB Connections 등)
- MySQL 일일 백업 CronJob (03:00 UTC, gzip 압축, 7일 보관, PVC 10Gi)

## Test plan
- [ ] `kubectl apply -k k8s/base/` 정상 적용 확인
- [ ] Prometheus targets 정상 수집 확인
- [ ] Grafana 대시보드 import 확인
- [ ] CronJob 수동 트리거 테스트