### PR TITLE
feat: 나눔 게시판 Go 백엔드 플러그인 추가

### DIFF
--- a/plugins/giving/config/giving.yaml
+++ b/plugins/giving/config/giving.yaml
@@ -1,0 +1,23 @@
+# 나눔 플러그인 설정
+# Giving Plugin Configuration
+
+# 응모 제한
+bid:
+  max_numbers_per_bid: 100      # 한 번에 최대 응모 번호 수
+  min_number: 1                  # 최소 응모 번호
+
+# 수수료
+commission:
+  rate: 50                       # 글작성자 수수료 비율 (%)
+
+# 목록
+list:
+  default_limit: 20              # 기본 페이지 크기
+  max_limit: 40                  # 최대 페이지 크기
+
+# 썸네일
+thumbnail:
+  s3_hostname: s3.damoang.net
+  width: 400
+  height: 225
+  format: webp

--- a/plugins/giving/domain/models.go
+++ b/plugins/giving/domain/models.go
@@ -1,0 +1,193 @@
+//go:build ignore
+
+// 나눔 플러그인 도메인 모델
+package domain
+
+import "time"
+
+// GivingPost 나눔 게시글 (g5_write_giving)
+type GivingPost struct {
+	WrID        int       `gorm:"column:wr_id;primaryKey" json:"wr_id"`
+	WrSubject   string    `gorm:"column:wr_subject" json:"wr_subject"`
+	WrName      string    `gorm:"column:wr_name" json:"wr_name"`
+	WrDatetime  time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
+	WrHit       int       `gorm:"column:wr_hit" json:"wr_hit"`
+	WrGood      int       `gorm:"column:wr_good" json:"wr_good"`
+	WrComment   int       `gorm:"column:wr_comment" json:"wr_comment"`
+	WrIsComment int       `gorm:"column:wr_is_comment" json:"wr_is_comment"`
+	MbID        string    `gorm:"column:mb_id" json:"mb_id"`
+	Wr2         string    `gorm:"column:wr_2" json:"wr_2"`   // 번호당 포인트
+	Wr3         string    `gorm:"column:wr_3" json:"wr_3"`   // 상품명
+	Wr4         string    `gorm:"column:wr_4" json:"wr_4"`   // 시작일시
+	Wr5         string    `gorm:"column:wr_5" json:"wr_5"`   // 종료일시
+	Wr6         string    `gorm:"column:wr_6" json:"wr_6"`   // 배송유형
+	Wr7         string    `gorm:"column:wr_7" json:"wr_7"`   // 상태 (0:진행, 1:일시정지, 2:강제종료)
+	Wr8         string    `gorm:"column:wr_8" json:"wr_8"`   // 일시정지 시각
+	Wr10        string    `gorm:"column:wr_10" json:"wr_10"` // 썸네일
+}
+
+func (GivingPost) TableName() string {
+	return "g5_write_giving"
+}
+
+// GivingBid 나눔 응모 (g5_giving_bid)
+type GivingBid struct {
+	BidID       int       `gorm:"column:bid_id;primaryKey;autoIncrement" json:"bid_id"`
+	WrID        int       `gorm:"column:wr_id;not null" json:"wr_id"`
+	MbID        string    `gorm:"column:mb_id;size:50;not null" json:"mb_id"`
+	MbNick      string    `gorm:"column:mb_nick;size:50" json:"mb_nick"`
+	BidNumbers  string    `gorm:"column:bid_numbers;type:text" json:"bid_numbers"`
+	BidCount    int       `gorm:"column:bid_count" json:"bid_count"`
+	BidPoints   int       `gorm:"column:bid_points" json:"bid_points"`
+	BidDatetime time.Time `gorm:"column:bid_datetime" json:"bid_datetime"`
+	BidStatus   string    `gorm:"column:bid_status;size:20;default:active" json:"bid_status"`
+}
+
+func (GivingBid) TableName() string {
+	return "g5_giving_bid"
+}
+
+// GivingBidNumber 나눔 응모 번호 (g5_giving_bid_numbers)
+type GivingBidNumber struct {
+	ID        int    `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	WrID      int    `gorm:"column:wr_id;not null" json:"wr_id"`
+	BidID     int    `gorm:"column:bid_id;not null" json:"bid_id"`
+	MbID      string `gorm:"column:mb_id;size:50;not null" json:"mb_id"`
+	BidNumber int    `gorm:"column:bid_number;not null" json:"bid_number"`
+	BidStatus string `gorm:"column:bid_status;size:20;default:active" json:"bid_status"`
+}
+
+func (GivingBidNumber) TableName() string {
+	return "g5_giving_bid_numbers"
+}
+
+// Member 회원 (g5_member) - 포인트 조회용
+type Member struct {
+	MbID    string `gorm:"column:mb_id;primaryKey" json:"mb_id"`
+	MbNick  string `gorm:"column:mb_nick" json:"mb_nick"`
+	MbPoint int    `gorm:"column:mb_point" json:"mb_point"`
+}
+
+func (Member) TableName() string {
+	return "g5_member"
+}
+
+// PointLog 포인트 내역 (g5_point)
+type PointLog struct {
+	PoID        int       `gorm:"column:po_id;primaryKey;autoIncrement" json:"po_id"`
+	MbID        string    `gorm:"column:mb_id;size:50;not null" json:"mb_id"`
+	PoContent   string    `gorm:"column:po_content;size:255" json:"po_content"`
+	PoPoint     int       `gorm:"column:po_point" json:"po_point"`
+	PoDatetime  time.Time `gorm:"column:po_datetime" json:"po_datetime"`
+	PoRelTable  string    `gorm:"column:po_rel_table;size:50" json:"po_rel_table"`
+	PoRelID     string    `gorm:"column:po_rel_id;size:50" json:"po_rel_id"`
+	PoRelAction string    `gorm:"column:po_rel_action;size:50" json:"po_rel_action"`
+}
+
+func (PointLog) TableName() string {
+	return "g5_point"
+}
+
+// BoardFile 게시판 첨부파일 (g5_board_file)
+type BoardFile struct {
+	BoTable string `gorm:"column:bo_table" json:"bo_table"`
+	WrID    int    `gorm:"column:wr_id" json:"wr_id"`
+	BfNo    int    `gorm:"column:bf_no" json:"bf_no"`
+	BfFile  string `gorm:"column:bf_file" json:"bf_file"`
+}
+
+func (BoardFile) TableName() string {
+	return "g5_board_file"
+}
+
+// --- Response DTOs ---
+
+// GivingListItem 나눔 목록 아이템 응답
+type GivingListItem struct {
+	ID               int    `json:"id"`
+	Title            string `json:"title"`
+	Content          string `json:"content"`
+	Author           string `json:"author"`
+	AuthorID         string `json:"author_id"`
+	Views            int    `json:"views"`
+	Likes            int    `json:"likes"`
+	CommentsCount    int    `json:"comments_count"`
+	CreatedAt        string `json:"created_at"`
+	Thumbnail        string `json:"thumbnail"`
+	Extra2           string `json:"extra_2"`
+	Extra3           string `json:"extra_3"`
+	Extra4           string `json:"extra_4"`
+	Extra5           string `json:"extra_5"`
+	Extra6           string `json:"extra_6"`
+	Extra7           string `json:"extra_7"`
+	Extra10          string `json:"extra_10"`
+	ParticipantCount string `json:"participant_count"`
+	IsUrgent         bool   `json:"is_urgent"`
+}
+
+// GivingDetailResponse 나눔 상세 응답
+type GivingDetailResponse struct {
+	TotalParticipants int         `json:"totalParticipants"`
+	TotalBidCount     int         `json:"totalBidCount"`
+	MyBids            []GivingBid `json:"myBids"`
+	Winner            *WinnerInfo `json:"winner"`
+}
+
+// WinnerInfo 당첨자 정보
+type WinnerInfo struct {
+	MbID          string `json:"mb_id"`
+	MbNick        string `json:"mb_nick"`
+	WinningNumber int    `json:"winning_number"`
+}
+
+// BidRequest 응모 요청
+type BidRequest struct {
+	Numbers string `json:"numbers" binding:"required"`
+}
+
+// BidResponse 응모 결과 응답
+type BidResponse struct {
+	BidID      int   `json:"bid_id"`
+	Numbers    []int `json:"numbers"`
+	PointsUsed int   `json:"points_used"`
+}
+
+// NumberCount 번호별 카운트
+type NumberCount struct {
+	BidNumber int `gorm:"column:bid_number" json:"bid_number"`
+	Count     int `gorm:"column:cnt" json:"count"`
+}
+
+// ParticipantCount 게시글별 참여자 수
+type ParticipantCount struct {
+	WrID               int `gorm:"column:wr_id" json:"wr_id"`
+	UniqueParticipants int `gorm:"column:unique_participants" json:"unique_participants"`
+}
+
+// BidStats 응모 통계
+type BidStats struct {
+	UniqueParticipants int `gorm:"column:unique_participants" json:"unique_participants"`
+	TotalBidCount      int `gorm:"column:total_bid_count" json:"total_bid_count"`
+}
+
+// AdminStats 관리자 통계
+type AdminStats struct {
+	PostID             int            `json:"post_id"`
+	UniqueParticipants int            `json:"unique_participants"`
+	TotalBidCount      int            `json:"total_bid_count"`
+	TotalPointsUsed    int            `json:"total_points_used"`
+	NumberDistribution []NumberCount  `json:"number_distribution"`
+	RecentBids         []GivingBid    `json:"recent_bids"`
+}
+
+// VisualizationResponse 번호 분포 시각화 응답
+type VisualizationResponse struct {
+	Numbers []NumberCount `json:"numbers"`
+	Winner  *WinnerInfo   `json:"winner"`
+}
+
+// LiveStatusResponse 실시간 현황 응답
+type LiveStatusResponse struct {
+	ParticipantCount int `json:"participant_count"`
+	TotalBidCount    int `json:"total_bid_count"`
+}

--- a/plugins/giving/handlers/admin.go
+++ b/plugins/giving/handlers/admin.go
@@ -1,0 +1,128 @@
+//go:build ignore
+
+// 나눔 플러그인 관리자 핸들러
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"angple-backend/plugins/giving/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AdminHandler 나눔 관리자 API 핸들러
+type AdminHandler struct {
+	svc service.GivingService
+}
+
+// NewAdminHandler 관리자 핸들러 생성자
+func NewAdminHandler(svc service.GivingService) *AdminHandler {
+	return &AdminHandler{svc: svc}
+}
+
+// PauseGiving 나눔 일시정지
+// POST /api/plugins/giving/admin/:id/pause
+func (h *AdminHandler) PauseGiving(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	if err := h.svc.PauseGiving(id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "나눔이 일시정지되었습니다.",
+	})
+}
+
+// ResumeGiving 나눔 재개
+// POST /api/plugins/giving/admin/:id/resume
+func (h *AdminHandler) ResumeGiving(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	if err := h.svc.ResumeGiving(id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "나눔이 재개되었습니다.",
+	})
+}
+
+// ForceStopGiving 나눔 강제종료
+// POST /api/plugins/giving/admin/:id/force-stop
+func (h *AdminHandler) ForceStopGiving(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	if err := h.svc.ForceStopGiving(id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "나눔이 강제종료되었습니다.",
+	})
+}
+
+// GetAdminStats 나눔 관리자 통계
+// GET /api/plugins/giving/admin/:id/stats
+func (h *AdminHandler) GetAdminStats(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	stats, err := h.svc.GetAdminStats(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch admin stats",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    stats,
+	})
+}

--- a/plugins/giving/handlers/public.go
+++ b/plugins/giving/handlers/public.go
@@ -1,0 +1,247 @@
+//go:build ignore
+
+// 나눔 플러그인 공개 + 인증 핸들러
+package handlers
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+
+	"angple-backend/plugins/giving/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PublicHandler 나눔 공개 API 핸들러
+type PublicHandler struct {
+	svc service.GivingService
+}
+
+// NewPublicHandler 핸들러 생성자
+func NewPublicHandler(svc service.GivingService) *PublicHandler {
+	return &PublicHandler{svc: svc}
+}
+
+// ListGivings 나눔 목록
+// GET /api/plugins/giving/list?tab=active&page=1&limit=20&sort=urgent
+func (h *PublicHandler) ListGivings(c *gin.Context) {
+	tab := c.DefaultQuery("tab", "active")
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	sort := c.DefaultQuery("sort", "urgent")
+
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 40 {
+		limit = 40
+	}
+
+	items, total, err := h.svc.ListGivings(tab, sort, page, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch giving data",
+		})
+		return
+	}
+
+	totalPages := int(math.Ceil(float64(total) / float64(limit)))
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    items,
+		"pagination": gin.H{
+			"page":       page,
+			"total":      total,
+			"totalPages": totalPages,
+			"limit":      limit,
+		},
+	})
+}
+
+// GetGivingDetail 나눔 상세 (통계 + 당첨자)
+// GET /api/plugins/giving/:id
+func (h *PublicHandler) GetGivingDetail(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	// optional auth: 사용자 ID가 있을 수도 없을 수도
+	mbID, _ := c.Get("userID")
+	mbIDStr := ""
+	if mbID != nil {
+		if s, ok := mbID.(string); ok {
+			mbIDStr = s
+		}
+	}
+
+	detail, err := h.svc.GetDetail(id, mbIDStr)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch giving detail",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    detail,
+	})
+}
+
+// CreateBid 나눔 응모
+// POST /api/plugins/giving/:id/bid
+func (h *PublicHandler) CreateBid(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	mbID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"success": false,
+			"error":   "로그인이 필요합니다.",
+		})
+		return
+	}
+
+	nickname, _ := c.Get("nickname")
+	mbIDStr := mbID.(string)
+	nickStr := ""
+	if nickname != nil {
+		if s, ok := nickname.(string); ok {
+			nickStr = s
+		}
+	}
+
+	var req struct {
+		Numbers string `json:"numbers" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "번호를 입력해주세요.",
+		})
+		return
+	}
+
+	result, err := h.svc.CreateBid(id, mbIDStr, nickStr, req.Numbers)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    result,
+	})
+}
+
+// GetMyBids 내 응모 현황
+// GET /api/plugins/giving/:id/bid
+func (h *PublicHandler) GetMyBids(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	mbID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"success": false,
+			"error":   "로그인이 필요합니다.",
+		})
+		return
+	}
+
+	bids, err := h.svc.GetMyBids(id, mbID.(string))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch bids",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    bids,
+	})
+}
+
+// GetVisualization 종료된 나눔 번호 분포
+// GET /api/plugins/giving/:id/visualization
+func (h *PublicHandler) GetVisualization(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	result, err := h.svc.GetVisualization(id)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    result,
+	})
+}
+
+// GetLiveStatus 진행중 나눔 실시간 현황
+// GET /api/plugins/giving/:id/live-status
+func (h *PublicHandler) GetLiveStatus(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   "Invalid post ID",
+		})
+		return
+	}
+
+	result, err := h.svc.GetLiveStatus(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch live status",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    result,
+	})
+}

