### PR TITLE
fix: health check DB ping + 댓글 순서 수정 + rate limit 완화

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -241,8 +242,29 @@ func main() {
 	// Prometheus metrics
 	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
 
-	// Health Check
+	// Health Check (DB ping 포함 — 커넥션 죽으면 K8s가 파드 재시작)
 	router.GET("/health", func(c *gin.Context) {
+		sqlDB, err := db.DB()
+		if err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"status":  "error",
+				"service": "angple-backend",
+				"error":   "db connection pool error",
+				"time":    time.Now().Unix(),
+			})
+			return
+		}
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+		defer cancel()
+		if err := sqlDB.PingContext(ctx); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"status":  "error",
+				"service": "angple-backend",
+				"error":   "db ping failed",
+				"time":    time.Now().Unix(),
+			})
+			return
+		}
 		c.JSON(http.StatusOK, gin.H{
 			"status":  "ok",
 			"service": "angple-backend",
@@ -3355,6 +3377,7 @@ func initDB(cfg *config.Config) (*gorm.DB, error) {
 	sqlDB.SetMaxIdleConns(cfg.Database.MaxIdleConns)
 	sqlDB.SetMaxOpenConns(cfg.Database.MaxOpenConns)
 	sqlDB.SetConnMaxLifetime(time.Duration(cfg.Database.ConnMaxLifetime) * time.Second)
+	sqlDB.SetConnMaxIdleTime(5 * time.Minute)
 
 	return db, nil
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -49,6 +49,7 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	gormlogger "gorm.io/gorm/logger"
 )
 
@@ -1670,23 +1671,27 @@ func main() {
 			wrCommentReply := ""
 			depth := 0
 
-			if req.ParentID != nil && *req.ParentID > 0 {
-				// 대댓글: 부모 댓글 조회
-				var parentComment gnuboard.G5Write
-				if err := db.Table(tableName).
-					Where("wr_id = ? AND wr_is_comment = 1", *req.ParentID).
-					First(&parentComment).Error; err == nil {
+			// 트랜잭션으로 댓글 생성 (wr_comment 레이스 컨디션 방지)
+			var createdComment gnuboard.G5Write
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if req.ParentID != nil && *req.ParentID > 0 {
+					// 대댓글: 부모 댓글 조회 (FOR UPDATE로 잠금)
+					var parentComment gnuboard.G5Write
+					if err := tx.Table(tableName).
+						Clauses(clause.Locking{Strength: "UPDATE"}).
+						Where("wr_id = ? AND wr_is_comment = 1", *req.ParentID).
+						First(&parentComment).Error; err != nil {
+						return fmt.Errorf("PARENT_NOT_FOUND")
+					}
 
-					// 부모의 wr_comment (순서 번호)를 그대로 사용
 					wrComment = parentComment.WrComment
 
-					// wr_comment_reply 계산: 부모의 reply + 다음 문자
 					parentReply := parentComment.WrCommentReply
 					replyLen := len(parentReply) + 1
 					depth = replyLen
 
 					var lastReply string
-					db.Table(tableName).
+					tx.Table(tableName).
 						Select("wr_comment_reply").
 						Where("wr_parent = ? AND wr_is_comment = 1 AND wr_comment = ? AND LENGTH(wr_comment_reply) = ? AND wr_comment_reply LIKE ?",
 							postID, wrComment, replyLen, parentReply+"%").
@@ -1701,46 +1706,63 @@ func main() {
 						if lastChar < 'Z' {
 							wrCommentReply = parentReply + string(lastChar+1)
 						} else {
-							c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "더 이상 대댓글을 작성할 수 없습니다."})
-							return
+							return fmt.Errorf("REPLY_LIMIT")
 						}
 					}
+				} else {
+					// 루트 댓글: FOR UPDATE로 게시글 행 잠금 후 MAX(wr_comment) + 1
+					tx.Table(tableName).
+						Clauses(clause.Locking{Strength: "UPDATE"}).
+						Select("wr_id").
+						Where("wr_id = ? AND wr_is_comment = 0", postID).
+						Scan(&struct{}{})
+
+					var maxComment int
+					tx.Table(tableName).
+						Select("COALESCE(MAX(wr_comment), -1)").
+						Where("wr_parent = ? AND wr_is_comment = 1", postID).
+						Scan(&maxComment)
+					wrComment = maxComment + 1
 				}
-			} else {
-				// 루트 댓글: 현재 게시글의 MAX(wr_comment) + 1
-				var maxComment int
-				db.Table(tableName).
-					Select("COALESCE(MAX(wr_comment), -1)").
-					Where("wr_parent = ? AND wr_is_comment = 1", postID).
-					Scan(&maxComment)
-				wrComment = maxComment + 1
-			}
 
-			comment := gnuboard.G5Write{
-				WrNum:          0,
-				WrParent:       postID,
-				WrIsComment:    1,
-				WrComment:      wrComment,
-				WrCommentReply: wrCommentReply,
-				WrContent:      req.Content,
-				MbID:           mbID,
-				WrName:         authorName,
-				WrDatetime:     now,
-				WrLast:         nowStr,
-				WrIP:           middleware.GetClientIP(c),
-			}
+				createdComment = gnuboard.G5Write{
+					WrNum:          0,
+					WrParent:       postID,
+					WrIsComment:    1,
+					WrComment:      wrComment,
+					WrCommentReply: wrCommentReply,
+					WrContent:      req.Content,
+					MbID:           mbID,
+					WrName:         authorName,
+					WrDatetime:     now,
+					WrLast:         nowStr,
+					WrIP:           middleware.GetClientIP(c),
+				}
 
-			if err := gnuWriteRepo.CreateComment(slug, &comment); err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 작성 실패"})
+				if err := tx.Table(tableName).Create(&createdComment).Error; err != nil {
+					return err
+				}
+
+				// 부모 게시글의 wr_comment 카운트 갱신
+				var commentCount int64
+				tx.Table(tableName).Where("wr_parent = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", postID).Count(&commentCount)
+				tx.Table(tableName).Where("wr_id = ?", postID).Update("wr_comment", commentCount)
+
+				return nil
+			})
+
+			if txErr != nil {
+				switch txErr.Error() {
+				case "PARENT_NOT_FOUND":
+					c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "부모 댓글을 찾을 수 없습니다"})
+				case "REPLY_LIMIT":
+					c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "더 이상 대댓글을 작성할 수 없습니다."})
+				default:
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 작성 실패"})
+				}
 				return
 			}
-
-			// (wr_comment는 INSERT 시 이미 올바른 순서 번호로 설정됨)
-
-			// 부모 게시글의 wr_comment 카운트 갱신
-			var commentCount int64
-			db.Table(tableName).Where("wr_parent = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", postID).Count(&commentCount)
-			db.Table(tableName).Where("wr_id = ?", postID).Update("wr_comment", commentCount)
+			comment := createdComment
 
 			// 포인트 처리
 			if board.BoCommentPoint != 0 {

--- a/internal/middleware/rate_limit.go
+++ b/internal/middleware/rate_limit.go
@@ -22,7 +22,7 @@ type RateLimitConfig struct {
 // DefaultRateLimitConfig returns default rate limit configuration
 func DefaultRateLimitConfig() RateLimitConfig {
 	return RateLimitConfig{
-		RequestsPerMinute: 120,
+		RequestsPerMinute: 600,
 		KeyPrefix:         "api:ratelimit:",
 		Message:           "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
 	}


### PR DESCRIPTION
## Summary
- Health check에 DB ping 추가 (3초 타임아웃) + ConnMaxIdleTime 5분 설정
- 댓글 생성 트랜잭션 적용으로 동시 작성 시 wr_comment 순서 보장
- API rate limit 120 → 600 req/min