### PR TITLE
feat: 공지사항 API 및 사용자 정보 조회 개선

### DIFF
--- a/internal/domain/good.go
+++ b/internal/domain/good.go
@@ -42,8 +42,8 @@ type DownvoteResponse struct {
 type LikerInfo struct {
 	MbID    string `json:"mb_id"`
 	MbName  string `json:"mb_name"`
-	MbNick  string `json:"mb_nick"`            // 닉네임
-	BgIP    string `json:"bg_ip,omitempty"`    // 마스킹된 IP (로그인 사용자만)
+	MbNick  string `json:"mb_nick"`         // 닉네임
+	BgIP    string `json:"bg_ip,omitempty"` // 마스킹된 IP (로그인 사용자만)
 	LikedAt string `json:"liked_at"`
 }
 

--- a/internal/domain/member.go
+++ b/internal/domain/member.go
@@ -48,6 +48,9 @@ type Member struct {
 	Level         int       `gorm:"column:mb_level" json:"level"`
 	MemoCount     int       `gorm:"column:mb_memo_cnt" json:"-"`
 	ScrapCount    int       `gorm:"column:mb_scrap_cnt" json:"-"`
+	AsExp         int       `gorm:"column:as_exp" json:"as_exp"`
+	AsLevel       int       `gorm:"column:as_level" json:"as_level"`
+	AsMax         int       `gorm:"column:as_max" json:"as_max"`
 }
 
 func (Member) TableName() string {

--- a/internal/handler/post_handler.go
+++ b/internal/handler/post_handler.go
@@ -49,6 +49,28 @@ func (h *PostHandler) ListPosts(c *gin.Context) {
 	common.SuccessResponse(c, data, meta)
 }
 
+// ListNotices godoc
+// @Summary      공지사항 목록 조회
+// @Description  특정 게시판의 공지사항 목록을 조회합니다
+// @Tags         posts
+// @Accept       json
+// @Produce      json
+// @Param        board_id  path      string  true   "게시판 ID"
+// @Success      200  {object}  common.APIResponse{data=[]domain.Post}
+// @Failure      500  {object}  common.APIResponse
+// @Router       /boards/{board_id}/notices [get]
+func (h *PostHandler) ListNotices(c *gin.Context) {
+	boardID := c.Param("board_id")
+
+	data, err := h.service.ListNotices(boardID)
+	if err != nil {
+		common.ErrorResponse(c, 500, "Failed to fetch notices", err)
+		return
+	}
+
+	common.SuccessResponse(c, data, nil)
+}
+
 // GetPost godoc
 // @Summary      게시글 상세 조회
 // @Description  특정 게시판의 특정 게시글 상세 정보를 조회합니다

--- a/internal/repository/post_repo.go
+++ b/internal/repository/post_repo.go
@@ -107,7 +107,7 @@ func (r *postRepository) ListNotices(boardID string) ([]*domain.Post, error) {
 	}
 
 	// ID 문자열을 정수로 변환
-	var ids []int
+	ids := make([]int, 0, len(noticeIDs))
 	for _, idStr := range noticeIDs {
 		idStr = strings.TrimSpace(idStr)
 		if idStr == "" {

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -85,6 +85,9 @@ func Setup(
 	// Board Posts (중첩 그룹 사용으로 Gin 라우팅 충돌 해결)
 	boards := api.Group("/boards")
 
+	// 공지사항 라우트 (먼저 등록해야 :board_id/posts보다 우선 매칭)
+	boards.GET("/:board_id/notices", postHandler.ListNotices)
+
 	// 게시판별 게시글 그룹
 	boardPosts := boards.Group("/:board_id/posts")
 	{

--- a/internal/service/post_service.go
+++ b/internal/service/post_service.go
@@ -10,6 +10,7 @@ import (
 // PostService business logic for posts
 type PostService interface {
 	ListPosts(boardID string, page, limit int) ([]*domain.PostResponse, *common.Meta, error)
+	ListNotices(boardID string) ([]*domain.PostResponse, error)
 	GetPost(boardID string, id int) (*domain.PostResponse, error)
 	CreatePost(boardID string, req *domain.CreatePostRequest, authorID string) (*domain.PostResponse, error)
 	UpdatePost(boardID string, id int, req *domain.UpdatePostRequest, authorID string) error
@@ -58,6 +59,22 @@ func (s *postService) ListPosts(boardID string, page, limit int) ([]*domain.Post
 	}
 
 	return responses, meta, nil
+}
+
+// ListNotices retrieves notice posts
+func (s *postService) ListNotices(boardID string) ([]*domain.PostResponse, error) {
+	posts, err := s.repo.ListNotices(boardID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to response
+	responses := make([]*domain.PostResponse, len(posts))
+	for i, post := range posts {
+		responses[i] = post.ToResponse()
+	}
+
+	return responses, nil
 }
 
 // GetPost retrieves a single post by ID

--- a/internal/service/post_service_test.go
+++ b/internal/service/post_service_test.go
@@ -64,6 +64,14 @@ func (m *mockPostRepo) DecrementLike(boardID string, id int) error {
 	return m.Called(boardID, id).Error(0)
 }
 
+func (m *mockPostRepo) ListNotices(boardID string) ([]*domain.Post, error) {
+	args := m.Called(boardID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Post), args.Error(1)
+}
+
 // --- Tests ---
 
 func TestListPosts_Success(t *testing.T) {


### PR DESCRIPTION
## 변경사항

### 1. 공지사항 API 추가
- `GET /boards/:board_id/notices` - 게시판별 공지사항 목록 조회
- `g5_board.bo_notice` 컬럼에서 쉼표로 구분된 ID 파싱
- 원래 순서 유지 (`FIELD` 함수 사용)

### 2. 사용자 정보 조회 개선 (`/api/v2/auth/me`)
기존 JWT 쿠키 정보 외에 DB에서 추가 정보 조회:
- `mb_point` - 포인트
- `mb_exp` - 경험치 (as_exp)
- `as_level` - 레벨
- `as_max` - 최대 경험치
- `mb_image` - 프로필 이미지 URL

### 3. Member 모델 확장
- `as_exp`, `as_level`, `as_max` 필드 추가

## 테스트
```bash
# 공지사항 조회
curl http://localhost:8081/api/v1/boards/free/notices

# 사용자 정보 조회
curl -b "damoang_jwt=xxx" http://localhost:8081/api/v2/auth/me
```