--- a/plugins/giving/hooks/hooks.go
+++ b/plugins/giving/hooks/hooks.go
@@ -1,0 +1,34 @@
+//go:build ignore
+
+// 나눔 플러그인 Hook 구현
+package hooks
+
+import (
+	"angple-backend/pkg/plugin"
+)
+
+var settings map[string]interface{}
+
+// Register Hook 등록
+func Register(ctx *plugin.Context) {
+	settings = ctx.Settings
+}
+
+// AddAdminMenu 관리자 메뉴에 나눔 관리 추가
+func AddAdminMenu(ctx *plugin.HookContext) error {
+	menus, ok := ctx.Input["menus"].([]map[string]interface{})
+	if !ok {
+		menus = []map[string]interface{}{}
+	}
+
+	menus = append(menus, map[string]interface{}{
+		"id":       "giving",
+		"title":    "나눔 관리",
+		"icon":     "gift",
+		"path":     "/admin/plugins/giving",
+		"priority": 40,
+	})
+
+	ctx.SetOutput("menus", menus)
+	return nil
+}

--- a/plugins/giving/main.go
+++ b/plugins/giving/main.go
@@ -1,0 +1,45 @@
+//go:build ignore
+
+// 나눔 플러그인
+// Giving Plugin
+package main
+
+import (
+	"angple-backend/plugins/giving/handlers"
+	"angple-backend/plugins/giving/hooks"
+
+	"angple-backend/pkg/plugin"
+)
+
+func init() {
+	plugin.Register("giving", &plugin.Plugin{
+		OnInit: func(ctx *plugin.Context) error {
+			// Hook 등록
+			hooks.Register(ctx)
+			return nil
+		},
+		OnShutdown: func(ctx *plugin.Context) error {
+			return nil
+		},
+		Handlers: map[string]plugin.HandlerFunc{
+			// 공개 API
+			"ListGivings":    handlers.ListGivings,
+			"GetGivingDetail": handlers.GetGivingDetail,
+			"GetVisualization": handlers.GetVisualization,
+			"GetLiveStatus":   handlers.GetLiveStatus,
+
+			// 인증 필요 API
+			"CreateBid": handlers.CreateBid,
+			"GetMyBids": handlers.GetMyBids,
+
+			// 관리자 API
+			"PauseGiving":    handlers.PauseGiving,
+			"ResumeGiving":   handlers.ResumeGiving,
+			"ForceStopGiving": handlers.ForceStopGiving,
+			"GetAdminStats":  handlers.GetAdminStats,
+		},
+		HookHandlers: map[string]plugin.HookFunc{
+			"AddAdminMenu": hooks.AddAdminMenu,
+		},
+	})
+}

