### PR TITLE
fix: 알림 시스템 g5_na_noti 테이블 매핑 수정

### DIFF
--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -5,22 +5,22 @@ import "time"
 // Notification represents a user notification (알림)
 // Based on g5_na_noti table (nariya plugin)
 type Notification struct {
-	ID           int       `gorm:"column:ph_id;primaryKey;autoIncrement" json:"id"`
-	ToCase       string    `gorm:"column:ph_to_case" json:"to_case"`                    // board, comment, inquire
-	FromCase     string    `gorm:"column:ph_from_case" json:"from_case"`                // write, board, comment, good, nogood, answer, reply
-	BoardTable   string    `gorm:"column:bo_table" json:"board_table"`                  // 게시판 테이블
-	RelBoardTable string   `gorm:"column:rel_bo_table" json:"rel_board_table"`          // 관련 게시판 테이블
-	WriteID      int       `gorm:"column:wr_id" json:"write_id"`                        // 게시글 ID
-	RelWriteID   int       `gorm:"column:rel_wr_id" json:"rel_write_id"`                // 관련 게시글 ID
-	MemberID     string    `gorm:"column:mb_id;index" json:"member_id"`                 // 수신자 회원 ID
-	SenderID     string    `gorm:"column:rel_mb_id" json:"sender_id,omitempty"`         // 발신자 회원 ID
-	SenderName   string    `gorm:"column:rel_mb_nick" json:"sender_name,omitempty"`     // 발신자 닉네임
-	Message      string    `gorm:"column:rel_msg" json:"message"`                       // 메시지
-	URL          string    `gorm:"column:rel_url" json:"url,omitempty"`                 // URL
-	IsReadChar   string    `gorm:"column:ph_readed" json:"-"`                           // 'Y' or 'N'
-	CreatedAt    time.Time `gorm:"column:ph_datetime" json:"created_at"`                // 생성일시
-	Title        string    `gorm:"column:parent_subject" json:"title"`                  // 제목 (parent_subject)
-	WriteParent  int       `gorm:"column:wr_parent" json:"write_parent"`                // 부모 게시글 ID
+	ID            int       `gorm:"column:ph_id;primaryKey;autoIncrement" json:"id"`
+	ToCase        string    `gorm:"column:ph_to_case" json:"to_case"`                // board, comment, inquire
+	FromCase      string    `gorm:"column:ph_from_case" json:"from_case"`            // write, board, comment, good, nogood, answer, reply
+	BoardTable    string    `gorm:"column:bo_table" json:"board_table"`              // 게시판 테이블
+	RelBoardTable string    `gorm:"column:rel_bo_table" json:"rel_board_table"`      // 관련 게시판 테이블
+	WriteID       int       `gorm:"column:wr_id" json:"write_id"`                    // 게시글 ID
+	RelWriteID    int       `gorm:"column:rel_wr_id" json:"rel_write_id"`            // 관련 게시글 ID
+	MemberID      string    `gorm:"column:mb_id;index" json:"member_id"`             // 수신자 회원 ID
+	SenderID      string    `gorm:"column:rel_mb_id" json:"sender_id,omitempty"`     // 발신자 회원 ID
+	SenderName    string    `gorm:"column:rel_mb_nick" json:"sender_name,omitempty"` // 발신자 닉네임
+	Message       string    `gorm:"column:rel_msg" json:"message"`                   // 메시지
+	URL           string    `gorm:"column:rel_url" json:"url,omitempty"`             // URL
+	IsReadChar    string    `gorm:"column:ph_readed" json:"-"`                       // 'Y' or 'N'
+	CreatedAt     time.Time `gorm:"column:ph_datetime" json:"created_at"`            // 생성일시
+	Title         string    `gorm:"column:parent_subject" json:"title"`              // 제목 (parent_subject)
+	WriteParent   int       `gorm:"column:wr_parent" json:"write_parent"`            // 부모 게시글 ID
 }
 
 // IsRead returns whether the notification has been read

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -3,22 +3,53 @@ package domain
 import "time"
 
 // Notification represents a user notification (알림)
