### PR TITLE
feat: PostResponse에 link1/link2 필드 추가

### DIFF
--- a/internal/domain/post.go
+++ b/internal/domain/post.go
@@ -64,6 +64,8 @@ type PostResponse struct {
 	Author        string    `json:"author"`
 	AuthorID      string    `json:"author_id"`
 	AuthorIP      string    `json:"author_ip,omitempty"` // 마스킹된 IP (예: 123.456.*.*)
+	Link1         string    `json:"link1,omitempty"`
+	Link2         string    `json:"link2,omitempty"`
 	ID            int       `json:"id"`
 	Views         int       `json:"views"`
 	Likes         int       `json:"likes"`
@@ -81,6 +83,8 @@ func (p *Post) ToResponse() *PostResponse {
 		Author:        p.Author,
 		AuthorID:      p.AuthorID,
 		AuthorIP:      maskIP(p.IP),
+		Link1:         p.Link1,
+		Link2:         p.Link2,
 		Views:         p.Views,
 		Likes:         p.Likes,
 		Dislikes:      p.Dislikes,


### PR DESCRIPTION
## Summary
- `PostResponse`에 `Link1`, `Link2` 필드 추가 (`json:"link1,omitempty"`, `json:"link2,omitempty"`)
- `ToResponse()`에서 `Post.Link1`, `Post.Link2` 매핑
- 그누보드 `wr_link1`/`wr_link2`에 저장된 동영상 URL을 프론트엔드에서 활용 가능

## Context
기존에 `domain.Post`에는 `Link1`/`Link2` 필드가 있었지만, `PostResponse` DTO에 포함되지 않아 API 응답에서 누락되고 있었음. 프론트엔드(Angple)에서 게시글 동영상 자동 임베드를 위해 필요.

## Test plan
- [ ] `GET /api/v1/boards/free/posts/{id}` 응답에 `link1` 필드 확인
- [ ] `link1`이 빈 문자열인 게시글은 `link1` 필드가 응답에서 생략되는지 확인 (`omitempty`)