--- a/plugins/giving/migrations/001_init.up.sql
+++ b/plugins/giving/migrations/001_init.up.sql
@@ -1,0 +1,28 @@
+-- 나눔 플러그인 초기 스키마
+-- Giving Plugin Initial Schema
+-- 참고: g5_write_giving, g5_giving_bid, g5_giving_bid_numbers 테이블은 기존에 존재.
+-- 이 마이그레이션은 인덱스 보완 및 향후 확장을 위한 것.
+
+-- g5_giving_bid 테이블 인덱스 보완
+CREATE INDEX IF NOT EXISTS idx_giving_bid_wr_id_status
+    ON g5_giving_bid (wr_id, bid_status);
+
+CREATE INDEX IF NOT EXISTS idx_giving_bid_mb_id_status
+    ON g5_giving_bid (mb_id, bid_status);
+
+CREATE INDEX IF NOT EXISTS idx_giving_bid_wr_mb_status
+    ON g5_giving_bid (wr_id, mb_id, bid_status);
+
+-- g5_giving_bid_numbers 테이블 인덱스 보완
+CREATE INDEX IF NOT EXISTS idx_giving_bid_numbers_wr_status
+    ON g5_giving_bid_numbers (wr_id, bid_status);
+
+CREATE INDEX IF NOT EXISTS idx_giving_bid_numbers_wr_mb_status
+    ON g5_giving_bid_numbers (wr_id, mb_id, bid_status);
+
+CREATE INDEX IF NOT EXISTS idx_giving_bid_numbers_bid_id
+    ON g5_giving_bid_numbers (bid_id);
+
+-- g5_write_giving 상태 관련 인덱스 보완
+CREATE INDEX IF NOT EXISTS idx_write_giving_status
+    ON g5_write_giving (wr_is_comment, wr_5, wr_7);

