### PR TITLE
fix: Load Test CI 실패율 계산 버그 수정

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -91,10 +91,16 @@ jobs:
 
     - name: Check failure rate
       run: |
-        # Extract failure rate from CSV
+        # Locust _stats.csv columns: Type, Name, Request Count, Failure Count, Median, Avg, ...
         if [ -f load-test-results_stats.csv ]; then
-          FAIL_RATE=$(tail -1 load-test-results_stats.csv | cut -d',' -f5)
-          echo "Failure rate: ${FAIL_RATE}%"
+          TOTAL_REQS=$(tail -1 load-test-results_stats.csv | cut -d',' -f3)
+          TOTAL_FAILS=$(tail -1 load-test-results_stats.csv | cut -d',' -f4)
+          if [ "$TOTAL_REQS" -gt 0 ] 2>/dev/null; then
+            FAIL_RATE=$(echo "scale=2; $TOTAL_FAILS * 100 / $TOTAL_REQS" | bc -l)
+          else
+            FAIL_RATE=0
+          fi
+          echo "Requests: $TOTAL_REQS, Failures: $TOTAL_FAILS, Failure rate: ${FAIL_RATE}%"
           # Fail if error rate > 1%
           if [ $(echo "$FAIL_RATE > 1" | bc -l) -eq 1 ]; then
             echo "Error rate too high: ${FAIL_RATE}%"


### PR DESCRIPTION
## Summary
- Load Test 워크플로우가 매주 실패하던 원인 수정
- CSV 파싱 시 5번째 컬럼(Median Response Time)을 실패율로 오인하고 있었음
- Request Count(f3)와 Failure Count(f4)로 실제 실패율을 계산하도록 변경

## 변경 전/후
```bash
# Before: Median(2ms)을 실패율 2%로 오인
FAIL_RATE=$(tail -1 load-test-results_stats.csv | cut -d',' -f5)

# After: 실제 실패율 계산 (failures * 100 / requests)
TOTAL_REQS=$(tail -1 load-test-results_stats.csv | cut -d',' -f3)
TOTAL_FAILS=$(tail -1 load-test-results_stats.csv | cut -d',' -f4)
FAIL_RATE=$(echo "scale=2; $TOTAL_FAILS * 100 / $TOTAL_REQS" | bc -l)
```

## 참고
- Docker init SQL에 `wr_deleted_at`/`wr_deleted_by` 컬럼이 없어 GORM 조회 실패 → 게시글 상세 404 발생
- `07a-dynamic-table-alter.sql`에 soft delete 컬럼 추가 필요 (별도 처리)

## Test plan
- [x] 로컬 Locust 테스트 실행 — 491 requests, 0 fails, exit code 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)