### PR TITLE
feat: 게시글 목록 API에 썸네일 필드 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -472,8 +472,17 @@ func main() {
 			noticeIDs := gnurepo.ParseNoticeIDs(board.BoNotice)
 			noticeIDMap := v1handler.BuildNoticeIDMap(noticeIDs)
 
-			// Transform to v1 format
-			items := v1handler.TransformToV1Posts(posts, noticeIDMap)
+			// Get thumbnails for posts with files
+			postIDs := make([]int, 0, len(posts))
+			for _, p := range posts {
+				if p.WrFile > 0 {
+					postIDs = append(postIDs, p.WrID)
+				}
+			}
+			thumbnails := gnuFileRepo.GetThumbnails(slug, postIDs, "https://s3.damoang.net")
+
+			// Transform to v1 format with thumbnails
+			items := v1handler.TransformToV1PostsWithThumbnails(posts, noticeIDMap, thumbnails)
 
 			response := gin.H{
 				"success": true,

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -44,6 +44,20 @@ func TransformToV1Posts(posts []*gnuboard.G5Write, noticeIDs map[int]bool) []map
 	return result
 }
 
+// TransformToV1PostsWithThumbnails converts posts with thumbnail URLs
+func TransformToV1PostsWithThumbnails(posts []*gnuboard.G5Write, noticeIDs map[int]bool, thumbnails map[int]string) []map[string]any {
+	result := make([]map[string]any, len(posts))
+	for i, p := range posts {
+		isNotice := noticeIDs[p.WrID]
+		item := TransformToV1Post(p, isNotice)
+		if thumb, ok := thumbnails[p.WrID]; ok {
+			item["thumbnail"] = thumb
+		}
+		result[i] = item
+	}
+	return result
+}
+
 // TransformToV1Comment converts G5Write (comment) to v1 API response format
 func TransformToV1Comment(w *gnuboard.G5Write) map[string]any {
 	depth := len(w.WrCommentReply)

--- a/internal/repository/gnuboard/file_repo.go
+++ b/internal/repository/gnuboard/file_repo.go
@@ -1,10 +1,18 @@
 package gnuboard
 
 import (
+	"strings"
+
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 
 	"gorm.io/gorm"
 )
+
+// imageExtensions lists common image file extensions
+var imageExtensions = map[string]bool{
+	".jpg": true, ".jpeg": true, ".png": true, ".gif": true,
+	".webp": true, ".bmp": true, ".svg": true, ".avif": true,
+}
 
 // FileRepository handles file attachment database operations
 type FileRepository struct {
@@ -42,4 +50,37 @@ func (r *FileRepository) IncrementDownloadCount(boardID string, postID int, file
 		Where("bo_table = ? AND wr_id = ? AND bf_no = ?", boardID, postID, fileNo).
 		UpdateColumn("bf_download", gorm.Expr("bf_download + 1")).
 		Error
+}
+
+// GetThumbnails returns the first image file for each post (batch query for list pages)
+// Returns a map of postID -> thumbnail URL
+func (r *FileRepository) GetThumbnails(boardID string, postIDs []int, baseURL string) map[int]string {
+	if len(postIDs) == 0 {
+		return map[int]string{}
+	}
+
+	// Get first file (bf_no = 0) for each post
+	var files []gnuboard.G5BoardFile
+	r.db.Where("bo_table = ? AND wr_id IN ? AND bf_no = 0", boardID, postIDs).
+		Find(&files)
+
+	result := make(map[int]string, len(files))
+	for _, f := range files {
+		// Check if file is an image by extension, bf_type, or dimensions
+		isImage := f.BfType == 1 || f.BfWidth > 0
+		if !isImage {
+			// Check by file extension
+			lowerName := strings.ToLower(f.BfFile)
+			for ext := range imageExtensions {
+				if strings.HasSuffix(lowerName, ext) {
+					isImage = true
+					break
+				}
+			}
+		}
+		if isImage {
+			result[f.WrID] = baseURL + "/data/file/" + f.BoTable + "/" + f.BfFile
+		}
+	}
+	return result
 }


### PR DESCRIPTION
## Summary
- 게시글 목록 API 응답에 `thumbnail` 필드 추가
- `g5_board_file` 테이블에서 첫 번째 이미지 파일을 배치 쿼리로 조회
- 이미지 확장자 기반 필터링 (jpg, png, gif, webp 등)

## Changes
- `internal/repository/gnuboard/file_repo.go`: `GetThumbnails` 메서드 추가
- `internal/handler/v1/transform.go`: `TransformToV1PostsWithThumbnails` 함수 추가
- `cmd/api/main.go`: 게시글 목록 핸들러에서 썸네일 조회 및 병합

## Test plan
- [ ] 갤러리 게시판 API 호출 시 thumbnail 필드 확인
- [ ] 첨부파일이 없는 게시글은 thumbnail 필드 없음 확인