### PR TITLE
feat(auth): damoang_jwt → angple JWT 토큰 교환 엔드포인트 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -500,7 +500,7 @@ func main() {
 		v2routes.Setup(router, v2Handler, jwtManager)
 
 		// v2 Auth API
-		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager)
+		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager, damoangJWT)
 		v2AuthHandler := v2handler.NewV2AuthHandler(v2AuthSvc)
 		v2routes.SetupAuth(router, v2AuthHandler, jwtManager)
 

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -13,6 +13,7 @@ func SetupAuth(router *gin.Engine, h *v2handler.V2AuthHandler, jwtManager *jwt.M
 	authGroup.POST("/login", h.Login)
 	authGroup.POST("/refresh", h.RefreshToken)
 	authGroup.POST("/logout", h.Logout)
+	authGroup.POST("/exchange", h.ExchangeGnuboardJWT) // damoang_jwt → angple JWT exchange (no auth middleware)
 	authGroup.GET("/me", middleware.JWTAuth(jwtManager), h.GetMe)
 }
 

--- a/tests/integration/v2_api_test.go
+++ b/tests/integration/v2_api_test.go
@@ -77,6 +77,7 @@ func (s *V2APISuite) SetupSuite() {
 
 	// JWT manager
 	s.jwtManager = jwt.NewManager("test-secret-key-for-integration-tests", 900, 86400)
+	damoangManager := jwt.NewDamoangManager("test-damoang-secret-key")
 
 	// Setup repos, handlers, routes
 	userRepo := v2repo.NewUserRepository(db)
@@ -85,7 +86,7 @@ func (s *V2APISuite) SetupSuite() {
 	boardRepo := v2repo.NewBoardRepository(db)
 
 	v2Handler := v2handler.NewV2Handler(userRepo, postRepo, commentRepo, boardRepo)
-	authSvc := v2svc.NewV2AuthService(userRepo, s.jwtManager)
+	authSvc := v2svc.NewV2AuthService(userRepo, s.jwtManager, damoangManager)
 	authHandler := v2handler.NewV2AuthHandler(authSvc)
 
 	s.router = gin.New()


### PR DESCRIPTION
POST /api/v2/auth/exchange 엔드포인트:
- damoang_jwt 쿠키에서 그누보드 JWT 읽기
- DamoangManager로 토큰 검증 후 mb_id 추출
- v2_users에서 사용자 조회 후 angple JWT 토큰 쌍 발급
- refresh_token은 httpOnly 쿠키로 설정

web.damoang.net 관리자 페이지에서 damoang.net SSO 로그인 후
자동 토큰 교환을 통해 관리자 권한 인증 가능