### PR TITLE
feat: v1 호환 스텁 라우트 및 v2 데이터 어댑터

### DIFF
--- a/internal/handler/v2/auth_handler.go
+++ b/internal/handler/v2/auth_handler.go
@@ -31,6 +31,12 @@ type v2RefreshRequest struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
+// isSecureCookie returns true if cookies should have the Secure flag.
+// In release mode (production), Secure=true; in debug/local, Secure=false.
+func isSecureCookie() bool {
+	return gin.Mode() == gin.ReleaseMode
+}
+
 // Login handles POST /api/v2/auth/login
 func (h *V2AuthHandler) Login(c *gin.Context) {
 	var req v2LoginRequest
@@ -46,7 +52,7 @@ func (h *V2AuthHandler) Login(c *gin.Context) {
 	}
 
 	// Set refresh token as httpOnly cookie
-	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", true, true)
+	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", isSecureCookie(), true)
 
 	common.V2Success(c, gin.H{
 		"access_token": resp.AccessToken,
@@ -73,7 +79,7 @@ func (h *V2AuthHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", true, true)
+	c.SetCookie("refresh_token", resp.RefreshToken, 7*24*3600, "/", "", isSecureCookie(), true)
 
 	common.V2Success(c, gin.H{
 		"access_token": resp.AccessToken,
@@ -83,7 +89,7 @@ func (h *V2AuthHandler) RefreshToken(c *gin.Context) {
 
 // Logout handles POST /api/v2/auth/logout
 func (h *V2AuthHandler) Logout(c *gin.Context) {
-	c.SetCookie("refresh_token", "", -1, "/", "", true, true)
+	c.SetCookie("refresh_token", "", -1, "/", "", isSecureCookie(), true)
 	common.V2Success(c, gin.H{"message": "로그아웃되었습니다"})
 }
 

--- a/internal/migration/v2_data.go
+++ b/internal/migration/v2_data.go
@@ -109,8 +109,8 @@ func migratePostsAndComments(db *gorm.DB) error {
 		postSQL := fmt.Sprintf(`
 			INSERT IGNORE INTO v2_posts (board_id, user_id, title, content, status, view_count, comment_count, is_notice, created_at, updated_at)
 			SELECT
-				(SELECT id FROM v2_boards WHERE slug = '%s'),
-				COALESCE((SELECT id FROM v2_users WHERE username = w.mb_id LIMIT 1), 1),
+				(SELECT id FROM v2_boards WHERE slug = '%s' COLLATE utf8mb4_unicode_ci),
+				COALESCE((SELECT id FROM v2_users WHERE username = w.mb_id COLLATE utf8mb4_unicode_ci LIMIT 1), 1),
 				w.wr_subject,
 				w.wr_content,
 				'published',
@@ -134,8 +134,8 @@ func migratePostsAndComments(db *gorm.DB) error {
 		commentSQL := fmt.Sprintf(`
 			INSERT IGNORE INTO v2_comments (post_id, user_id, content, depth, status, created_at, updated_at)
 			SELECT
-				(SELECT p.id FROM v2_posts p JOIN v2_boards b ON p.board_id = b.id WHERE b.slug = '%s' AND p.title = (SELECT wr_subject FROM %s WHERE wr_id = w.wr_parent AND wr_is_comment = 0 LIMIT 1) LIMIT 1),
-				COALESCE((SELECT id FROM v2_users WHERE username = w.mb_id LIMIT 1), 1),
+				(SELECT p.id FROM v2_posts p JOIN v2_boards b ON p.board_id = b.id WHERE b.slug = '%s' COLLATE utf8mb4_unicode_ci AND p.title = (SELECT wr_subject FROM %s WHERE wr_id = w.wr_parent AND wr_is_comment = 0 LIMIT 1) COLLATE utf8mb4_unicode_ci LIMIT 1),
+				COALESCE((SELECT id FROM v2_users WHERE username = w.mb_id COLLATE utf8mb4_unicode_ci LIMIT 1), 1),
 				w.wr_content,
 				0,
 				'active',


### PR DESCRIPTION
## Summary
- v1 API 호환 라우트 추가: auth, boards, menus, recommended 등 프론트엔드가 호출하는 `/api/v1/*` 엔드포인트를 v2 데이터로 변환하여 제공
- v1 boards API (`/api/v1/boards/:slug/posts`)를 v2 데이터에서 변환하여 목록/상세/댓글 제공
- 쿠키 Secure 플래그를 `gin.Mode()` 기반으로 환경 분기 (개발: false, 운영: true)
- 개발 환경 v2 데이터 마이그레이션 자동 실행 및 COLLATE utf8mb4_unicode_ci 호환성 수정
- 미매핑 `/api/v1/*` 경로에 대한 catch-all 빈 성공 응답 (404 방지)

## Test plan
- [ ] `go build ./...` 빌드 성공 확인
- [ ] `/api/v1/auth/login`, `/api/v1/auth/me` 동작 확인
- [ ] `/api/v1/boards/:slug/posts` 목록 및 상세 조회 확인
- [ ] 미등록 v1 엔드포인트 호출 시 빈 성공 응답 반환 확인
- [ ] 개발 환경에서 v2 데이터 마이그레이션 자동 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)