### PR TITLE
fix: golangci-lint 에러 140개 수정

### DIFF
--- a/internal/handler/file_handler.go
+++ b/internal/handler/file_handler.go
@@ -54,7 +54,9 @@ func (h *FileHandler) UploadEditorImage(c *gin.Context) {
 
 	wrID := 0
 	if id := c.PostForm("wr_id"); id != "" {
-		wrID, _ = strconv.Atoi(id)
+		if val, err := strconv.Atoi(id); err == nil {
+			wrID = val
+		}
 	}
 
 	result, err := h.service.UploadEditorImage(file, boardID, wrID)
@@ -100,7 +102,9 @@ func (h *FileHandler) UploadAttachment(c *gin.Context) {
 
 	wrID := 0
 	if id := c.PostForm("wr_id"); id != "" {
-		wrID, _ = strconv.Atoi(id)
+		if val, err := strconv.Atoi(id); err == nil {
+			wrID = val
+		}
 	}
 
 	result, err := h.service.UploadAttachment(file, boardID, wrID)

--- a/internal/handler/good_handler.go
+++ b/internal/handler/good_handler.go
@@ -246,8 +246,14 @@ func (h *GoodHandler) GetLikers(c *gin.Context) {
 		return
 	}
 
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	page := 1
+	if val, err := strconv.Atoi(c.DefaultQuery("page", "1")); err == nil {
+		page = val
+	}
+	limit := 20
+	if val, err := strconv.Atoi(c.DefaultQuery("limit", "20")); err == nil {
+		limit = val
+	}
 
 	result, err := h.service.GetLikers(boardID, wrID, page, limit)
 	if err != nil {

--- a/internal/handler/media_handler.go
+++ b/internal/handler/media_handler.go
@@ -28,7 +28,10 @@ func (h *MediaHandler) UploadImage(c *gin.Context) {
 		return
 	}
 
-	maxWidth, _ := strconv.Atoi(c.DefaultPostForm("max_width", "1920"))
+	maxWidth := 1920
+	if val, err := strconv.Atoi(c.DefaultPostForm("max_width", "1920")); err == nil {
+		maxWidth = val
+	}
 
 	result, err := h.mediaService.UploadImage(c.Request.Context(), file, maxWidth)
 	if err != nil {

--- a/internal/handler/payment_handler.go
+++ b/internal/handler/payment_handler.go
@@ -171,8 +171,14 @@ func (h *PaymentHandler) ListPayments(c *gin.Context) {
 		return
 	}
 
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+	page := 1
+	if val, err := strconv.Atoi(c.DefaultQuery("page", "1")); err == nil {
+		page = val
+	}
+	perPage := 20
+	if val, err := strconv.Atoi(c.DefaultQuery("per_page", "20")); err == nil {
+		perPage = val
+	}
 	if page < 1 {
 		page = 1
 	}

--- a/internal/handler/search_handler.go
+++ b/internal/handler/search_handler.go
@@ -30,8 +30,14 @@ func (h *SearchHandler) Search(c *gin.Context) {
 
 	boardID := c.Query("board_id")
 	searchType := c.DefaultQuery("type", "all") // all, posts, comments
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	perPage, _ := strconv.Atoi(c.DefaultQuery("per_page", "20"))
+	page := 1
+	if val, err := strconv.Atoi(c.DefaultQuery("page", "1")); err == nil {
+		page = val
+	}
+	perPage := 20
+	if val, err := strconv.Atoi(c.DefaultQuery("per_page", "20")); err == nil {
+		perPage = val
+	}
 
 	if page < 1 {
 		page = 1
@@ -68,7 +74,10 @@ func (h *SearchHandler) Autocomplete(c *gin.Context) {
 		return
 	}
 
-	size, _ := strconv.Atoi(c.DefaultQuery("size", "10"))
+	size := 10
+	if val, err := strconv.Atoi(c.DefaultQuery("size", "10")); err == nil {
+		size = val
+	}
 	suggestions, err := h.searchService.Autocomplete(c.Request.Context(), prefix, size)
 	if err != nil {
 		common.ErrorResponse(c, http.StatusInternalServerError, "Autocomplete failed", nil)

--- a/internal/handler/tenant_handler.go
+++ b/internal/handler/tenant_handler.go
@@ -75,7 +75,8 @@ func (h *TenantHandler) SuspendTenant(c *gin.Context) {
 	var req struct {
 		Reason string `json:"reason"`
 	}
-	_ = c.ShouldBindJSON(&req)
+	// Reason is optional; ignore bind errors (body may be empty)
+	_ = c.ShouldBindJSON(&req) //nolint:errcheck // optional body
 
 	if err := h.tenantService.SuspendTenant(c.Request.Context(), siteID, req.Reason); err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)

--- a/internal/middleware/audit.go
+++ b/internal/middleware/audit.go
@@ -36,13 +36,15 @@ type AuditLogger struct {
 // NewAuditLogger creates a new AuditLogger
 func NewAuditLogger(db *gorm.DB) *AuditLogger {
 	if db != nil {
-		_ = db.AutoMigrate(&AuditLog{})
+		if err := db.AutoMigrate(&AuditLog{}); err != nil {
+			logger.GetLogger().Error().Err(err).Msg("audit_logs AutoMigrate failed")
+		}
 	}
 	return &AuditLogger{db: db}
 }
 
 // Log writes an audit entry to the database
-func (a *AuditLogger) Log(ctx context.Context, userID, action, resource, resourceID, details, clientIP, userAgent, requestID string) {
+func (a *AuditLogger) Log(_ context.Context, userID, action, resource, resourceID, details, clientIP, userAgent, requestID string) {
 	if a.db == nil {
 		return
 	}

--- a/internal/middleware/cache.go
+++ b/internal/middleware/cache.go
@@ -2,7 +2,7 @@ package middleware
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -82,7 +82,10 @@ func Cache(redisClient *redis.Client, cfg CacheConfig) gin.HandlerFunc {
 				Headers: headers,
 				Body:    string(w.body),
 			}
-			data, _ := json.Marshal(cached)
+			data, err := json.Marshal(cached)
+			if err != nil {
+				return
+			}
 			redisClient.Set(ctx, key, data, cfg.TTL)
 		}
 
@@ -114,7 +117,7 @@ func cacheKey(path, query string) string {
 	if query != "" {
 		raw += "?" + query
 	}
-	return fmt.Sprintf("%x", md5.Sum([]byte(raw)))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(raw)))
 }
 
 // responseWriter captures the response body

--- a/internal/middleware/permission.go
+++ b/internal/middleware/permission.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -70,7 +71,7 @@ func BoardPermission(checker BoardPermissionChecker, action PermissionAction) gi
 
 		if err != nil {
 			// Board not found or other error
-			if err == common.ErrNotFound {
+			if errors.Is(err, common.ErrNotFound) {
 				common.ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
 			} else {
 				common.ErrorResponse(c, http.StatusInternalServerError, "권한 확인 중 오류가 발생했습니다", err)

--- a/internal/middleware/tenant.go
+++ b/internal/middleware/tenant.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const planFree = "free"
+
 // TenantContext holds tenant-specific information
 type TenantContext struct {
 	SiteID     string `json:"site_id"`
@@ -147,12 +149,12 @@ func GetTenantDBStrategy(c *gin.Context) string {
 func GetTenantPlan(c *gin.Context) string {
 	plan, exists := c.Get("tenant_plan")
 	if !exists {
-		return "free"
+		return planFree
 	}
 	if str, ok := plan.(string); ok {
 		return str
 	}
-	return "free"
+	return planFree
 }
 
 // shouldSkipTenant returns true for paths that don't need tenant resolution
@@ -226,7 +228,7 @@ func RequireTenant() gin.HandlerFunc {
 // RequirePlan middleware ensures the tenant has a specific plan or higher
 func RequirePlan(minPlan string) gin.HandlerFunc {
 	planOrder := map[string]int{
-		"free":       0,
+		planFree:     0,
 		"pro":        1,
 		"business":   2,
 		"enterprise": 3,

--- a/internal/migration/v2_data.go
+++ b/internal/migration/v2_data.go
@@ -153,7 +153,7 @@ func migratePostsAndComments(db *gorm.DB) error {
 	return nil
 }
 
-func migrateFiles(db *gorm.DB) error {
+func migrateFiles(_ *gorm.DB) error {
 	// g5_board_file migration is complex due to dynamic table references
 	// For now, we log a placeholder - full implementation requires board_id context
 	log.Println("[v2-migration] File migration requires board-level iteration (skipped in auto-migration)")

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -131,6 +131,8 @@ func (m *Manager) RegisterAllFactories() error {
 }
 
 // Enable 플러그인 활성화
+//
+//nolint:gocyclo // plugin activation requires many sequential steps
 func (m *Manager) Enable(name string) error {
 	m.mu.Lock()
 	info, exists := m.plugins[name]

--- a/internal/plugins/advertising/handler/admin.go
+++ b/internal/plugins/advertising/handler/admin.go
@@ -129,7 +129,7 @@ func (h *AdminHandler) CreateAdUnit(c *gin.Context) {
 // @Failure      404  {object}  common.APIResponse
 // @Failure      500  {object}  common.APIResponse
 // @Router       /plugins/advertising/admin/units/{id} [put]
-func (h *AdminHandler) UpdateAdUnit(c *gin.Context) {
+func (h *AdminHandler) UpdateAdUnit(c *gin.Context) { //nolint:dupl
 	id, err := h.parseID(c, "id")
 	if err != nil {
 		common.ErrorResponse(c, http.StatusBadRequest, "Invalid ad unit ID", err)
@@ -292,7 +292,7 @@ func (h *AdminHandler) CreateBanner(c *gin.Context) {
 // @Failure      404  {object}  common.APIResponse
 // @Failure      500  {object}  common.APIResponse
 // @Router       /plugins/advertising/admin/banners/{id} [put]
-func (h *AdminHandler) UpdateBanner(c *gin.Context) {
+func (h *AdminHandler) UpdateBanner(c *gin.Context) { //nolint:dupl
 	id, err := h.parseID(c, "id")
 	if err != nil {
 		common.ErrorResponse(c, http.StatusBadRequest, "Invalid banner ID", err)

--- a/internal/plugins/advertising/handler/public.go
+++ b/internal/plugins/advertising/handler/public.go
@@ -94,7 +94,9 @@ func (h *PublicHandler) GetAdByPosition(c *gin.Context) {
 	if sessionKey == "" {
 		// JWT에서 jti 추출 시도
 		if jti, exists := c.Get("jti"); exists {
-			sessionKey = jti.(string)
+			if s, ok := jti.(string); ok {
+				sessionKey = s
+			}
 		}
 	}
 
@@ -173,7 +175,9 @@ func (h *PublicHandler) GetRotationIndex(c *gin.Context) {
 	sessionKey := c.Query("session_key")
 	if sessionKey == "" {
 		if jti, exists := c.Get("jti"); exists {
-			sessionKey = jti.(string)
+			if s, ok := jti.(string); ok {
+				sessionKey = s
+			}
 		}
 	}
 

--- a/internal/plugins/advertising/plugin.go
+++ b/internal/plugins/advertising/plugin.go
@@ -19,7 +19,7 @@ func init() {
 }
 
 // AdvertisingPlugin 광고 관리 플러그인
-type AdvertisingPlugin struct {
+type AdvertisingPlugin struct { //nolint:revive // plugin identifier naming convention
 	db            *gorm.DB
 	redis         *redis.Client
 	logger        plugin.Logger

--- a/internal/plugins/advertising/repository/ad_repository.go
+++ b/internal/plugins/advertising/repository/ad_repository.go
@@ -222,7 +222,7 @@ func (r *adRepository) ListBannersByDate(date time.Time) ([]*domain.CelebrationB
 	}
 
 	// MessageRow를 CelebrationBanner로 변환
-	var banners []*domain.CelebrationBanner
+	banners := make([]*domain.CelebrationBanner, 0, len(results))
 	for _, row := range results {
 		imageURL := extractFirstImage(row.WrContent)
 

--- a/internal/plugins/embed/plugin.go
+++ b/internal/plugins/embed/plugin.go
@@ -3,7 +3,6 @@ package embed
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/damoang/angple-backend/internal/plugin"
 	"github.com/gin-gonic/gin"
@@ -134,12 +133,12 @@ func (p *Plugin) GetManifest() *plugin.PluginManifest {
 }
 
 // Migrate DB 마이그레이션 (필요 없음)
-func (p *Plugin) Migrate(db *gorm.DB) error {
+func (p *Plugin) Migrate(_ *gorm.DB) error {
 	return nil
 }
 
 // RegisterRoutes 라우트 등록 (필요 없음)
-func (p *Plugin) RegisterRoutes(router gin.IRouter) {
+func (p *Plugin) RegisterRoutes(_ gin.IRouter) {
 }
 
 // RegisterHooks Hook 등록 (HookAware 인터페이스)
@@ -252,13 +251,4 @@ func (p *Plugin) calculateHeight() int {
 	default: // 16:9
 		return p.maxWidth * 9 / 16
 	}
-}
-
-// escapeHTML HTML 특수문자 이스케이프
-func escapeHTML(s string) string {
-	s = strings.ReplaceAll(s, "&", "&amp;")
-	s = strings.ReplaceAll(s, "<", "&lt;")
-	s = strings.ReplaceAll(s, ">", "&gt;")
-	s = strings.ReplaceAll(s, `"`, "&quot;")
-	return s
 }

--- a/internal/plugins/imagelink/plugin.go
+++ b/internal/plugins/imagelink/plugin.go
@@ -128,12 +128,12 @@ func (p *Plugin) GetManifest() *plugin.PluginManifest {
 }
 
 // Migrate DB 마이그레이션 (필요 없음)
-func (p *Plugin) Migrate(db *gorm.DB) error {
+func (p *Plugin) Migrate(_ *gorm.DB) error {
 	return nil
 }
 
 // RegisterRoutes 라우트 등록 (필요 없음)
-func (p *Plugin) RegisterRoutes(router gin.IRouter) {
+func (p *Plugin) RegisterRoutes(_ gin.IRouter) {
 }
 
 // RegisterHooks Hook 등록 (HookAware 인터페이스)

--- a/internal/plugins/marketplace/plugin.go
+++ b/internal/plugins/marketplace/plugin.go
@@ -143,7 +143,7 @@ func (p *Plugin) GetManifest() *plugin.PluginManifest {
 }
 
 // Migrate DB 마이그레이션 실행
-func (p *Plugin) Migrate(db *gorm.DB) error {
+func (p *Plugin) Migrate(_ *gorm.DB) error {
 	// 마이그레이션은 SQL 파일로 처리
 	return nil
 }

--- a/internal/pluginstore/service/marketplace_service.go
+++ b/internal/pluginstore/service/marketplace_service.go
@@ -29,7 +29,7 @@ func (s *MarketplaceService) Browse(page, perPage int, category, keyword string)
 
 	items := make([]domain.MarketplaceListItem, len(subs))
 	for i, sub := range subs {
-		avgRating, reviewCount, _ := s.repo.GetAverageRating(sub.PluginName)
+		avgRating, reviewCount, _ := s.repo.GetAverageRating(sub.PluginName) //nolint:errcheck // rating lookup is best-effort
 		// developer name lookup
 		devName := ""
 		if dev, err := s.repo.FindDeveloperByID(sub.DeveloperID); err == nil {
@@ -56,7 +56,7 @@ func (s *MarketplaceService) GetPlugin(pluginName string) (*domain.PluginSubmiss
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	avgRating, reviewCount, _ := s.repo.GetAverageRating(pluginName)
+	avgRating, reviewCount, _ := s.repo.GetAverageRating(pluginName) //nolint:errcheck // rating lookup is best-effort
 	return sub, avgRating, reviewCount, nil
 }
 

--- a/internal/pluginstore/service/setting_service.go
+++ b/internal/pluginstore/service/setting_service.go
@@ -121,7 +121,7 @@ func (s *SettingService) SaveSettings(pluginName string, settings map[string]str
 	}
 
 	// 이벤트 로그
-	detailsJSON, _ := json.Marshal(settings)
+	detailsJSON, _ := json.Marshal(settings) //nolint:errcheck // marshal of map[string]string always succeeds
 	detailsStr := string(detailsJSON)
 	event := &domain.PluginEvent{
 		PluginName: pluginName,
@@ -129,7 +129,7 @@ func (s *SettingService) SaveSettings(pluginName string, settings map[string]str
 		Details:    &detailsStr,
 		ActorID:    &actorID,
 	}
-	_ = s.eventRepo.Create(event)
+	_ = s.eventRepo.Create(event) //nolint:errcheck // event logging is best-effort
 
 	// 설정 변경 후 플러그인 자동 리로드
 	if s.reloader != nil {
@@ -209,7 +209,8 @@ func (s *SettingService) ExportSettings(pluginName string) (*PluginConfigExport,
 
 // ImportSettings 플러그인 설정 가져오기
 func (s *SettingService) ImportSettings(exports []PluginConfigExport, actorID string) ([]string, []string) {
-	var imported, skipped []string
+	imported := make([]string, 0, len(exports))
+	var skipped []string
 
 	for _, export := range exports {
 		manifest := s.catalogSvc.GetManifest(export.PluginName)

--- a/internal/pluginstore/service/setting_validator_test.go
+++ b/internal/pluginstore/service/setting_validator_test.go
@@ -21,8 +21,8 @@ func TestValidateSetting_Textarea(t *testing.T) {
 }
 
 func TestValidateSetting_Number_Valid(t *testing.T) {
-	min, max := 0, 100
-	schema := plugin.SettingConfig{Key: "count", Type: "number", Min: &min, Max: &max}
+	minVal, maxVal := 0, 100
+	schema := plugin.SettingConfig{Key: "count", Type: "number", Min: &minVal, Max: &maxVal}
 
 	tests := []struct {
 		value string

--- a/internal/pluginstore/service/store_service_test.go
+++ b/internal/pluginstore/service/store_service_test.go
@@ -55,11 +55,11 @@ type mockPlugin struct {
 	shutdown    bool
 }
 
-func (m *mockPlugin) Name() string                               { return m.name }
-func (m *mockPlugin) Migrate(db *gorm.DB) error                  { return nil }
-func (m *mockPlugin) Initialize(ctx *plugin.PluginContext) error { m.initialized = true; return nil }
-func (m *mockPlugin) RegisterRoutes(router gin.IRouter)          {}
-func (m *mockPlugin) Shutdown() error                            { m.shutdown = true; return nil }
+func (m *mockPlugin) Name() string                             { return m.name }
+func (m *mockPlugin) Migrate(_ *gorm.DB) error                 { return nil }
+func (m *mockPlugin) Initialize(_ *plugin.PluginContext) error { m.initialized = true; return nil }
+func (m *mockPlugin) RegisterRoutes(_ gin.IRouter)             {}
+func (m *mockPlugin) Shutdown() error                          { m.shutdown = true; return nil }
 
 func TestInstallPlugin(t *testing.T) {
 	storeSvc, _, manager := setupStoreService(t)

--- a/internal/repository/gallery_repo.go
+++ b/internal/repository/gallery_repo.go
@@ -84,7 +84,7 @@ func (r *GalleryRepository) FindGalleryAll(boardIDs []string, page, limit int) (
 	offset := (page - 1) * limit
 
 	// Build UNION ALL for count
-	var countParts []string
+	countParts := make([]string, 0, len(boardIDs))
 	for _, bid := range boardIDs {
 		countParts = append(countParts, fmt.Sprintf(
 			"SELECT wr_id FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND wr_file > 0",
@@ -98,7 +98,7 @@ func (r *GalleryRepository) FindGalleryAll(boardIDs []string, page, limit int) (
 	}
 
 	// Build UNION ALL for data
-	var dataParts []string
+	dataParts := make([]string, 0, len(boardIDs))
 	for _, bid := range boardIDs {
 		dataParts = append(dataParts, fmt.Sprintf(
 			"SELECT '%s' AS bo_table, wr_id, wr_subject, wr_name, mb_id, wr_hit, wr_good, wr_comment, wr_datetime "+
@@ -158,7 +158,7 @@ func (r *GalleryRepository) UnifiedSearch(boardIDs []string, keyword string, pag
 	likeKeyword := "%" + keyword + "%"
 
 	// Count
-	var countParts []string
+	countParts := make([]string, 0, len(boardIDs))
 	for _, bid := range boardIDs {
 		countParts = append(countParts, fmt.Sprintf(
 			"SELECT wr_id FROM `g5_write_%s` WHERE wr_is_comment = 0 AND wr_parent = wr_id AND (wr_subject LIKE ? OR wr_content LIKE ?)",
@@ -179,7 +179,7 @@ func (r *GalleryRepository) UnifiedSearch(boardIDs []string, keyword string, pag
 	}
 
 	// Data
-	var dataParts []string
+	dataParts := make([]string, 0, len(boardIDs))
 	for _, bid := range boardIDs {
 		dataParts = append(dataParts, fmt.Sprintf(
 			"SELECT '%s' AS bo_table, wr_id, wr_subject, SUBSTRING(wr_content, 1, 200) AS wr_content, wr_name, mb_id, wr_hit, wr_good, wr_datetime "+

--- a/internal/repository/payment_repo.go
+++ b/internal/repository/payment_repo.go
@@ -14,7 +14,9 @@ type PaymentRepository struct {
 
 // NewPaymentRepository creates a new PaymentRepository
 func NewPaymentRepository(db *gorm.DB) *PaymentRepository {
-	_ = db.AutoMigrate(&domain.Payment{})
+	if err := db.AutoMigrate(&domain.Payment{}); err != nil {
+		panic("failed to auto-migrate Payment: " + err.Error())
+	}
 	return &PaymentRepository{db: db}
 }
 

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -110,9 +111,13 @@ func (s *authService) Login(userID, password string) (*LoginResponse, error) {
 			"level":    member.Level,
 			"email":    member.Email,
 		}
-		_ = s.cache.SetSession(context.Background(), member.UserID, sessionData)
+		if err := s.cache.SetSession(context.Background(), member.UserID, sessionData); err != nil {
+			log.Printf("cache warning: failed to set session: %v", err)
+		}
 		// Also cache user profile for faster profile lookups
-		_ = s.cache.SetUser(context.Background(), member.UserID, member.ToProfileResponse())
+		if err := s.cache.SetUser(context.Background(), member.UserID, member.ToProfileResponse()); err != nil {
+			log.Printf("cache warning: failed to set user: %v", err)
+		}
 	}
 
 	// 6. Fire after_login hook

--- a/internal/service/board_service.go
+++ b/internal/service/board_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -133,7 +134,9 @@ func (s *BoardService) GetBoard(boardID string) (*domain.Board, error) {
 
 	// 캐시에 저장
 	if s.cache != nil {
-		_ = s.cache.SetBoard(ctx, boardID, board)
+		if err := s.cache.SetBoard(ctx, boardID, board); err != nil {
+			log.Printf("cache warning: failed to set board: %v", err)
+		}
 	}
 
 	return board, nil
@@ -181,7 +184,9 @@ func (s *BoardService) UpdateBoard(boardID string, req *domain.UpdateBoardReques
 
 	// 5. 캐시 무효화
 	if s.cache != nil {
-		_ = s.cache.InvalidateBoard(context.Background(), boardID)
+		if err := s.cache.InvalidateBoard(context.Background(), boardID); err != nil {
+			log.Printf("cache warning: failed to invalidate board: %v", err)
+		}
 	}
 
 	return nil
@@ -221,7 +226,9 @@ func (s *BoardService) DeleteBoard(boardID string) error {
 
 	// 캐시 무효화
 	if s.cache != nil {
-		_ = s.cache.InvalidateBoard(context.Background(), boardID)
+		if err := s.cache.InvalidateBoard(context.Background(), boardID); err != nil {
+			log.Printf("cache warning: failed to invalidate board: %v", err)
+		}
 	}
 
 	return nil

--- a/internal/service/file_service.go
+++ b/internal/service/file_service.go
@@ -37,7 +37,7 @@ func NewFileService(repo repository.FileRepository, uploadPath string) FileServi
 func (s *fileService) UploadEditorImage(file *multipart.FileHeader, boardID string, wrID int) (*domain.FileUploadResponse, error) {
 	// 이미지 파일 검증
 	ext := strings.ToLower(filepath.Ext(file.Filename))
-	allowedExts := map[string]bool{".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".webp": true, ".bmp": true}
+	allowedExts := map[string]bool{extJPG: true, extJPEG: true, extPNG: true, extGIF: true, extWebP: true, ".bmp": true}
 	if !allowedExts[ext] {
 		return nil, fmt.Errorf("허용되지 않는 이미지 형식입니다: %s", ext)
 	}
@@ -158,22 +158,34 @@ func (s *fileService) saveFile(file *multipart.FileHeader, boardID string, wrID 
 	}, nil
 }
 
+// File extension constants
+const (
+	extJPG  = ".jpg"
+	extJPEG = ".jpeg"
+	extPNG  = ".png"
+	extGIF  = ".gif"
+	extWebP = ".webp"
+	extPDF  = ".pdf"
+	extZip  = ".zip"
+	extTxt  = ".txt"
+)
+
 // detectContentType returns content type from file extension
 func detectContentType(ext string) string {
 	switch strings.ToLower(ext) {
-	case ".jpg", ".jpeg":
+	case extJPG, extJPEG:
 		return "image/jpeg"
-	case ".png":
+	case extPNG:
 		return "image/png"
-	case ".gif":
+	case extGIF:
 		return "image/gif"
-	case ".webp":
+	case extWebP:
 		return "image/webp"
-	case ".pdf":
+	case extPDF:
 		return "application/pdf"
-	case ".zip":
+	case extZip:
 		return "application/zip"
-	case ".txt":
+	case extTxt:
 		return "text/plain"
 	default:
 		return "application/octet-stream"

--- a/internal/service/message_service.go
+++ b/internal/service/message_service.go
@@ -70,6 +70,8 @@ func (s *messageService) SendMessage(senderID string, req *domain.SendMessageReq
 }
 
 // GetInbox returns received messages
+//
+//nolint:dupl // GetInbox and GetSent share the same pagination structure but query different data
 func (s *messageService) GetInbox(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error) {
 	if page < 1 {
 		page = 1
@@ -98,6 +100,8 @@ func (s *messageService) GetInbox(mbID string, page, limit int) ([]*domain.Messa
 }
 
 // GetSent returns sent messages
+//
+//nolint:dupl // GetSent and GetInbox share the same pagination structure but query different data
 func (s *messageService) GetSent(mbID string, page, limit int) ([]*domain.MessageResponse, *common.Meta, error) {
 	if page < 1 {
 		page = 1

--- a/internal/service/notification_service.go
+++ b/internal/service/notification_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"log"
 	"math"
 	"time"
 
@@ -42,7 +43,10 @@ func (s *NotificationService) CreateAndBroadcast(memberID, nType, title, content
 
 	// Push via WebSocket if hub is available
 	if s.hub != nil {
-		unreadCount, _ := s.repo.GetUnreadCount(memberID)
+		unreadCount, err := s.repo.GetUnreadCount(memberID)
+		if err != nil {
+			log.Printf("cache warning: failed to get unread count: %v", err)
+		}
 		s.hub.SendToMember(memberID, &ws.Event{
 			Type: "notification",
 			Payload: map[string]interface{}{

--- a/internal/service/scrap_service.go
+++ b/internal/service/scrap_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/domain"
@@ -39,7 +40,10 @@ func (s *scrapService) AddScrap(mbID string, boardID string, wrID int) (*domain.
 		return nil, err
 	}
 
-	title, author, _ := s.repo.GetPostTitle(boardID, wrID)
+	title, author, err := s.repo.GetPostTitle(boardID, wrID)
+	if err != nil {
+		log.Printf("warning: failed to get post title for board=%s wr=%d: %v", boardID, wrID, err)
+	}
 
 	return &domain.ScrapResponse{
 		ScrapID:   scrap.ID,
@@ -72,7 +76,10 @@ func (s *scrapService) ListScraps(mbID string, page, limit int) ([]*domain.Scrap
 
 	responses := make([]*domain.ScrapResponse, len(scraps))
 	for i, sc := range scraps {
-		title, author, _ := s.repo.GetPostTitle(sc.BoTable, sc.WrID)
+		title, author, err := s.repo.GetPostTitle(sc.BoTable, sc.WrID)
+		if err != nil {
+			log.Printf("warning: failed to get post title for board=%s wr=%d: %v", sc.BoTable, sc.WrID, err)
+		}
 		responses[i] = &domain.ScrapResponse{
 			ScrapID:   sc.ID,
 			BoardID:   sc.BoTable,

--- a/internal/service/site_service.go
+++ b/internal/service/site_service.go
@@ -314,13 +314,13 @@ func (s *SiteService) isValidPlan(plan string) bool {
 // getDBStrategyByPlan determines DB strategy based on plan
 func (s *SiteService) getDBStrategyByPlan(plan string) string {
 	switch plan {
-	case "free":
-		return "shared"
-	case "pro", "business":
-		return "schema"
-	case "enterprise":
-		return "dedicated"
+	case planFree:
+		return dbStrategyShared
+	case planPro, planBusiness:
+		return dbStrategySchema
+	case planEnterprise:
+		return dbStrategyDedicated
 	default:
-		return "shared"
+		return dbStrategyShared
 	}
 }

--- a/internal/service/v2/admin_service.go
+++ b/internal/service/v2/admin_service.go
@@ -7,6 +7,12 @@ import (
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 )
 
+// User status constants
+const (
+	userStatusBanned = "banned"
+	userStatusActive = "active"
+)
+
 // AdminService handles v2 admin business logic
 type AdminService struct {
 	userRepo    v2repo.UserRepository
@@ -82,9 +88,9 @@ func (s *AdminService) BanMember(id uint64, ban bool) error {
 		return err
 	}
 	if ban {
-		user.Status = "banned"
+		user.Status = userStatusBanned
 	} else {
-		user.Status = "active"
+		user.Status = userStatusActive
 	}
 	return s.userRepo.Update(user)
 }

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -49,7 +49,7 @@ func (s *V2AuthService) Login(username, password string) (*V2LoginResponse, erro
 		return nil, common.ErrInvalidCredentials
 	}
 
-	if user.Status == "banned" {
+	if user.Status == userStatusBanned {
 		return nil, errors.New("account is banned")
 	}
 	if user.Status == "inactive" {
@@ -162,7 +162,7 @@ func (s *V2AuthService) ExchangeGnuboardJWT(gnuJwt string) (*V2LoginResponse, er
 			Nickname: mbName,
 			Email:    claims.MbEmail,
 			Level:    uint8(level), // #nosec G115 - bounds checked above
-			Status:   "active",
+			Status:   userStatusActive,
 		}
 		if createErr := s.userRepo.Create(user); createErr != nil {
 			return nil, fmt.Errorf("failed to create user: %w", createErr)
@@ -170,7 +170,7 @@ func (s *V2AuthService) ExchangeGnuboardJWT(gnuJwt string) (*V2LoginResponse, er
 		log.Printf("[ExchangeJWT] Created user %s with ID %d", mbID, user.ID)
 	}
 
-	if user.Status == "banned" {
+	if user.Status == userStatusBanned {
 		return nil, errors.New("account is banned")
 	}
 	if user.Status == "inactive" {

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -146,7 +146,7 @@ func (b *Bundle) SupportedLocales() []Locale {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	var locales []Locale
+	locales := make([]Locale, 0, len(b.translations))
 	for l := range b.translations {
 		locales = append(locales, l)
 	}

--- a/pkg/i18n/messages.go
+++ b/pkg/i18n/messages.go
@@ -10,6 +10,7 @@ func DefaultMessages() map[Locale]map[string]string {
 	}
 }
 
+//nolint:dupl // i18n message maps for different languages intentionally share the same keys
 var koMessages = map[string]string{
 	// Common errors
 	"error.not_found":         "요청한 리소스를 찾을 수 없습니다",
@@ -66,6 +67,7 @@ var koMessages = map[string]string{
 	"search.query_required": "검색어를 입력해주세요",
 }
 
+//nolint:dupl // i18n message maps for different languages intentionally share the same keys
 var enMessages = map[string]string{
 	// Common errors
 	"error.not_found":         "The requested resource was not found",
@@ -122,6 +124,7 @@ var enMessages = map[string]string{
 	"search.query_required": "Search query is required",
 }
 
+//nolint:dupl // i18n message maps for different languages intentionally share the same keys
 var jaMessages = map[string]string{
 	// Common errors
 	"error.not_found":         "リクエストされたリソースが見つかりません",


### PR DESCRIPTION
## Summary
- golangci-lint 에러 151개 → 11개로 감소 (140개 수정)
- 47개 파일 수정, 빌드 및 테스트 통과 확인
- 남은 11개는 v2 모델 stuttering (V2User → User 등) - 17+ 파일 영향, 별도 PR 예정

## 수정 내역
| 카테고리 | 수정 수 | 내용 |
|---------|--------|------|
| errcheck | ~94 | AutoMigrate, json.Marshal, cache, HTTP builder 등 에러 처리 |
| goconst | ~14 | 반복 문자열 상수화 (plan, dbStrategy, status 등) |
| prealloc | ~10 | 슬라이스 사전 할당 |
| gosec | ~6 | MD5→SHA256, nolint 주석 |
| revive | ~8 | 미사용 파라미터 _ 처리 (v2 stuttering 제외) |
| errorlint | ~4 | errors.Is(), %w 포맷 |
| gofmt/goimports | ~2 | 코드 포맷팅 |
| noctx | ~2 | http.NewRequestWithContext |
| dupl | ~7 | nolint 주석 (i18n, 유사 구조 함수) |
| unused | ~1 | 미사용 함수 제거 |
| gocyclo | ~2 | nolint 주석 |

## Test plan
- [x] `go build ./...` 통과
- [x] `golangci-lint run ./...` 11개만 남음 (v2 stuttering)
- [x] pluginstore 테스트 통과