### PR TITLE
feat: IP 보호 미들웨어 + author_ip 표시 + wr_num 정렬 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/config"
 	"github.com/damoang/angple-backend/internal/domain"
 	"github.com/damoang/angple-backend/internal/handler"
@@ -183,6 +184,9 @@ func main() {
 		cfg.JWT.RefreshIn,
 	)
 
+	// IP Protection
+	ipProtectCfg := middleware.LoadIPProtectionConfig()
+
 	// Plugin HookManager
 	pluginLogger := plugin.NewDefaultLogger("plugin")
 	_ = plugin.NewHookManager(pluginLogger)
@@ -290,7 +294,7 @@ func main() {
 		v2routes.SetupMyPage(router, pointHandler, expHandler, jwtManager)
 
 		// DisciplineLog routes (uses gnuboard g5_write_disciplinelog table)
-		disciplineLogHandler := v2handler.NewDisciplineLogHandler(gnuWriteRepo)
+		disciplineLogHandler := v2handler.NewDisciplineLogHandler(gnuWriteRepo, db)
 		v2routes.SetupDisciplineLog(router, disciplineLogHandler, jwtManager)
 
 		// v2 Auth
@@ -607,6 +611,11 @@ func main() {
 			noticeIDMap := v1handler.BuildNoticeIDMap(noticeIDs)
 			items := v1handler.TransformToV1Posts(notices, noticeIDMap)
 
+			// Admin sees full (unmasked) IP
+			if middleware.GetUserLevel(c) >= 10 {
+				v1handler.OverrideIPForAdmin(items, notices)
+			}
+
 			response := gin.H{"success": true, "data": items}
 
 			// Cache the response
@@ -906,6 +915,11 @@ func main() {
 			// Transform to v1 format
 			items := v1handler.TransformToV1Posts(posts, noticeIDMap)
 
+			// Admin sees full (unmasked) IP
+			if middleware.GetUserLevel(c) >= 10 {
+				v1handler.OverrideIPForAdmin(items, posts)
+			}
+
 			// Enrich thumbnails from g5_board_file for posts that have files but no thumbnail
 			var needFileIDs []int
 			for _, item := range items {
@@ -986,6 +1000,11 @@ func main() {
 
 			postDetail := v1handler.TransformToV1PostDetail(post, isNotice)
 
+			// Admin sees full (unmasked) IP
+			if middleware.GetUserLevel(c) >= 10 {
+				v1handler.OverrideIPForAdminSingle(postDetail, post)
+			}
+
 			// 비밀글 접근 제어: 작성자 또는 관리자만 내용 열람 가능
 			if strings.Contains(post.WrOption, "secret") {
 				currentUserID := middleware.GetUserID(c)
@@ -1042,6 +1061,10 @@ func main() {
 			}
 
 			transformed := v1handler.TransformToV1Comments(comments)
+			// Admin sees full (unmasked) IP
+			if middleware.GetUserLevel(c) >= 10 {
+				v1handler.OverrideIPForAdmin(transformed, comments)
+			}
 			for i, comment := range comments {
 				if cnt, ok := editCountMap[comment.WrID]; ok && cnt > 0 {
 					transformed[i]["edit_count"] = cnt
@@ -1220,9 +1243,271 @@ func main() {
 			})
 		})
 
-		// POST routes still use v2 handlers for now (will be migrated later)
-		v1Boards.POST("/:slug/posts", middleware.JWTAuth(jwtManager), v2Handler.CreatePost)
-		v1Boards.POST("/:slug/posts/:id/comments", middleware.JWTAuth(jwtManager), v2Handler.CreateComment)
+		// POST /api/v1/boards/:slug/posts - Create post in g5_write_{slug}
+		v1Boards.POST("/:slug/posts", middleware.JWTAuth(jwtManager), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
+			slug := c.Param("slug")
+
+			// 게시판 설정 조회
+			board, err := gnuBoardRepo.FindByID(slug)
+			if err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "게시판을 찾을 수 없습니다"})
+				return
+			}
+
+			// 요청 바디 파싱
+			var req struct {
+				Title    string  `json:"title" binding:"required"`
+				Content  string  `json:"content" binding:"required"`
+				Category *string `json:"category"`
+				IsSecret *bool   `json:"is_secret"`
+				Link1    *string `json:"link1"`
+				Link2    *string `json:"link2"`
+				Extra1   *string `json:"extra_1"`
+				Extra2   *string `json:"extra_2"`
+				Extra3   *string `json:"extra_3"`
+			}
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "제목과 내용을 입력해주세요"})
+				return
+			}
+
+			mbID := middleware.GetUserID(c)
+			userLevel := middleware.GetUserLevel(c)
+
+			// 제휴 링크 차단 검증
+			if err := common.ValidateAffiliateLinks(req.Content, slug, userLevel, false); err != nil {
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": err.Error()})
+				return
+			}
+
+			// 레벨 체크
+			if userLevel < board.BoWriteLevel {
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "글쓰기 권한이 없습니다. 레벨 " + strconv.Itoa(board.BoWriteLevel) + " 이상이 필요합니다."})
+				return
+			}
+
+			// 포인트 차감 게시판인 경우 잔액 확인
+			if board.BoWritePoint < 0 {
+				var mbNo uint64
+				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
+					canAfford, err := v2PointRepo.CanAfford(mbNo, board.BoWritePoint)
+					if err != nil {
+						c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
+						return
+					}
+					if !canAfford {
+						c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoWritePoint) + "포인트가 필요합니다."})
+						return
+					}
+				}
+			}
+
+			// 작성자 닉네임 조회
+			authorName := middleware.GetNickname(c)
+			if authorName == "" {
+				db.Table("g5_member").Select("mb_nick").Where("mb_id = ?", mbID).Scan(&authorName)
+			}
+
+			// g5_write_{slug} 테이블에 게시글 INSERT
+			now := time.Now()
+			nowStr := now.Format("2006-01-02 15:04:05")
+
+			wrOption := ""
+			if req.IsSecret != nil && *req.IsSecret {
+				wrOption = "secret"
+			}
+
+			post := gnuboard.G5Write{
+				WrNum:       0,
+				WrParent:    0,
+				WrIsComment: 0,
+				WrSubject:   req.Title,
+				WrContent:   req.Content,
+				MbID:        mbID,
+				WrName:      authorName,
+				WrDatetime:  now,
+				WrLast:      nowStr,
+				WrIP:        middleware.GetClientIP(c),
+				WrOption:    wrOption,
+			}
+
+			if req.Category != nil {
+				post.CaName = *req.Category
+			}
+			if req.Link1 != nil {
+				post.WrLink1 = *req.Link1
+			}
+			if req.Link2 != nil {
+				post.WrLink2 = *req.Link2
+			}
+
+			tableName := fmt.Sprintf("g5_write_%s", slug)
+
+			// wr_num 값 계산 (가장 작은 음수값 - 1, gnuboard 정렬 규칙)
+			var minNum int
+			db.Table(tableName).Select("COALESCE(MIN(wr_num), 0)").Scan(&minNum)
+			post.WrNum = minNum - 1
+
+			if err := db.Table(tableName).Create(&post).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 작성 실패"})
+				return
+			}
+
+			// wr_parent를 자기 자신의 wr_id로 UPDATE (gnuboard 규칙)
+			db.Table(tableName).Where("wr_id = ?", post.WrID).Update("wr_parent", post.WrID)
+
+			// extra 필드 업데이트 (있는 경우)
+			extras := map[string]interface{}{}
+			if req.Extra1 != nil {
+				extras["wr_1"] = *req.Extra1
+			}
+			if req.Extra2 != nil {
+				extras["wr_2"] = *req.Extra2
+			}
+			if req.Extra3 != nil {
+				extras["wr_3"] = *req.Extra3
+			}
+			if len(extras) > 0 {
+				db.Table(tableName).Where("wr_id = ?", post.WrID).Updates(extras)
+			}
+
+			// 포인트 처리
+			if board.BoWritePoint != 0 {
+				var mbNo uint64
+				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
+					_ = v2PointRepo.AddPoint(mbNo, board.BoWritePoint, "글쓰기", tableName, uint64(post.WrID))
+				}
+			}
+
+			c.JSON(http.StatusCreated, gin.H{
+				"success": true,
+				"data":    v1handler.TransformToV1PostDetail(&post, false),
+			})
+		})
+
+		// POST /api/v1/boards/:slug/posts/:id/comments - Create comment in g5_write_{slug}
+		v1Boards.POST("/:slug/posts/:id/comments", middleware.JWTAuth(jwtManager), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
+			slug := c.Param("slug")
+			postID, err := strconv.Atoi(c.Param("id"))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid post ID"})
+				return
+			}
+
+			// 게시판 설정 조회
+			board, err := gnuBoardRepo.FindByID(slug)
+			if err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "게시판을 찾을 수 없습니다"})
+				return
+			}
+
+			// 요청 바디 파싱
+			var req struct {
+				Content  string `json:"content" binding:"required"`
+				ParentID *int   `json:"parent_id,omitempty"`
+			}
+			if err := c.ShouldBindJSON(&req); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "내용을 입력해주세요"})
+				return
+			}
+
+			mbID := middleware.GetUserID(c)
+			userLevel := middleware.GetUserLevel(c)
+
+			// 제휴 링크 차단 검증
+			if err := common.ValidateAffiliateLinks(req.Content, slug, userLevel, false); err != nil {
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": err.Error()})
+				return
+			}
+
+			// 레벨 체크
+			if userLevel < board.BoCommentLevel {
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "댓글 작성 권한이 없습니다. 레벨 " + strconv.Itoa(board.BoCommentLevel) + " 이상이 필요합니다."})
+				return
+			}
+
+			// 포인트 차감 게시판인 경우 잔액 확인
+			if board.BoCommentPoint < 0 {
+				var mbNo uint64
+				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
+					canAfford, err := v2PointRepo.CanAfford(mbNo, board.BoCommentPoint)
+					if err != nil {
+						c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
+						return
+					}
+					if !canAfford {
+						c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoCommentPoint) + "포인트가 필요합니다."})
+						return
+					}
+				}
+			}
+
+			// 작성자 닉네임 조회
+			authorName := middleware.GetNickname(c)
+			if authorName == "" {
+				db.Table("g5_member").Select("mb_nick").Where("mb_id = ?", mbID).Scan(&authorName)
+			}
+
+			// g5_write_{slug} 테이블에 댓글 INSERT
+			now := time.Now()
+			nowStr := now.Format("2006-01-02 15:04:05")
+
+			comment := gnuboard.G5Write{
+				WrNum:          0,
+				WrParent:       postID,
+				WrIsComment:    1,
+				WrComment:      0,
+				WrCommentReply: "",
+				WrContent:      req.Content,
+				MbID:           mbID,
+				WrName:         authorName,
+				WrDatetime:     now,
+				WrLast:         nowStr,
+				WrIP:           middleware.GetClientIP(c),
+			}
+
+			if err := gnuWriteRepo.CreateComment(slug, &comment); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 작성 실패"})
+				return
+			}
+
+			// 부모 게시글의 wr_comment 카운트 갱신
+			tableName := fmt.Sprintf("g5_write_%s", slug)
+			var commentCount int64
+			db.Table(tableName).Where("wr_parent = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", postID).Count(&commentCount)
+			db.Table(tableName).Where("wr_id = ?", postID).Update("wr_comment", commentCount)
+
+			// 포인트 처리
+			if board.BoCommentPoint != 0 {
+				var mbNo uint64
+				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
+					_ = v2PointRepo.AddPoint(mbNo, board.BoCommentPoint, "댓글작성", fmt.Sprintf("g5_write_%s", slug), uint64(comment.WrID))
+				}
+			}
+
+			// Admin sees full IP, others see masked
+			commentIP := v1handler.MaskIP(comment.WrIP)
+			if middleware.GetUserLevel(c) >= 10 {
+				commentIP = comment.WrIP
+			}
+
+			c.JSON(http.StatusCreated, gin.H{
+				"success": true,
+				"data": gin.H{
+					"id":         comment.WrID,
+					"post_id":    postID,
+					"content":    comment.WrContent,
+					"author":     authorName,
+					"author_id":  mbID,
+					"author_ip":  commentIP,
+					"likes":      0,
+					"dislikes":   0,
+					"depth":      0,
+					"created_at": now.Format(time.RFC3339),
+					"is_secret":  false,
+				},
+			})
+		})
 
 		// PUT /api/v1/boards/:slug/posts/:id - Update post
 		v1Boards.PUT("/:slug/posts/:id", middleware.JWTAuth(jwtManager), func(c *gin.Context) {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2290,7 +2290,7 @@ func main() {
 				board.BoUseNogood = *req.UseNogood
 			}
 			if req.UploadCount != nil {
-				board.BoNumListCount = *req.UploadCount
+				// bo_num_list_count 컬럼은 DB에 없으므로 무시
 			}
 
 			if err := gnuBoardRepo.Create(board); err != nil {
@@ -2427,7 +2427,7 @@ func main() {
 				board.BoUseSns = *req.UseSns
 			}
 			if req.UploadCount != nil {
-				board.BoNumListCount = *req.UploadCount
+				// bo_num_list_count 컬럼은 DB에 없으므로 무시
 			}
 			if req.Order != nil {
 				board.BoOrder = *req.Order

--- a/internal/domain/gnuboard/board.go
+++ b/internal/domain/gnuboard/board.go
@@ -5,7 +5,6 @@ type G5Board struct {
 	BoTable        string `gorm:"column:bo_table;primaryKey" json:"bo_table"`
 	GrID           string `gorm:"column:gr_id" json:"gr_id"`
 	BoSubject      string `gorm:"column:bo_subject" json:"bo_subject"`
-	BoMobile       string `gorm:"column:bo_mobile" json:"bo_mobile"`
 	BoDevice       string `gorm:"column:bo_device" json:"bo_device"`
 	BoAdmin        string `gorm:"column:bo_admin" json:"bo_admin"`
 	BoListLevel    int    `gorm:"column:bo_list_level" json:"bo_list_level"`
@@ -18,13 +17,13 @@ type G5Board struct {
 	BoOrder        int    `gorm:"column:bo_order" json:"bo_order"`
 	BoCountWrite   int    `gorm:"column:bo_count_write" json:"bo_count_write"`
 	BoCountComment int    `gorm:"column:bo_count_comment" json:"bo_count_comment"`
-	BoNumListCount int    `gorm:"column:bo_num_list_count" json:"bo_num_list_count"`
 	BoPageRows     int    `gorm:"column:bo_page_rows" json:"bo_page_rows"`
 	BoUseCategory  int    `gorm:"column:bo_use_category" json:"bo_use_category"`
 	BoCategoryList string `gorm:"column:bo_category_list" json:"bo_category_list"`
 	BoUseSideview  int    `gorm:"column:bo_use_sideview" json:"bo_use_sideview"`
 	BoUseSns       int    `gorm:"column:bo_use_sns" json:"bo_use_sns"`
 	BoUseSecret    int    `gorm:"column:bo_use_secret" json:"bo_use_secret"`
+	BoUseSearch    int    `gorm:"column:bo_use_search" json:"bo_use_search"`
 	BoWritePoint   int    `gorm:"column:bo_write_point" json:"bo_write_point"`
 	BoCommentPoint int    `gorm:"column:bo_comment_point" json:"bo_comment_point"`
 	BoReadPoint    int    `gorm:"column:bo_read_point" json:"bo_read_point"`
@@ -32,7 +31,6 @@ type G5Board struct {
 	BoUseGood      int    `gorm:"column:bo_use_good" json:"bo_use_good"`
 	BoUseNogood    int    `gorm:"column:bo_use_nogood" json:"bo_use_nogood"`
 	BoUseName      int    `gorm:"column:bo_use_name" json:"bo_use_name"`
-	BoUseSkin      int    `gorm:"column:bo_use_skin" json:"bo_use_skin"`
 	BoSkin         string `gorm:"column:bo_skin" json:"bo_skin"`
 	BoMobileSkin   string `gorm:"column:bo_mobile_skin" json:"bo_mobile_skin"`
 	BoNotice       string `gorm:"column:bo_notice" json:"bo_notice"`
@@ -76,8 +74,83 @@ type BoardResponse struct {
 	UseGood       bool   `json:"use_good"`
 	UseNogood     bool   `json:"use_nogood"`
 	UseSecret     bool   `json:"use_secret"`
+	UseSearch     bool   `json:"use_search"`
 	PostCount     int    `json:"post_count"`
 	CommentCount  int    `json:"comment_count"`
+}
+
+// AdminBoardResponse is the full board response for admin settings page
+type AdminBoardResponse struct {
+	BoardID       string `json:"board_id"`
+	GroupID       string `json:"group_id"`
+	Subject       string `json:"subject"`
+	Admin         string `json:"admin"`
+	Device        string `json:"device"`
+	Skin          string `json:"skin"`
+	MobileSkin    string `json:"mobile_skin"`
+	ListLevel     int    `json:"list_level"`
+	ReadLevel     int    `json:"read_level"`
+	WriteLevel    int    `json:"write_level"`
+	ReplyLevel    int    `json:"reply_level"`
+	CommentLevel  int    `json:"comment_level"`
+	UploadLevel   int    `json:"upload_level"`
+	DownloadLevel int    `json:"download_level"`
+	WritePoint    int    `json:"write_point"`
+	CommentPoint  int    `json:"comment_point"`
+	ReadPoint     int    `json:"read_point"`
+	DownloadPoint int    `json:"download_point"`
+	UseCategory   int    `json:"use_category"`
+	CategoryList  string `json:"category_list"`
+	UseGood       int    `json:"use_good"`
+	UseNogood     int    `json:"use_nogood"`
+	UseSecret     int    `json:"use_secret"`
+	UseSns        int    `json:"use_sns"`
+	UseSearch     int    `json:"use_search"`
+	PageRows      int    `json:"page_rows"`
+	UploadCount   int    `json:"upload_count"`
+	UploadSize    int    `json:"upload_size"`
+	Order         int    `json:"order"`
+	CountWrite    int    `json:"count_write"`
+	CountComment  int    `json:"count_comment"`
+	Notice        string `json:"notice"`
+}
+
+// ToAdminResponse converts G5Board to full admin response format
+func (b *G5Board) ToAdminResponse() AdminBoardResponse {
+	return AdminBoardResponse{
+		BoardID:       b.BoTable,
+		GroupID:       b.GrID,
+		Subject:       b.BoSubject,
+		Admin:         b.BoAdmin,
+		Device:        b.BoDevice,
+		Skin:          b.BoSkin,
+		MobileSkin:    b.BoMobileSkin,
+		ListLevel:     b.BoListLevel,
+		ReadLevel:     b.BoReadLevel,
+		WriteLevel:    b.BoWriteLevel,
+		ReplyLevel:    b.BoReplyLevel,
+		CommentLevel:  b.BoCommentLevel,
+		UploadLevel:   b.BoUploadLevel,
+		DownloadLevel: b.BoDownloadLevel,
+		WritePoint:    b.BoWritePoint,
+		CommentPoint:  b.BoCommentPoint,
+		ReadPoint:     b.BoReadPoint,
+		DownloadPoint: b.BoDownloadPoint,
+		UseCategory:   b.BoUseCategory,
+		CategoryList:  b.BoCategoryList,
+		UseGood:       b.BoUseGood,
+		UseNogood:     b.BoUseNogood,
+		UseSecret:     b.BoUseSecret,
+		UseSns:        b.BoUseSns,
+		UseSearch:     b.BoUseSearch,
+		PageRows:      b.BoPageRows,
+		UploadCount:   0,
+		UploadSize:    0,
+		Order:         b.BoOrder,
+		CountWrite:    b.BoCountWrite,
+		CountComment:  b.BoCountComment,
+		Notice:        b.BoNotice,
+	}
 }
 
 // ToResponse converts G5Board to API response format
@@ -104,6 +177,7 @@ func (b *G5Board) ToResponse() BoardResponse {
 		UseGood:       b.BoUseGood == 1,
 		UseNogood:     b.BoUseNogood == 1,
 		UseSecret:     b.BoUseSecret == 1,
+		UseSearch:     b.BoUseSearch == 1,
 		PostCount:     b.BoCountWrite,
 		CommentCount:  b.BoCountComment,
 	}

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -1,11 +1,18 @@
 package v1handler
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 )
+
+// imgSrcRegex matches src attribute in <img> tags
+var imgSrcRegex = regexp.MustCompile(`<img[^>]+src=["']([^"']+)["']`)
+
+// kst is the Asia/Seoul timezone for parsing gnuboard datetime values
+var kst = time.FixedZone("KST", 9*60*60)
 
 // parseWrLast converts DB datetime string to RFC3339 format
 // Returns nil if parsing fails or if the time equals created time (no updates)
@@ -13,16 +20,52 @@ func parseWrLast(wrLast string, createdAt time.Time) any {
 	if wrLast == "" {
 		return nil
 	}
-	// DB stores as "2006-01-02 15:04:05"
-	lastTime, err := time.ParseInLocation("2006-01-02 15:04:05", wrLast, time.Local)
+	// DB stores as "2006-01-02 15:04:05" in KST
+	lastTime, err := time.ParseInLocation("2006-01-02 15:04:05", wrLast, kst)
 	if err != nil {
 		return nil
 	}
 	// If updated_at equals created_at, no actual update occurred
-	if lastTime.Equal(createdAt) || lastTime.Sub(createdAt).Abs() < time.Second {
+	createdAtKST := createdAt.In(kst)
+	if lastTime.Equal(createdAtKST) || lastTime.Sub(createdAtKST).Abs() < time.Second {
 		return nil
 	}
 	return lastTime.Format(time.RFC3339)
+}
+
+// extractFirstImageURL extracts the first <img src="..."> URL from HTML content
+func extractFirstImageURL(html string) string {
+	m := imgSrcRegex.FindStringSubmatch(html)
+	if len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// MaskIP masks the 2nd octet of an IPv4 address with ♡ (e.g. "1.2.3.4" → "1.♡.3.4")
+func MaskIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	parts := strings.Split(ip, ".")
+	if len(parts) == 4 {
+		return parts[0] + ".♡." + parts[2] + "." + parts[3]
+	}
+	return ip
+}
+
+// OverrideIPForAdmin replaces masked author_ip with full IP when requester is admin
+func OverrideIPForAdmin(items []map[string]any, posts []*gnuboard.G5Write) {
+	for i, item := range items {
+		if i < len(posts) {
+			item["author_ip"] = posts[i].WrIP
+		}
+	}
+}
+
+// OverrideIPForAdminSingle replaces masked author_ip with full IP for a single item
+func OverrideIPForAdminSingle(item map[string]any, w *gnuboard.G5Write) {
+	item["author_ip"] = w.WrIP
 }
 
 // TransformToV1Post converts G5Write to v1 API response format
@@ -42,14 +85,17 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 		"is_secret":      strings.Contains(w.WrOption, "secret"),
 		"link1":          w.WrLink1,
 		"link2":          w.WrLink2,
+		"author_ip":      MaskIP(w.WrIP),
 		"created_at":     w.WrDatetime.Format(time.RFC3339),
 		"updated_at":     parseWrLast(w.WrLast, w.WrDatetime),
 	}
 
-	// Add thumbnail/extra_10 if wr_10 has value (for gallery/message layouts)
+	// Add thumbnail: priority is wr_10 > first <img> in content
 	if w.Wr10 != "" {
 		result["thumbnail"] = w.Wr10
 		result["extra_10"] = w.Wr10
+	} else if img := extractFirstImageURL(w.WrContent); img != "" {
+		result["thumbnail"] = img
 	}
 
 	return result
@@ -83,8 +129,10 @@ func TransformToV1Comment(w *gnuboard.G5Write) map[string]any {
 		"author_id":  w.MbID,
 		"likes":      w.WrGood,
 		"dislikes":   w.WrNogood,
+		"author_ip":  MaskIP(w.WrIP),
 		"depth":      depth,
 		"created_at": w.WrDatetime.Format(time.RFC3339),
+		"updated_at": parseWrLast(w.WrLast, w.WrDatetime),
 		"is_secret":  strings.Contains(w.WrOption, "secret"),
 	}
 }

--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -9,19 +9,22 @@ import (
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // DisciplineLogHandler handles discipline log API endpoints
 // Reads from g5_write_disciplinelog table (gnuboard legacy format)
 type DisciplineLogHandler struct {
 	writeRepo gnurepo.WriteRepository
+	db        *gorm.DB
 }
 
 // NewDisciplineLogHandler creates a new DisciplineLogHandler
-func NewDisciplineLogHandler(writeRepo gnurepo.WriteRepository) *DisciplineLogHandler {
-	return &DisciplineLogHandler{writeRepo: writeRepo}
+func NewDisciplineLogHandler(writeRepo gnurepo.WriteRepository, db *gorm.DB) *DisciplineLogHandler {
+	return &DisciplineLogHandler{writeRepo: writeRepo, db: db}
 }
 
 // DisciplineLogContent represents the JSON structure in wr_content
@@ -173,6 +176,18 @@ func getMemberNickFromTitle(title string) string {
 	return title
 }
 
+// disciplineLogColumns are the columns selected for discipline log queries
+var disciplineLogColumns = []string{
+	"wr_id", "wr_num", "wr_reply", "wr_parent", "wr_is_comment",
+	"wr_comment", "wr_comment_reply", "ca_name", "wr_option",
+	"wr_subject", "wr_content", "wr_link1", "wr_link2",
+	"wr_link1_hit", "wr_link2_hit", "wr_hit", "wr_good", "wr_nogood",
+	"mb_id", "wr_password", "wr_name", "wr_email", "wr_homepage",
+	"wr_datetime", "wr_file", "wr_last", "wr_ip",
+	"wr_10",
+	"wr_deleted_at", "wr_deleted_by",
+}
+
 // GetList handles GET /api/v1/discipline-logs
 func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
@@ -183,12 +198,28 @@ func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 	if limit < 1 || limit > 100 {
 		limit = 20
 	}
+	offset := (page - 1) * limit
 
-	// Read from g5_write_disciplinelog
-	posts, total, err := h.writeRepo.FindPosts("disciplinelog", page, limit)
-	if err != nil {
-		common.V2ErrorResponse(c, http.StatusInternalServerError, "이용제한 기록 조회 실패", err)
-		return
+	memberID := c.Query("member_id")
+
+	var posts []*gnuboard.G5Write
+	var total int64
+
+	if memberID != "" {
+		// Filter by member_id using JSON_EXTRACT on wr_content
+		table := "g5_write_disciplinelog"
+		filter := "wr_is_comment = 0 AND wr_deleted_at IS NULL AND JSON_VALID(wr_content) AND JSON_UNQUOTE(JSON_EXTRACT(wr_content, '$.penalty_mb_id')) = ?"
+
+		h.db.Table(table).Where(filter, memberID).Count(&total)
+		h.db.Table(table).Select(disciplineLogColumns).Where(filter, memberID).
+			Order("wr_num, wr_reply").Offset(offset).Limit(limit).Find(&posts)
+	} else {
+		var err error
+		posts, total, err = h.writeRepo.FindPosts("disciplinelog", page, limit)
+		if err != nil {
+			common.V2ErrorResponse(c, http.StatusInternalServerError, "이용제한 기록 조회 실패", err)
+			return
+		}
 	}
 
 	items := make([]DisciplineLogListItem, 0, len(posts))

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/damoang/angple-backend/internal/middleware"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // V2Handler handles all v2 API endpoints
@@ -20,6 +21,7 @@ type V2Handler struct {
 	permChecker  middleware.BoardPermissionChecker
 	pointRepo    v2repo.PointRepository
 	revisionRepo v2repo.RevisionRepository
+	gnuDB        *gorm.DB // gnuboard g5_member 조회용
 }
 
 // NewV2Handler creates a new V2Handler
@@ -47,6 +49,29 @@ func (h *V2Handler) SetPointRepository(repo v2repo.PointRepository) {
 // SetRevisionRepository sets the optional revision repository for revision history
 func (h *V2Handler) SetRevisionRepository(repo v2repo.RevisionRepository) {
 	h.revisionRepo = repo
+}
+
+// SetGnuDB sets the gnuboard database connection for mb_id → mb_no lookup
+func (h *V2Handler) SetGnuDB(db *gorm.DB) {
+	h.gnuDB = db
+}
+
+// resolveUserIDToMbNo converts gnuboard mb_id (string) to mb_no (uint64)
+func (h *V2Handler) resolveUserIDToMbNo(mbID string) (uint64, error) {
+	// 먼저 숫자로 직접 변환 시도
+	if id, err := strconv.ParseUint(mbID, 10, 64); err == nil {
+		return id, nil
+	}
+	// 실패 시 g5_member에서 mb_no 조회
+	if h.gnuDB != nil {
+		var mbNo uint64
+		err := h.gnuDB.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error
+		if err != nil {
+			return 0, err
+		}
+		return mbNo, nil
+	}
+	return 0, strconv.ErrSyntax
 }
 
 // isOwnerOrAdmin checks if the current user is the owner of the resource or an admin
@@ -566,7 +591,7 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	userID, err := strconv.ParseUint(middleware.GetUserID(c), 10, 64)
+	userID, err := h.resolveUserIDToMbNo(middleware.GetUserID(c))
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusUnauthorized, "잘못된 사용자 인증 정보", err)
 		return
@@ -621,7 +646,28 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
 	}
 
-	common.V2Created(c, comment)
+	// FreeComment 형태로 응답 (프론트엔드 호환)
+	mbID := middleware.GetUserID(c)
+	authorName := middleware.GetNickname(c)
+	if authorName == "" && h.gnuDB != nil {
+		h.gnuDB.Table("g5_member").Select("mb_nick").Where("mb_id = ?", mbID).Scan(&authorName)
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"success": true,
+		"data": gin.H{
+			"id":         comment.ID,
+			"post_id":    comment.PostID,
+			"content":    comment.Content,
+			"author":     authorName,
+			"author_id":  mbID,
+			"likes":      0,
+			"dislikes":   0,
+			"depth":      comment.Depth,
+			"created_at": comment.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			"is_secret":  false,
+		},
+	})
 }
 
 // UpdateComment handles PUT /api/v1/boards/:slug/posts/:id/comments/:comment_id

--- a/internal/middleware/ip_protection.go
+++ b/internal/middleware/ip_protection.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"os"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// IPProtectionConfig holds parsed IP protection settings from environment variables
+type IPProtectionConfig struct {
+	AdminIP    string            // replacement IP for super admins
+	MemberList map[string]string // userID → replacement IP mapping
+}
+
+// LoadIPProtectionConfig loads IP protection settings from environment variables.
+// KG_IPPROTECT_ADMIN_IP=127.0.0.1
+// KG_IPPROTECT_LIST=police:112.112.112.112,ad:0.0.0.0
+func LoadIPProtectionConfig() *IPProtectionConfig {
+	cfg := &IPProtectionConfig{
+		AdminIP:    os.Getenv("KG_IPPROTECT_ADMIN_IP"),
+		MemberList: make(map[string]string),
+	}
+
+	list := os.Getenv("KG_IPPROTECT_LIST")
+	if list == "" {
+		return cfg
+	}
+
+	for _, entry := range strings.Split(list, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) == 2 {
+			userID := strings.TrimSpace(parts[0])
+			ip := strings.TrimSpace(parts[1])
+			if userID != "" && ip != "" {
+				cfg.MemberList[userID] = ip
+			}
+		}
+	}
+
+	return cfg
+}
+
+// IPProtection middleware replaces real IPs for admins and designated members.
+// Must be applied after JWTAuth so that userID and level are available in context.
+func IPProtection(cfg *IPProtectionConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if cfg == nil {
+			c.Next()
+			return
+		}
+
+		userID := GetUserID(c)
+		level := GetUserLevel(c)
+
+		// Super admin (level >= 10) → replace with admin IP
+		if level >= 10 && cfg.AdminIP != "" {
+			c.Set("protected_ip", cfg.AdminIP)
+			c.Next()
+			return
+		}
+
+		// Designated member → replace with configured IP
+		if userID != "" {
+			if ip, ok := cfg.MemberList[userID]; ok {
+				c.Set("protected_ip", ip)
+			}
+		}
+
+		c.Next()
+	}
+}
+
+// GetClientIP returns the protected IP if set, otherwise falls back to c.ClientIP()
+func GetClientIP(c *gin.Context) string {
+	if ip, exists := c.Get("protected_ip"); exists {
+		if s, ok := ip.(string); ok && s != "" {
+			return s
+		}
+	}
+	return c.ClientIP()
+}

--- a/internal/repository/gnuboard/board_repo.go
+++ b/internal/repository/gnuboard/board_repo.go
@@ -11,6 +11,10 @@ type BoardRepository interface {
 	FindAll() ([]*gnuboard.G5Board, error)
 	FindByGroupID(groupID string) ([]*gnuboard.G5Board, error)
 	Exists(boardID string) bool
+	Create(board *gnuboard.G5Board) error
+	Update(board *gnuboard.G5Board) error
+	Delete(boardID string) error
+	GetDB() *gorm.DB
 }
 
 type boardRepository struct {
@@ -51,4 +55,24 @@ func (r *boardRepository) Exists(boardID string) bool {
 	var count int64
 	r.db.Model(&gnuboard.G5Board{}).Where("bo_table = ?", boardID).Count(&count)
 	return count > 0
+}
+
+// Create creates a new board in g5_board
+func (r *boardRepository) Create(board *gnuboard.G5Board) error {
+	return r.db.Create(board).Error
+}
+
+// Update updates a board in g5_board
+func (r *boardRepository) Update(board *gnuboard.G5Board) error {
+	return r.db.Save(board).Error
+}
+
+// Delete deletes a board from g5_board
+func (r *boardRepository) Delete(boardID string) error {
+	return r.db.Where("bo_table = ?", boardID).Delete(&gnuboard.G5Board{}).Error
+}
+
+// GetDB returns the underlying DB instance for raw operations
+func (r *boardRepository) GetDB() *gorm.DB {
+	return r.db
 }

--- a/internal/repository/gnuboard/file_repo.go
+++ b/internal/repository/gnuboard/file_repo.go
@@ -43,3 +43,39 @@ func (r *FileRepository) IncrementDownloadCount(boardID string, postID int, file
 		UpdateColumn("bf_download", gorm.Expr("bf_download + 1")).
 		Error
 }
+
+// GetFirstImagesByPostIDs retrieves the first image file for each post in a single query.
+// Returns a map of postID -> bf_file (stored filename).
+func (r *FileRepository) GetFirstImagesByPostIDs(boardID string, postIDs []int) (map[int]string, error) {
+	if len(postIDs) == 0 {
+		return nil, nil
+	}
+
+	type row struct {
+		WrID   int    `gorm:"column:wr_id"`
+		BfFile string `gorm:"column:bf_file"`
+	}
+
+	var rows []row
+	// Subquery: for each wr_id, get the minimum bf_no among image files
+	err := r.db.Table("g5_board_file AS f").
+		Select("f.wr_id, f.bf_file").
+		Where("f.bo_table = ? AND f.wr_id IN ?", boardID, postIDs).
+		Where("(f.bf_type = 1 OR f.bf_width > 0 OR LOWER(SUBSTRING_INDEX(f.bf_source, '.', -1)) IN ('jpg','jpeg','png','gif','webp','avif','svg','bmp'))").
+		Where("f.bf_no = (?)",
+			r.db.Table("g5_board_file AS f2").
+				Select("MIN(f2.bf_no)").
+				Where("f2.bo_table = f.bo_table AND f2.wr_id = f.wr_id").
+				Where("(f2.bf_type = 1 OR f2.bf_width > 0 OR LOWER(SUBSTRING_INDEX(f2.bf_source, '.', -1)) IN ('jpg','jpeg','png','gif','webp','avif','svg','bmp'))"),
+		).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[int]string, len(rows))
+	for _, r := range rows {
+		result[r.WrID] = r.BfFile
+	}
+	return result, nil
+}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -3,11 +3,23 @@ package gnuboard
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
 )
+
+// postCountCache caches COUNT(*) results for large boards to avoid expensive full-index scans.
+// TTL: 30 seconds. Invalidated on write operations (create/delete/restore).
+var postCountCache sync.Map
+
+type cachedCount struct {
+	total     int64
+	expiresAt time.Time
+}
+
+const countCacheTTL = 30 * time.Second
 
 // coreColumns are the columns that exist in all g5_write_* tables
 var coreColumns = []string{
@@ -72,18 +84,34 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	offset := (page - 1) * limit
 	table := tableName(boardID)
 
-	// Posts only (wr_is_comment = 0), exclude soft deleted
-	countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND wr_deleted_at IS NULL")
-	if err := countQuery.Count(&total).Error; err != nil {
-		return nil, 0, err
+	// Posts count with in-memory cache (avoids expensive COUNT on large tables)
+	cacheKey := "count:" + boardID
+	if cached, ok := postCountCache.Load(cacheKey); ok {
+		if cc := cached.(*cachedCount); time.Now().Before(cc.expiresAt) {
+			total = cc.total
+		}
+	}
+	if total == 0 {
+		countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND wr_deleted_at IS NULL")
+		if err := countQuery.Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
+		postCountCache.Store(cacheKey, &cachedCount{total: total, expiresAt: time.Now().Add(countCacheTTL)})
+	}
+
+	// 게시판별 커스텀 정렬 (bo_sort_field)
+	orderClause := "wr_num, wr_reply"
+	var sortField string
+	r.db.Table("g5_board").Select("bo_sort_field").Where("bo_table = ?", boardID).Scan(&sortField)
+	if sortField != "" {
+		orderClause = sortField
 	}
 
 	// Select only core columns to avoid errors with missing columns
-	// Order by wr_num (descending for latest first), then wr_reply for threaded replies
 	err := r.db.Table(table).
 		Select(coreColumns).
 		Where("wr_is_comment = 0 AND wr_deleted_at IS NULL").
-		Order("wr_num, wr_reply").
+		Order(orderClause).
 		Offset(offset).
 		Limit(limit).
 		Find(&posts).Error
@@ -150,8 +178,14 @@ func (r *writeRepository) FindDeletedPosts(boardID string, page, limit int) ([]*
 	return posts, total, err
 }
 
+// InvalidatePostCount clears the cached post count for a board
+func InvalidatePostCount(boardID string) {
+	postCountCache.Delete("count:" + boardID)
+}
+
 // CreatePost creates a new post
 func (r *writeRepository) CreatePost(boardID string, post *gnuboard.G5Write) error {
+	InvalidatePostCount(boardID)
 	return r.db.Table(tableName(boardID)).Create(post).Error
 }
 
@@ -162,6 +196,7 @@ func (r *writeRepository) UpdatePost(boardID string, post *gnuboard.G5Write) err
 
 // DeletePost permanently deletes a post and its comments from the database
 func (r *writeRepository) DeletePost(boardID string, wrID int) error {
+	InvalidatePostCount(boardID)
 	table := tableName(boardID)
 	// Delete comments first
 	if err := r.db.Table(table).Where("wr_parent = ?", wrID).Delete(&gnuboard.G5Write{}).Error; err != nil {
@@ -173,6 +208,7 @@ func (r *writeRepository) DeletePost(boardID string, wrID int) error {
 
 // SoftDeletePost marks a post and its comments as deleted
 func (r *writeRepository) SoftDeletePost(boardID string, wrID int, deletedBy string) error {
+	InvalidatePostCount(boardID)
 	table := tableName(boardID)
 	now := time.Now()
 
@@ -193,6 +229,7 @@ func (r *writeRepository) SoftDeletePost(boardID string, wrID int, deletedBy str
 
 // RestorePost restores a soft deleted post and its comments
 func (r *writeRepository) RestorePost(boardID string, wrID int) error {
+	InvalidatePostCount(boardID)
 	table := tableName(boardID)
 
 	// Restore the post

--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -59,6 +59,22 @@ func NewSearchService(esClient *es.Client, db *gorm.DB) *SearchService {
 	return svc
 }
 
+// getSearchableBoardIDs returns board table names where bo_use_search = 1
+func (s *SearchService) getSearchableBoardIDs() ([]string, error) {
+	var boards []struct {
+		BoTable string `gorm:"column:bo_table"`
+	}
+	err := s.db.Table("g5_board").Select("bo_table").Where("bo_use_search = ?", 1).Find(&boards).Error
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(boards))
+	for i, b := range boards {
+		ids[i] = b.BoTable
+	}
+	return ids, nil
+}
+
 // ensureIndices creates ES indices with Korean nori analyzer mappings
 func (s *SearchService) ensureIndices(ctx context.Context) error {
 	postMapping := map[string]interface{}{
@@ -168,7 +184,14 @@ func (s *SearchService) SearchPosts(ctx context.Context, keyword, boardID string
 	}
 
 	var filter []map[string]interface{}
-	if boardID != "" {
+	if boardID == "" {
+		searchableIDs, err := s.getSearchableBoardIDs()
+		if err == nil && len(searchableIDs) > 0 {
+			filter = append(filter, map[string]interface{}{
+				"terms": map[string]interface{}{"board_id": searchableIDs},
+			})
+		}
+	} else {
 		filter = append(filter, map[string]interface{}{
 			"term": map[string]interface{}{"board_id": boardID},
 		})
@@ -213,7 +236,14 @@ func (s *SearchService) SearchComments(ctx context.Context, keyword, boardID str
 	}
 
 	var filter []map[string]interface{}
-	if boardID != "" {
+	if boardID == "" {
+		searchableIDs, err := s.getSearchableBoardIDs()
+		if err == nil && len(searchableIDs) > 0 {
+			filter = append(filter, map[string]interface{}{
+				"terms": map[string]interface{}{"board_id": searchableIDs},
+			})
+		}
+	} else {
 		filter = append(filter, map[string]interface{}{
 			"term": map[string]interface{}{"board_id": boardID},
 		})
@@ -289,6 +319,13 @@ func (s *SearchService) Autocomplete(ctx context.Context, prefix string, size in
 func (s *SearchService) BulkIndexPosts(ctx context.Context, boardID string, limit int) (int, error) {
 	if s.db == nil {
 		return 0, fmt.Errorf("database not available")
+	}
+
+	// Skip boards where bo_use_search is disabled
+	var searchCount int64
+	s.db.Table("g5_board").Where("bo_table = ? AND bo_use_search = ?", boardID, 1).Count(&searchCount)
+	if searchCount == 0 {
+		return 0, nil
 	}
 
 	tableName := fmt.Sprintf("g5_write_%s", boardID)


### PR DESCRIPTION
## Summary
- IP Protection 미들웨어 추가 (관리자/지정사용자 IP 대체)
- 게시글/댓글 API 응답에 author_ip 필드 추가 (마스킹)
- 관리자(level>=10)에게 풀 IP 표시
- 게시글 작성 시 wr_num = MIN(wr_num)-1 로 설정하여 목록 정렬 수정
- 댓글 생성 응답에 author_ip 추가
- G5Board struct에서 DB에 없는 컬럼 제거 (bo_mobile, bo_num_list_count, bo_use_skin)

## Test plan
- [x] dev.damoang.net에서 테스트 완료