--- a/plugins/giving/plugin.yaml
+++ b/plugins/giving/plugin.yaml
@@ -1,0 +1,116 @@
+# 나눔 플러그인
+# Giving Plugin
+
+name: giving
+version: 1.0.0
+title: 나눔
+description: 최저고유번호 기반 나눔 시스템 (응모, 당첨, 포인트 연동)
+author: Damoang Team
+license: MIT
+homepage: https://github.com/damoang/angple-backend
+
+# 호환성
+requires:
+  angple: ">=1.0.0 <2.0.0"
+  go: ">=1.21"
+
+# DB 마이그레이션
+migrations:
+  - file: 001_init.up.sql
+    version: 1
+
+# Hook 등록
+hooks:
+  - event: admin.menu
+    handler: AddAdminMenu
+    priority: 50
+    description: 관리자 메뉴에 나눔 관리 추가
+
+# API 라우트
+routes:
+  # 공개 API
+  - path: /list
+    method: GET
+    handler: ListGivings
+    auth: none
+    description: 나눔 목록 (진행중/종료)
+
+  - path: /:id
+    method: GET
+    handler: GetGivingDetail
+    auth: optional
+    description: 나눔 상세 (통계 + 당첨자)
+
+  - path: /:id/visualization
+    method: GET
+    handler: GetVisualization
+    auth: none
+    description: 종료된 나눔 번호 분포
+
+  - path: /:id/live-status
+    method: GET
+    handler: GetLiveStatus
+    auth: none
+    description: 진행중 나눔 실시간 현황
+
+  # 인증 필요 API
+  - path: /:id/bid
+    method: POST
+    handler: CreateBid
+    auth: required
+    description: 나눔 응모
+
+  - path: /:id/bid
+    method: GET
+    handler: GetMyBids
+    auth: required
+    description: 내 응모 현황
+
+  # 관리자 API
+  - path: /admin/:id/pause
+    method: POST
+    handler: PauseGiving
+    auth: required
+    description: 나눔 일시정지
+
+  - path: /admin/:id/resume
+    method: POST
+    handler: ResumeGiving
+    auth: required
+    description: 나눔 재개
+
+  - path: /admin/:id/force-stop
+    method: POST
+    handler: ForceStopGiving
+    auth: required
+    description: 나눔 강제종료
+
+  - path: /admin/:id/stats
+    method: GET
+    handler: GetAdminStats
+    auth: required
+    description: 나눔 관리자 통계
+
+# 설정 스키마
+settings:
+  - key: max_bid_numbers
+    type: number
+    default: 100
+    min: 1
+    max: 500
+    label: 최대 응모 번호 개수
+    description: 한 번에 응모 가능한 최대 번호 수
+
+  - key: commission_rate
+    type: number
+    default: 50
+    min: 0
+    max: 100
+    label: 수수료 비율 (%)
+    description: 글작성자에게 지급되는 수수료 비율
+
+# 권한 정의
+permissions:
+  - id: giving.manage
+    label: 나눔 관리
+    description: 나눔 일시정지/재개/강제종료 권한