+// Based on g5_na_noti table (nariya plugin)
 type Notification struct {
-	ID         int       `gorm:"column:nt_id;primaryKey;autoIncrement" json:"id"`
-	MemberID   string    `gorm:"column:mb_id;index" json:"member_id"`
-	Type       string    `gorm:"column:nt_type" json:"type"`
-	Title      string    `gorm:"column:nt_title" json:"title"`
-	Content    string    `gorm:"column:nt_content" json:"content"`
-	URL        string    `gorm:"column:nt_url" json:"url,omitempty"`
-	SenderID   string    `gorm:"column:nt_sender_id" json:"sender_id,omitempty"`
-	SenderName string    `gorm:"column:nt_sender_name" json:"sender_name,omitempty"`
-	IsRead     bool      `gorm:"column:nt_is_read" json:"is_read"`
-	CreatedAt  time.Time `gorm:"column:nt_created_at" json:"created_at"`
+	ID           int       `gorm:"column:ph_id;primaryKey;autoIncrement" json:"id"`
+	ToCase       string    `gorm:"column:ph_to_case" json:"to_case"`                    // board, comment, inquire
+	FromCase     string    `gorm:"column:ph_from_case" json:"from_case"`                // write, board, comment, good, nogood, answer, reply
+	BoardTable   string    `gorm:"column:bo_table" json:"board_table"`                  // 게시판 테이블
+	RelBoardTable string   `gorm:"column:rel_bo_table" json:"rel_board_table"`          // 관련 게시판 테이블
+	WriteID      int       `gorm:"column:wr_id" json:"write_id"`                        // 게시글 ID
+	RelWriteID   int       `gorm:"column:rel_wr_id" json:"rel_write_id"`                // 관련 게시글 ID
+	MemberID     string    `gorm:"column:mb_id;index" json:"member_id"`                 // 수신자 회원 ID
+	SenderID     string    `gorm:"column:rel_mb_id" json:"sender_id,omitempty"`         // 발신자 회원 ID
+	SenderName   string    `gorm:"column:rel_mb_nick" json:"sender_name,omitempty"`     // 발신자 닉네임
+	Message      string    `gorm:"column:rel_msg" json:"message"`                       // 메시지
+	URL          string    `gorm:"column:rel_url" json:"url,omitempty"`                 // URL
+	IsReadChar   string    `gorm:"column:ph_readed" json:"-"`                           // 'Y' or 'N'
+	CreatedAt    time.Time `gorm:"column:ph_datetime" json:"created_at"`                // 생성일시
+	Title        string    `gorm:"column:parent_subject" json:"title"`                  // 제목 (parent_subject)
+	WriteParent  int       `gorm:"column:wr_parent" json:"write_parent"`                // 부모 게시글 ID
+}
+
+// IsRead returns whether the notification has been read
+func (n *Notification) IsRead() bool {
+	return n.IsReadChar == "Y"
+}
+
+// SetRead sets the read status
+func (n *Notification) SetRead(read bool) {
+	if read {
+		n.IsReadChar = "Y"
+	} else {
+		n.IsReadChar = "N"
+	}
+}
+
+// Type returns the notification type (alias for FromCase for API compatibility)
+func (n *Notification) Type() string {
+	return n.FromCase
+}
+
+// Content returns the notification content (alias for Message for API compatibility)
+func (n *Notification) Content() string {
+	return n.Message
 }
 
 // TableName returns the table name
 func (Notification) TableName() string {
-	return "g5_da_notification"
+	return "g5_na_noti"
 }
 
 // NotificationSummaryResponse represents unread count response

