### PR TITLE
feat: AI 평가 API 와이어링 및 라우트 등록

### DIFF
--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -9,7 +9,7 @@ import (
 // Run executes AutoMigrate for the menus table and seeds default data if empty.
 func Run(db *gorm.DB) error {
 	// 1. AutoMigrate - 테이블 없으면 생성, 있으면 skip
-	if err := db.AutoMigrate(&domain.Menu{}, &domain.MemberBlock{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &domain.MemberBlock{}, &domain.AIEvaluation{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
 		return err
 	}
 

--- a/internal/service/ai_evaluation_service.go
+++ b/internal/service/ai_evaluation_service.go
@@ -80,3 +80,8 @@ func (s *AIEvaluationService) GetByReport(table string, parent int) (*domain.AIE
 	}
 	return eval, nil
 }
+
+// ListByReport retrieves all AI evaluations for a report
+func (s *AIEvaluationService) ListByReport(table string, parent int) ([]domain.AIEvaluation, error) {
+	return s.repo.ListByReport(table, parent)
+}


### PR DESCRIPTION
## Summary
- `AIEvaluationService`에 `ListByReport` 메서드 추가
- `AIEvaluationHandler`에 `ListEvaluation` 핸들러 추가
- `AutoMigrate`에 `AIEvaluation` 테이블 추가
- `/api/v2/reports/ai-evaluation` 라우트 등록 (POST/GET/GET list, DamoangCookieAuth)

## Test plan
- [ ] `go build ./...` 빌드 확인
- [ ] AI 평가 저장/조회/목록 API 동작 확인