--- a/plugins/giving/repository/repository.go
+++ b/plugins/giving/repository/repository.go
@@ -1,0 +1,393 @@
+//go:build ignore
+
+// 나눔 플러그인 Repository
+package repository
+
+import (
+	"fmt"
+	"time"
+
+	"angple-backend/plugins/giving/domain"
+
+	"gorm.io/gorm"
+)
+
+// GivingRepository 나눔 데이터 접근 인터페이스
+type GivingRepository interface {
+	// 목록 조회
+	ListActive(sort string, limit, offset int) ([]domain.GivingPost, int64, error)
+	ListEnded(limit, offset int) ([]domain.GivingPost, int64, error)
+
+	// 참여자 수 조회
+	GetParticipantCounts(wrIDs []int) (map[int]int, error)
+
+	// 첨부파일 조회 (첫 번째만)
+	GetFirstFiles(wrIDs []int) (map[int]string, error)
+
+	// 상세 조회
+	GetPost(wrID int) (*domain.GivingPost, error)
+	GetBidStats(wrID int) (*domain.BidStats, error)
+	GetUserBids(wrID int, mbID string) ([]domain.GivingBid, error)
+
+	// 당첨자 계산
+	GetNumberCounts(wrID int) ([]domain.NumberCount, error)
+	GetWinnerByNumber(wrID int, bidNumber int) (*domain.WinnerInfo, error)
+
+	// 응모
+	GetMemberPoints(mbID string) (int, error)
+	GetDuplicateNumbers(wrID int, mbID string, numbers []int) ([]int, error)
+	CreateBid(tx *gorm.DB, bid *domain.GivingBid) (int, error)
+	CreateBidNumbers(tx *gorm.DB, numbers []domain.GivingBidNumber) error
+	DeductPoints(tx *gorm.DB, mbID string, points int) error
+	AddPoints(tx *gorm.DB, mbID string, points int) error
+	InsertPointLog(tx *gorm.DB, log *domain.PointLog) error
+
+	// 관리자
+	PausePost(wrID int) error
+	ResumePost(wrID int) error
+	ForceStopPost(wrID int) error
+	GetAdminStats(wrID int) (*domain.AdminStats, error)
+
+	// 라이브 현황
+	GetLiveStatus(wrID int) (*domain.LiveStatusResponse, error)
+
+	// 트랜잭션
+	Begin() *gorm.DB
+}
+
+type givingRepository struct {
+	db *gorm.DB
+}
+
+// NewGivingRepository Repository 생성자
+func NewGivingRepository(db *gorm.DB) GivingRepository {
+	return &givingRepository{db: db}
+}
+
+func (r *givingRepository) ListActive(sort string, limit, offset int) ([]domain.GivingPost, int64, error) {
+	now := time.Now().Format("2006-01-02 15:04:05")
+
+	where := "wr_is_comment = 0 AND (wr_5 = '' OR wr_5 > ?) AND (wr_4 = '' OR wr_4 <= ?) AND (wr_7 IS NULL OR wr_7 = '' OR wr_7 = '0')"
+
+	var total int64
+	if err := r.db.Model(&domain.GivingPost{}).Where(where, now, now).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var orderClause string
+	if sort == "urgent" {
+		orderClause = "CASE WHEN wr_5 != '' THEN wr_5 END ASC, wr_datetime DESC"
+	} else {
+		orderClause = "wr_datetime DESC"
+	}
+
+	var posts []domain.GivingPost
+	if err := r.db.Where(where, now, now).
+		Order(orderClause).
+		Limit(limit).
+		Offset(offset).
+		Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return posts, total, nil
+}
+
+func (r *givingRepository) ListEnded(limit, offset int) ([]domain.GivingPost, int64, error) {
+	now := time.Now().Format("2006-01-02 15:04:05")
+
+	where := "wr_is_comment = 0 AND ((wr_5 != '' AND wr_5 <= ?) OR wr_7 = '2')"
+
+	var total int64
+	if err := r.db.Model(&domain.GivingPost{}).Where(where, now).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var posts []domain.GivingPost
+	if err := r.db.Where(where, now).
+		Order("wr_datetime DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return posts, total, nil
+}
+
+func (r *givingRepository) GetParticipantCounts(wrIDs []int) (map[int]int, error) {
+	if len(wrIDs) == 0 {
+		return map[int]int{}, nil
+	}
+
+	var results []domain.ParticipantCount
+	if err := r.db.Model(&domain.GivingBid{}).
+		Select("wr_id, COUNT(DISTINCT mb_id) as unique_participants").
+		Where("wr_id IN ? AND bid_status = 'active'", wrIDs).
+		Group("wr_id").
+		Scan(&results).Error; err != nil {
+		return nil, err
+	}
+
+	m := make(map[int]int)
+	for _, row := range results {
+		m[row.WrID] = row.UniqueParticipants
+	}
+	return m, nil
+}
+
+func (r *givingRepository) GetFirstFiles(wrIDs []int) (map[int]string, error) {
+	if len(wrIDs) == 0 {
+		return map[int]string{}, nil
+	}
+
+	var files []domain.BoardFile
+	if err := r.db.Where("bo_table = 'giving' AND wr_id IN ? AND bf_file != ''", wrIDs).
+		Order("bf_no").
+		Find(&files).Error; err != nil {
+		return nil, err
+	}
+
+	m := make(map[int]string)
+	for _, f := range files {
+		if _, exists := m[f.WrID]; !exists {
+			m[f.WrID] = f.BfFile
+		}
+	}
+	return m, nil
+}
+
+func (r *givingRepository) GetPost(wrID int) (*domain.GivingPost, error) {
+	var post domain.GivingPost
+	if err := r.db.Where("wr_id = ? AND wr_is_comment = 0", wrID).First(&post).Error; err != nil {
+		return nil, err
+	}
+	return &post, nil
+}
+
+func (r *givingRepository) GetBidStats(wrID int) (*domain.BidStats, error) {
+	var stats domain.BidStats
+	if err := r.db.Model(&domain.GivingBid{}).
+		Select("COUNT(DISTINCT mb_id) as unique_participants, COALESCE(SUM(bid_count), 0) as total_bid_count").
+		Where("wr_id = ? AND bid_status = 'active'", wrID).
+		Scan(&stats).Error; err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+func (r *givingRepository) GetUserBids(wrID int, mbID string) ([]domain.GivingBid, error) {
+	var bids []domain.GivingBid
+	if err := r.db.
+		Where("wr_id = ? AND mb_id = ? AND bid_status = 'active'", wrID, mbID).
+		Order("bid_datetime DESC").
+		Find(&bids).Error; err != nil {
+		return nil, err
+	}
+	return bids, nil
+}
+
+func (r *givingRepository) GetNumberCounts(wrID int) ([]domain.NumberCount, error) {
+	var counts []domain.NumberCount
+	if err := r.db.Model(&domain.GivingBidNumber{}).
+		Select("bid_number, COUNT(*) as cnt").
+		Where("wr_id = ? AND bid_status = 'active'", wrID).
+		Group("bid_number").
+		Order("bid_number ASC").
+		Scan(&counts).Error; err != nil {
+		return nil, err
+	}
+	return counts, nil
+}
+
+func (r *givingRepository) GetWinnerByNumber(wrID int, bidNumber int) (*domain.WinnerInfo, error) {
+	var result struct {
+		MbID   string `gorm:"column:mb_id"`
+		MbNick string `gorm:"column:mb_nick"`
+	}
+
+	if err := r.db.Table("g5_giving_bid_numbers bn").
+		Select("b.mb_id, b.mb_nick").
+		Joins("JOIN g5_giving_bid b ON bn.bid_id = b.bid_id").
+		Where("bn.wr_id = ? AND bn.bid_number = ? AND bn.bid_status = 'active'", wrID, bidNumber).
+		Limit(1).
+		Scan(&result).Error; err != nil {
+		return nil, err
+	}
+
+	if result.MbID == "" {
+		return nil, nil
+	}
+
+	return &domain.WinnerInfo{
+		MbID:          result.MbID,
+		MbNick:        result.MbNick,
+		WinningNumber: bidNumber,
+	}, nil
+}
+
+func (r *givingRepository) GetMemberPoints(mbID string) (int, error) {
+	var member domain.Member
+	if err := r.db.Select("mb_point").Where("mb_id = ?", mbID).First(&member).Error; err != nil {
+		return 0, err
+	}
+	return member.MbPoint, nil
+}
+
+func (r *givingRepository) GetDuplicateNumbers(wrID int, mbID string, numbers []int) ([]int, error) {
+	if len(numbers) == 0 {
+		return nil, nil
+	}
+
+	var existing []int
+	if err := r.db.Model(&domain.GivingBidNumber{}).
+		Select("bid_number").
+		Where("wr_id = ? AND mb_id = ? AND bid_status = 'active' AND bid_number IN ?", wrID, mbID, numbers).
+		Pluck("bid_number", &existing).Error; err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+func (r *givingRepository) CreateBid(tx *gorm.DB, bid *domain.GivingBid) (int, error) {
+	bid.BidDatetime = time.Now()
+	bid.BidStatus = "active"
+	if err := tx.Create(bid).Error; err != nil {
+		return 0, err
+	}
+	return bid.BidID, nil
+}
+
+func (r *givingRepository) CreateBidNumbers(tx *gorm.DB, numbers []domain.GivingBidNumber) error {
+	if len(numbers) == 0 {
+		return nil
+	}
+	return tx.Create(&numbers).Error
+}
+
+func (r *givingRepository) DeductPoints(tx *gorm.DB, mbID string, points int) error {
+	return tx.Model(&domain.Member{}).
+		Where("mb_id = ?", mbID).
+		UpdateColumn("mb_point", gorm.Expr("mb_point - ?", points)).Error
+}
+
+func (r *givingRepository) AddPoints(tx *gorm.DB, mbID string, points int) error {
+	return tx.Model(&domain.Member{}).
+		Where("mb_id = ?", mbID).
+		UpdateColumn("mb_point", gorm.Expr("mb_point + ?", points)).Error
+}
+
+func (r *givingRepository) InsertPointLog(tx *gorm.DB, log *domain.PointLog) error {
+	log.PoDatetime = time.Now()
+	return tx.Create(log).Error
+}
+
+func (r *givingRepository) PausePost(wrID int) error {
+	now := time.Now().Format("2006-01-02 15:04:05")
+	return r.db.Model(&domain.GivingPost{}).
+		Where("wr_id = ?", wrID).
+		Updates(map[string]interface{}{
+			"wr_7": "1",
+			"wr_8": now,
+		}).Error
+}
+
+func (r *givingRepository) ResumePost(wrID int) error {
+	// 일시정지 시각 조회
+	var post domain.GivingPost
+	if err := r.db.Select("wr_5, wr_8").Where("wr_id = ?", wrID).First(&post).Error; err != nil {
+		return err
+	}
+
+	updates := map[string]interface{}{
+		"wr_7": "0",
+		"wr_8": "",
+	}
+
+	// 정지 기간만큼 종료시간 연장
+	if post.Wr5 != "" && post.Wr8 != "" {
+		endTime, err1 := time.Parse("2006-01-02 15:04:05", post.Wr5)
+		pauseTime, err2 := time.Parse("2006-01-02 15:04:05", post.Wr8)
+		if err1 == nil && err2 == nil {
+			pauseDuration := time.Since(pauseTime)
+			newEndTime := endTime.Add(pauseDuration)
+			updates["wr_5"] = newEndTime.Format("2006-01-02 15:04:05")
+		}
+	}
+
+	return r.db.Model(&domain.GivingPost{}).
+		Where("wr_id = ?", wrID).
+		Updates(updates).Error
+}
+
+func (r *givingRepository) ForceStopPost(wrID int) error {
+	return r.db.Model(&domain.GivingPost{}).
+		Where("wr_id = ?", wrID).
+		UpdateColumn("wr_7", "2").Error
+}
+
+func (r *givingRepository) GetAdminStats(wrID int) (*domain.AdminStats, error) {
+	stats := &domain.AdminStats{PostID: wrID}
+
+	// 기본 통계
+	bidStats, err := r.GetBidStats(wrID)
+	if err != nil {
+		return nil, err
+	}
+	stats.UniqueParticipants = bidStats.UniqueParticipants
+	stats.TotalBidCount = bidStats.TotalBidCount
+
+	// 총 사용 포인트
+	var totalPoints struct {
+		Total int `gorm:"column:total"`
+	}
+	if err := r.db.Model(&domain.GivingBid{}).
+		Select("COALESCE(SUM(bid_points), 0) as total").
+		Where("wr_id = ? AND bid_status = 'active'", wrID).
+		Scan(&totalPoints).Error; err != nil {
+		return nil, err
+	}
+	stats.TotalPointsUsed = totalPoints.Total
+
+	// 번호 분포
+	numberCounts, err := r.GetNumberCounts(wrID)
+	if err != nil {
+		return nil, err
+	}
+	stats.NumberDistribution = numberCounts
+
+	// 최근 응모 10건
+	var recentBids []domain.GivingBid
+	if err := r.db.Where("wr_id = ? AND bid_status = 'active'", wrID).
+		Order("bid_datetime DESC").
+		Limit(10).
+		Find(&recentBids).Error; err != nil {
+		return nil, err
+	}
+	stats.RecentBids = recentBids
+
+	return stats, nil
+}
+
+func (r *givingRepository) GetLiveStatus(wrID int) (*domain.LiveStatusResponse, error) {
+	var result struct {
+		ParticipantCount int `gorm:"column:participant_count"`
+		TotalBidCount    int `gorm:"column:total_bid_count"`
+	}
+
+	if err := r.db.Model(&domain.GivingBid{}).
+		Select("COUNT(DISTINCT mb_id) as participant_count, COALESCE(SUM(bid_count), 0) as total_bid_count").
+		Where("wr_id = ? AND bid_status = 'active'", wrID).
+		Scan(&result).Error; err != nil {
+		return nil, fmt.Errorf("live status query failed: %w", err)
+	}
+
+	return &domain.LiveStatusResponse{
+		ParticipantCount: result.ParticipantCount,
+		TotalBidCount:    result.TotalBidCount,
+	}, nil
+}
+
+func (r *givingRepository) Begin() *gorm.DB {
+	return r.db.Begin()
+}

--- a/plugins/giving/service/service.go
+++ b/plugins/giving/service/service.go
@@ -1,0 +1,547 @@
+//go:build ignore
+
+// 나눔 플러그인 비즈니스 로직
+package service
+
+import (
+	"fmt"
+	"math"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"angple-backend/plugins/giving/domain"
+	"angple-backend/plugins/giving/repository"
+
+	"gorm.io/gorm"
+)
+
+// GivingService 나눔 서비스 인터페이스
+type GivingService interface {
+	// 목록
+	ListGivings(tab, sort string, page, limit int) ([]domain.GivingListItem, int64, error)
+
+	// 상세
+	GetDetail(wrID int, mbID string) (*domain.GivingDetailResponse, error)
+
+	// 응모
+	CreateBid(wrID int, mbID, mbNick, numbersInput string) (*domain.BidResponse, error)
+	GetMyBids(wrID int, mbID string) ([]domain.GivingBid, error)
+
+	// 관리자
+	PauseGiving(wrID int) error
+	ResumeGiving(wrID int) error
+	ForceStopGiving(wrID int) error
+	GetAdminStats(wrID int) (*domain.AdminStats, error)
+
+	// 공개
+	GetVisualization(wrID int) (*domain.VisualizationResponse, error)
+	GetLiveStatus(wrID int) (*domain.LiveStatusResponse, error)
+}
+
+type givingService struct {
+	repo repository.GivingRepository
+}
+
+// NewGivingService 서비스 생성자
+func NewGivingService(repo repository.GivingRepository) GivingService {
+	return &givingService{repo: repo}
+}
+
+func (s *givingService) ListGivings(tab, sort string, page, limit int) ([]domain.GivingListItem, int64, error) {
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 40 {
+		limit = 40
+	}
+	if page < 1 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+
+	var posts []domain.GivingPost
+	var total int64
+	var err error
+
+	if tab == "ended" {
+		posts, total, err = s.repo.ListEnded(limit, offset)
+	} else {
+		posts, total, err = s.repo.ListActive(sort, limit, offset)
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("목록 조회 실패: %w", err)
+	}
+
+	if len(posts) == 0 {
+		return []domain.GivingListItem{}, total, nil
+	}
+
+	// 게시글 ID 수집
+	wrIDs := make([]int, len(posts))
+	for i, p := range posts {
+		wrIDs[i] = p.WrID
+	}
+
+	// 참여자 수 조회
+	participantMap, err := s.repo.GetParticipantCounts(wrIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("참여자 수 조회 실패: %w", err)
+	}
+
+	// 첨부파일 조회
+	fileMap, err := s.repo.GetFirstFiles(wrIDs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("첨부파일 조회 실패: %w", err)
+	}
+
+	now := time.Now()
+	items := make([]domain.GivingListItem, len(posts))
+	for i, post := range posts {
+		// 긴급 여부 계산
+		isUrgent := false
+		if post.Wr5 != "" {
+			if endTime, err := time.Parse("2006-01-02 15:04:05", post.Wr5); err == nil {
+				diff := endTime.Sub(now)
+				isUrgent = diff > 0 && diff <= 24*time.Hour
+			}
+		}
+
+		// 썸네일 처리
+		thumbnail := post.Wr10
+		if thumbnail == "" {
+			if fileURL, ok := fileMap[post.WrID]; ok {
+				thumbnail = "https://damoang.net/data/file/giving/" + fileURL
+			}
+		}
+
+		// S3 URL → Lambda 썸네일 변환
+		if thumbnail != "" && isS3DamoangURL(thumbnail) {
+			thumbnail = convertToThumbnailURL(thumbnail)
+		}
+
+		extra10 := post.Wr10
+		if extra10 == "" {
+			extra10 = thumbnail
+		}
+
+		items[i] = domain.GivingListItem{
+			ID:               post.WrID,
+			Title:            post.WrSubject,
+			Content:          "",
+			Author:           post.WrName,
+			AuthorID:         "",
+			Views:            post.WrHit,
+			Likes:            post.WrGood,
+			CommentsCount:    post.WrComment,
+			CreatedAt:        post.WrDatetime.Format("2006-01-02 15:04:05"),
+			Thumbnail:        thumbnail,
+			Extra2:           post.Wr2,
+			Extra3:           post.Wr3,
+			Extra4:           post.Wr4,
+			Extra5:           post.Wr5,
+			Extra6:           post.Wr6,
+			Extra7:           post.Wr7,
+			Extra10:          extra10,
+			ParticipantCount: strconv.Itoa(participantMap[post.WrID]),
+			IsUrgent:         isUrgent,
+		}
+	}
+
+	return items, total, nil
+}
+
+func (s *givingService) GetDetail(wrID int, mbID string) (*domain.GivingDetailResponse, error) {
+	// 응모 통계
+	stats, err := s.repo.GetBidStats(wrID)
+	if err != nil {
+		return nil, fmt.Errorf("통계 조회 실패: %w", err)
+	}
+
+	resp := &domain.GivingDetailResponse{
+		TotalParticipants: stats.UniqueParticipants,
+		TotalBidCount:     stats.TotalBidCount,
+		MyBids:            []domain.GivingBid{},
+	}
+
+	// 로그인 사용자의 응모 현황
+	if mbID != "" {
+		bids, err := s.repo.GetUserBids(wrID, mbID)
+		if err != nil {
+			return nil, fmt.Errorf("사용자 응모 조회 실패: %w", err)
+		}
+		if bids != nil {
+			resp.MyBids = bids
+		}
+	}
+
+	// 종료 여부 확인 → 당첨자 계산
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		return nil, fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+
+	isEnded := post.Wr7 == "2"
+	if !isEnded && post.Wr5 != "" {
+		if endTime, err := time.Parse("2006-01-02 15:04:05", post.Wr5); err == nil {
+			isEnded = endTime.Before(time.Now()) || endTime.Equal(time.Now())
+		}
+	}
+
+	if isEnded {
+		winner, err := s.calculateWinner(wrID)
+		if err != nil {
+			return nil, fmt.Errorf("당첨자 계산 실패: %w", err)
+		}
+		resp.Winner = winner
+	}
+
+	return resp, nil
+}
+
+func (s *givingService) CreateBid(wrID int, mbID, mbNick, numbersInput string) (*domain.BidResponse, error) {
+	// 번호 파싱
+	numbers := parseBidNumbers(numbersInput)
+	if len(numbers) == 0 {
+		return nil, fmt.Errorf("유효한 번호가 없습니다")
+	}
+	if len(numbers) > 100 {
+		return nil, fmt.Errorf("한 번에 최대 100개 번호까지 응모 가능합니다")
+	}
+
+	// 게시글 확인
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("나눔을 찾을 수 없습니다")
+		}
+		return nil, fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+
+	// 상태 확인
+	if post.Wr7 == "1" || post.Wr7 == "2" {
+		return nil, fmt.Errorf("이 나눔은 현재 응모할 수 없습니다")
+	}
+
+	now := time.Now()
+	if post.Wr5 != "" {
+		if endTime, err := time.Parse("2006-01-02 15:04:05", post.Wr5); err == nil {
+			if !endTime.After(now) {
+				return nil, fmt.Errorf("종료된 나눔입니다")
+			}
+		}
+	}
+
+	if post.Wr4 != "" {
+		if startTime, err := time.Parse("2006-01-02 15:04:05", post.Wr4); err == nil {
+			if startTime.After(now) {
+				return nil, fmt.Errorf("아직 시작되지 않은 나눔입니다")
+			}
+		}
+	}
+
+	// 번호당 포인트
+	pointsPerNumber, _ := strconv.Atoi(post.Wr2)
+	totalPoints := len(numbers) * pointsPerNumber
+
+	// 사용자 포인트 확인
+	currentPoints, err := s.repo.GetMemberPoints(mbID)
+	if err != nil {
+		return nil, fmt.Errorf("포인트 조회 실패: %w", err)
+	}
+
+	if currentPoints < totalPoints {
+		return nil, fmt.Errorf("포인트가 부족합니다. (필요: %d, 보유: %d)", totalPoints, currentPoints)
+	}
+
+	// 중복 번호 체크
+	dupes, err := s.repo.GetDuplicateNumbers(wrID, mbID, numbers)
+	if err != nil {
+		return nil, fmt.Errorf("중복 확인 실패: %w", err)
+	}
+	if len(dupes) > 0 {
+		dupeStrs := make([]string, len(dupes))
+		for i, d := range dupes {
+			dupeStrs[i] = strconv.Itoa(d)
+		}
+		return nil, fmt.Errorf("이미 응모한 번호가 있습니다: %s", strings.Join(dupeStrs, ", "))
+	}
+
+	// 트랜잭션으로 응모 처리
+	tx := s.repo.Begin()
+	if tx.Error != nil {
+		return nil, fmt.Errorf("트랜잭션 시작 실패: %w", tx.Error)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+		}
+	}()
+
+	// 1. 응모 레코드 생성
+	bid := &domain.GivingBid{
+		WrID:       wrID,
+		MbID:       mbID,
+		MbNick:     mbNick,
+		BidNumbers: numbersInput,
+		BidCount:   len(numbers),
+		BidPoints:  totalPoints,
+	}
+	bidID, err := s.repo.CreateBid(tx, bid)
+	if err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("응모 생성 실패: %w", err)
+	}
+
+	// 2. 개별 번호 레코드 생성
+	bidNumbers := make([]domain.GivingBidNumber, len(numbers))
+	for i, n := range numbers {
+		bidNumbers[i] = domain.GivingBidNumber{
+			WrID:      wrID,
+			BidID:     bidID,
+			MbID:      mbID,
+			BidNumber: n,
+			BidStatus: "active",
+		}
+	}
+	if err := s.repo.CreateBidNumbers(tx, bidNumbers); err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("응모 번호 생성 실패: %w", err)
+	}
+
+	// 3. 포인트 차감 (응모자)
+	if err := s.repo.DeductPoints(tx, mbID, totalPoints); err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("포인트 차감 실패: %w", err)
+	}
+
+	// 4. 포인트 내역 기록 (응모자 차감)
+	if err := s.repo.InsertPointLog(tx, &domain.PointLog{
+		MbID:        mbID,
+		PoContent:   fmt.Sprintf("나눔 응모 (%d개 번호)", len(numbers)),
+		PoPoint:     -totalPoints,
+		PoRelTable:  "giving",
+		PoRelID:     strconv.Itoa(wrID),
+		PoRelAction: "bid",
+	}); err != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("포인트 내역 기록 실패: %w", err)
+	}
+
+	// 5. 수수료 50%: 글작성자에게 포인트 지급
+	if post.MbID != "" && post.MbID != mbID {
+		authorPoints := int(math.Floor(float64(totalPoints) * 0.5))
+		if authorPoints > 0 {
+			if err := s.repo.AddPoints(tx, post.MbID, authorPoints); err != nil {
+				tx.Rollback()
+				return nil, fmt.Errorf("수수료 지급 실패: %w", err)
+			}
+
+			if err := s.repo.InsertPointLog(tx, &domain.PointLog{
+				MbID:        post.MbID,
+				PoContent:   "나눔 응모 수수료",
+				PoPoint:     authorPoints,
+				PoRelTable:  "giving",
+				PoRelID:     strconv.Itoa(wrID),
+				PoRelAction: "bid_commission",
+			}); err != nil {
+				tx.Rollback()
+				return nil, fmt.Errorf("수수료 내역 기록 실패: %w", err)
+			}
+		}
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return nil, fmt.Errorf("트랜잭션 커밋 실패: %w", err)
+	}
+
+	return &domain.BidResponse{
+		BidID:      bidID,
+		Numbers:    numbers,
+		PointsUsed: totalPoints,
+	}, nil
+}
+
+func (s *givingService) GetMyBids(wrID int, mbID string) ([]domain.GivingBid, error) {
+	bids, err := s.repo.GetUserBids(wrID, mbID)
+	if err != nil {
+		return nil, fmt.Errorf("응모 조회 실패: %w", err)
+	}
+	if bids == nil {
+		return []domain.GivingBid{}, nil
+	}
+	return bids, nil
+}
+
+func (s *givingService) PauseGiving(wrID int) error {
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		return fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+	if post.Wr7 == "2" {
+		return fmt.Errorf("이미 종료된 나눔입니다")
+	}
+	if post.Wr7 == "1" {
+		return fmt.Errorf("이미 일시정지 상태입니다")
+	}
+	return s.repo.PausePost(wrID)
+}
+
+func (s *givingService) ResumeGiving(wrID int) error {
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		return fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+	if post.Wr7 != "1" {
+		return fmt.Errorf("일시정지 상태가 아닙니다")
+	}
+	return s.repo.ResumePost(wrID)
+}
+
+func (s *givingService) ForceStopGiving(wrID int) error {
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		return fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+	if post.Wr7 == "2" {
+		return fmt.Errorf("이미 종료된 나눔입니다")
+	}
+	return s.repo.ForceStopPost(wrID)
+}
+
+func (s *givingService) GetAdminStats(wrID int) (*domain.AdminStats, error) {
+	return s.repo.GetAdminStats(wrID)
+}
+
+func (s *givingService) GetVisualization(wrID int) (*domain.VisualizationResponse, error) {
+	// 종료 여부 확인
+	post, err := s.repo.GetPost(wrID)
+	if err != nil {
+		return nil, fmt.Errorf("게시글 조회 실패: %w", err)
+	}
+
+	isEnded := post.Wr7 == "2"
+	if !isEnded && post.Wr5 != "" {
+		if endTime, err := time.Parse("2006-01-02 15:04:05", post.Wr5); err == nil {
+			isEnded = endTime.Before(time.Now()) || endTime.Equal(time.Now())
+		}
+	}
+
+	if !isEnded {
+		return nil, fmt.Errorf("진행중인 나눔의 번호 분포는 조회할 수 없습니다")
+	}
+
+	numbers, err := s.repo.GetNumberCounts(wrID)
+	if err != nil {
+		return nil, fmt.Errorf("번호 분포 조회 실패: %w", err)
+	}
+
+	winner, err := s.calculateWinner(wrID)
+	if err != nil {
+		return nil, fmt.Errorf("당첨자 계산 실패: %w", err)
+	}
+
+	return &domain.VisualizationResponse{
+		Numbers: numbers,
+		Winner:  winner,
+	}, nil
+}
+
+func (s *givingService) GetLiveStatus(wrID int) (*domain.LiveStatusResponse, error) {
+	return s.repo.GetLiveStatus(wrID)
+}
+
+// --- 내부 헬퍼 함수 ---
+
+// calculateWinner 최저고유번호 당첨자 계산
+func (s *givingService) calculateWinner(wrID int) (*domain.WinnerInfo, error) {
+	numberCounts, err := s.repo.GetNumberCounts(wrID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 고유번호 (1번만 선택된 번호) 중 최저 찾기
+	for _, nc := range numberCounts {
+		if nc.Count == 1 {
+			return s.repo.GetWinnerByNumber(wrID, nc.BidNumber)
+		}
+	}
+
+	return nil, nil
+}
+
+// isS3DamoangURL S3 URL 여부 확인
+func isS3DamoangURL(urlStr string) bool {
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+	return u.Hostname() == "s3.damoang.net"
+}
+
+// s3ThumbnailRegex S3 URL 파싱용 정규식
+var s3ThumbnailRegex = regexp.MustCompile(`^(https?://s3\.damoang\.net/.+/)([^/]+)\.([a-zA-Z0-9]+)$`)
+
+// convertToThumbnailURL S3 URL → Lambda 썸네일 URL 변환
+func convertToThumbnailURL(urlStr string) string {
+	matches := s3ThumbnailRegex.FindStringSubmatch(urlStr)
+	if len(matches) == 4 {
+		return matches[1] + matches[2] + "-400x225.webp"
+	}
+	return urlStr
+}
+
+// parseBidNumbers 번호 문자열 파싱: "1,3,5-10,15~20" → [1,3,5,6,7,8,9,10,15,16,17,18,19,20]
+func parseBidNumbers(input string) []int {
+	numbers := make(map[int]struct{})
+	parts := strings.Split(input, ",")
+
+	rangeRegex := regexp.MustCompile(`^\s*(\d+)\s*[-~]\s*(\d+)\s*$`)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		if matches := rangeRegex.FindStringSubmatch(part); len(matches) == 3 {
+			start, _ := strconv.Atoi(matches[1])
+			end, _ := strconv.Atoi(matches[2])
+			if start > end {
+				start, end = end, start
+			}
+			for i := start; i <= end; i++ {
+				numbers[i] = struct{}{}
+			}
+		} else {
+			num, err := strconv.Atoi(part)
+			if err == nil && num > 0 {
+				numbers[num] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]int, 0, len(numbers))
+	for n := range numbers {
+		result = append(result, n)
+	}
+
+	// 정렬
+	sortInts(result)
+	return result
+}
+
+// sortInts 정수 배열 정렬 (sort 패키지 import 없이)
+func sortInts(a []int) {
+	for i := 1; i < len(a); i++ {
+		key := a[i]
+		j := i - 1
+		for j >= 0 && a[j] > key {
+			a[j+1] = a[j]
+			j--
+		}
+		a[j+1] = key
+	}
+}


### PR DESCRIPTION
## Summary
- 포인트 기반 번호 응모 나눔 시스템 백엔드 플러그인
- 기존 SvelteKit API를 Go로 포팅 + 신규 관리자/시각화 API 추가

## API 엔드포인트

### 공개 API
| 메서드 | 경로 | 설명 |
|---|---|---|
| GET | `/api/plugins/giving/list` | 나눔 목록 (tab, page, limit, sort) |
| GET | `/api/plugins/giving/:id` | 나눔 상세 + 통계 + 당첨자 |
| GET | `/api/plugins/giving/:id/visualization` | 종료된 나눔 번호 분포 |
| GET | `/api/plugins/giving/:id/live-status` | 실시간 참여자/응모 수 |

### 인증 필요 API
| 메서드 | 경로 | 설명 |
|---|---|---|
| POST | `/api/plugins/giving/:id/bid` | 응모 (트랜잭션) |
| GET | `/api/plugins/giving/:id/bid` | 내 응모 현황 |

### 관리자 API
| 메서드 | 경로 | 설명 |
|---|---|---|
| POST | `/admin/:id/pause` | 일시정지 |
| POST | `/admin/:id/resume` | 재개 (종료시간 연장) |
| POST | `/admin/:id/force-stop` | 강제종료 |
| GET | `/admin/:id/stats` | 관리자 통계 |

## 파일 구조
```
plugins/giving/
├── plugin.yaml, config/giving.yaml
├── domain/models.go
├── repository/repository.go
├── service/service.go
├── handlers/public.go, admin.go
├── hooks/hooks.go
├── main.go
└── migrations/001_init.up.sql
```

## Test plan
- [x] 코드 리뷰 완료
- [ ] API 엔드포인트 통합 테스트
- [ ] 응모 트랜잭션 테스트 (포인트 차감 + 수수료)
- [ ] 관리자 기능 테스트 (일시정지/재개/강제종료)