--- a/internal/repository/notification_repo.go
+++ b/internal/repository/notification_repo.go
@@ -21,7 +21,7 @@ func NewNotificationRepository(db *gorm.DB) *NotificationRepository {
 func (r *NotificationRepository) GetUnreadCount(memberID string) (int64, error) {
 	var count int64
 	err := r.db.Model(&domain.Notification{}).
-		Where("mb_id = ? AND nt_is_read = 0", memberID).
+		Where("mb_id = ? AND ph_readed = 'N'", memberID).
 		Count(&count).Error
 	return count, err
 }
@@ -38,7 +38,7 @@ func (r *NotificationRepository) GetList(memberID string, offset, limit int) ([]
 	}
 
 	if err := r.db.Where("mb_id = ?", memberID).
-		Order("nt_created_at DESC").
+		Order("ph_datetime DESC").
 		Offset(offset).
 		Limit(limit).
 		Find(&notifications).Error; err != nil {
@@ -51,7 +51,7 @@ func (r *NotificationRepository) GetList(memberID string, offset, limit int) ([]
 // FindByID returns a notification by ID
 func (r *NotificationRepository) FindByID(id int) (*domain.Notification, error) {
 	var notification domain.Notification
-	err := r.db.Where("nt_id = ?", id).First(&notification).Error
+	err := r.db.Where("ph_id = ?", id).First(&notification).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
@@ -64,15 +64,15 @@ func (r *NotificationRepository) FindByID(id int) (*domain.Notification, error) 
 // MarkAsRead marks a notification as read
 func (r *NotificationRepository) MarkAsRead(id int) error {
 	return r.db.Model(&domain.Notification{}).
-		Where("nt_id = ?", id).
-		Update("nt_is_read", 1).Error
+		Where("ph_id = ?", id).
+		Update("ph_readed", "Y").Error
 }
 
 // MarkAllAsRead marks all notifications as read for a member
 func (r *NotificationRepository) MarkAllAsRead(memberID string) error {
 	return r.db.Model(&domain.Notification{}).
-		Where("mb_id = ? AND nt_is_read = 0", memberID).
-		Update("nt_is_read", 1).Error
+		Where("mb_id = ? AND ph_readed = 'N'", memberID).
+		Update("ph_readed", "Y").Error
 }
 
 // Create inserts a new notification
@@ -82,5 +82,5 @@ func (r *NotificationRepository) Create(notification *domain.Notification) error
 
 // Delete deletes a notification by ID
 func (r *NotificationRepository) Delete(id int) error {
-	return r.db.Where("nt_id = ?", id).Delete(&domain.Notification{}).Error
+	return r.db.Where("ph_id = ?", id).Delete(&domain.Notification{}).Error
 }

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -25,14 +25,14 @@ func NewNotificationService(repo *repository.NotificationRepository, hub *ws.Hub
 func (s *NotificationService) CreateAndBroadcast(memberID, nType, title, content, url, senderID, senderName string) error {
 	n := &domain.Notification{
 		MemberID:   memberID,
-		FromCase:   nType,     // ph_from_case
-		ToCase:     "board",   // ph_to_case (default)
-		Title:      title,     // parent_subject
-		Message:    content,   // rel_msg
-		URL:        url,       // rel_url
-		SenderID:   senderID,  // rel_mb_id
+		FromCase:   nType,      // ph_from_case
+		ToCase:     "board",    // ph_to_case (default)
+		Title:      title,      // parent_subject
+		Message:    content,    // rel_msg
+		URL:        url,        // rel_url
+		SenderID:   senderID,   // rel_mb_id
 		SenderName: senderName, // rel_mb_nick
-		IsReadChar: "N",       // ph_readed
+		IsReadChar: "N",        // ph_readed
 		CreatedAt:  time.Now(), // ph_datetime
 	}
 

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -25,14 +25,15 @@ func NewNotificationService(repo *repository.NotificationRepository, hub *ws.Hub
 func (s *NotificationService) CreateAndBroadcast(memberID, nType, title, content, url, senderID, senderName string) error {
 	n := &domain.Notification{
 		MemberID:   memberID,
-		Type:       nType,
-		Title:      title,
-		Content:    content,
-		URL:        url,
-		SenderID:   senderID,
-		SenderName: senderName,
-		IsRead:     false,
-		CreatedAt:  time.Now(),
+		FromCase:   nType,     // ph_from_case
+		ToCase:     "board",   // ph_to_case (default)
+		Title:      title,     // parent_subject
+		Message:    content,   // rel_msg
+		URL:        url,       // rel_url
+		SenderID:   senderID,  // rel_mb_id
+		SenderName: senderName, // rel_mb_nick
+		IsReadChar: "N",       // ph_readed
+		CreatedAt:  time.Now(), // ph_datetime
 	}
 
 	if err := s.repo.Create(n); err != nil {
@@ -46,9 +47,9 @@ func (s *NotificationService) CreateAndBroadcast(memberID, nType, title, content
 			Type: "notification",
 			Payload: map[string]interface{}{
 				"id":          n.ID,
-				"type":        n.Type,
+				"type":        n.Type(),
 				"title":       n.Title,
-				"content":     n.Content,
+				"content":     n.Content(),
 				"url":         n.URL,
 				"sender_id":   n.SenderID,
 				"sender_name": n.SenderName,
@@ -97,13 +98,13 @@ func (s *NotificationService) GetList(memberID string, page, limit int) (*domain
 	for i, n := range notifications {
 		items[i] = domain.NotificationItem{
 			ID:         n.ID,
-			Type:       n.Type,
+			Type:       n.Type(),
 			Title:      n.Title,
-			Content:    n.Content,
+			Content:    n.Content(),
 			URL:        n.URL,
 			SenderID:   n.SenderID,
 			SenderName: n.SenderName,
-			IsRead:     n.IsRead,
+			IsRead:     n.IsRead(),
 			CreatedAt:  n.CreatedAt.Format(time.RFC3339),
 		}
 	}


### PR DESCRIPTION
- Notification 도메인 모델을 g5_na_noti (nariya plugin) 테이블 구조에 맞게 수정
- 컬럼 매핑: ph_id, ph_from_case, ph_to_case, ph_readed, ph_datetime 등
- Repository 쿼리 컬럼명 수정
- Service에서 메서드 호출 방식 변경 (Type(), Content(), IsRead())