### PR TITLE
fix: g5_group 테이블 누락으로 Load Test MySQL 초기화 실패 수정

### DIFF
--- a/.docker/mysql/init/05-gnuboard-tables.sql
+++ b/.docker/mysql/init/05-gnuboard-tables.sql
@@ -5,6 +5,23 @@ SET NAMES utf8mb4;
 SET CHARACTER SET utf8mb4;
 
 -- ============================================================
+-- 게시판 그룹 테이블 (g5_group)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS `g5_group` (
+  `gr_id` varchar(255) NOT NULL DEFAULT '' COMMENT '그룹 ID',
+  `gr_subject` varchar(255) NOT NULL DEFAULT '' COMMENT '그룹 제목',
+  `gr_admin` varchar(255) NOT NULL DEFAULT '' COMMENT '그룹 관리자',
+  `gr_use_access` tinyint(4) NOT NULL DEFAULT 0 COMMENT '접근 사용',
+  `gr_order` int(11) NOT NULL DEFAULT 0 COMMENT '정렬 순서',
+  `gr_1` varchar(255) NOT NULL DEFAULT '' COMMENT '여분 필드1',
+  `gr_2` varchar(255) NOT NULL DEFAULT '' COMMENT '여분 필드2',
+  `gr_3` varchar(255) NOT NULL DEFAULT '' COMMENT '여분 필드3',
+  `gr_4` varchar(255) NOT NULL DEFAULT '' COMMENT '여분 필드4',
+  `gr_5` varchar(255) NOT NULL DEFAULT '' COMMENT '여분 필드5',
+  PRIMARY KEY (`gr_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COMMENT='게시판 그룹';
+
+-- ============================================================
 -- 게시판 설정 테이블 (g5_board)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS `g5_board` (


### PR DESCRIPTION
## Summary
- `g5_group` 테이블이 init 스크립트에서 CREATE 되지 않아 MySQL 컨테이너가 초기화 중 exit(1)로 종료
- `07-seed-boards.sql`과 `11-seed-full-content.sql`에서 `g5_group`에 INSERT 시도 → 테이블 없어서 크래시
- `05-gnuboard-tables.sql`에 그누보드 호환 `g5_group` 테이블 생성문 추가

## Test plan
- [ ] Load Test 워크플로우가 MySQL 초기화 성공하는지 확인
- [ ] CI 전체 통과 확인