### PR TITLE
feat: 쪽지/팔로워/구독자 알림 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1789,6 +1789,59 @@ func main() {
 				commentIP = comment.WrIP
 			}
 
+			// 알림 생성 (비동기)
+			go func() {
+				// 게시글 작성자 조회
+				var postAuthor struct {
+					MbID      string `gorm:"column:mb_id"`
+					WrSubject string `gorm:"column:wr_subject"`
+				}
+				if err := db.Table(tableName).Select("mb_id, wr_subject").Where("wr_id = ? AND wr_is_comment = 0", postID).Scan(&postAuthor).Error; err != nil || postAuthor.MbID == "" {
+					return
+				}
+
+				// 대댓글인 경우: 부모 댓글 작성자에게 알림
+				if req.ParentID != nil && *req.ParentID > 0 {
+					var parentAuthorMbID string
+					if err := db.Table(tableName).Select("mb_id").Where("wr_id = ?", *req.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != mbID {
+						_ = notiRepo.Create(&gnurepo.Notification{
+							PhToCase:      "comment_reply",
+							PhFromCase:    "comment",
+							BoTable:       slug,
+							WrID:          comment.WrID,
+							MbID:          parentAuthorMbID,
+							RelMbID:       mbID,
+							RelMbNick:     authorName,
+							RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", authorName),
+							RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
+							PhReaded:      "N",
+							PhDatetime:    now,
+							ParentSubject: postAuthor.WrSubject,
+							WrParent:      postID,
+						})
+					}
+				}
+
+				// 게시글 작성자에게 알림 (자기 댓글은 제외)
+				if postAuthor.MbID != mbID {
+					_ = notiRepo.Create(&gnurepo.Notification{
+						PhToCase:      "comment",
+						PhFromCase:    "comment",
+						BoTable:       slug,
+						WrID:          comment.WrID,
+						MbID:          postAuthor.MbID,
+						RelMbID:       mbID,
+						RelMbNick:     authorName,
+						RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", authorName),
+						RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
+						PhReaded:      "N",
+						PhDatetime:    now,
+						ParentSubject: postAuthor.WrSubject,
+						WrParent:      postID,
+					})
+				}
+			}()
+
 			c.JSON(http.StatusCreated, gin.H{
 				"success": true,
 				"data": gin.H{

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1601,6 +1601,55 @@ func main() {
 				}
 			}
 
+			// 팔로워/구독자 알림 (비동기)
+			go func() {
+				authorName := post.WrName
+				if authorName == "" {
+					authorName = mbID
+				}
+				subject := post.WrSubject
+				now := time.Now()
+
+				// 1. 팔로워 알림: 이 작성자를 팔로우한 사람들
+				var followerIDs []string
+				db.Table("g5_member_follow").Select("mb_id").Where("target_id = ?", mbID).Pluck("mb_id", &followerIDs)
+				for _, fid := range followerIDs {
+					_ = notiRepo.Create(&gnurepo.Notification{
+						PhToCase: "follow", PhFromCase: "write", BoTable: slug,
+						WrID: post.WrID, MbID: fid, RelMbID: mbID,
+						RelMbNick:    authorName,
+						RelMsg:       fmt.Sprintf("%s님이 새 글을 작성했습니다: %s", authorName, subject),
+						RelURL:       fmt.Sprintf("/%s/%d", slug, post.WrID),
+						PhReaded:     "N",
+						PhDatetime:   now,
+						WrParent:     post.WrID,
+					})
+				}
+
+				// 2. 게시판 구독자 알림: 이 게시판을 구독한 사람들 (작성자 제외, 팔로워 중복 제외)
+				var subscriberIDs []string
+				db.Table("g5_board_subscribe").Select("mb_id").Where("bo_table = ? AND mb_id != ?", slug, mbID).Pluck("mb_id", &subscriberIDs)
+				followerSet := make(map[string]bool, len(followerIDs))
+				for _, fid := range followerIDs {
+					followerSet[fid] = true
+				}
+				for _, sid := range subscriberIDs {
+					if followerSet[sid] {
+						continue // 이미 팔로워 알림 받음
+					}
+					_ = notiRepo.Create(&gnurepo.Notification{
+						PhToCase: "subscribe", PhFromCase: "write", BoTable: slug,
+						WrID: post.WrID, MbID: sid, RelMbID: mbID,
+						RelMbNick:    authorName,
+						RelMsg:       fmt.Sprintf("%s 게시판에 새 글: %s", slug, subject),
+						RelURL:       fmt.Sprintf("/%s/%d", slug, post.WrID),
+						PhReaded:     "N",
+						PhDatetime:   now,
+						WrParent:     post.WrID,
+					})
+				}
+			}()
+
 			c.JSON(http.StatusCreated, gin.H{
 				"success": true,
 				"data":    v1handler.TransformToV1PostDetail(&post, false),
@@ -3033,7 +3082,7 @@ func main() {
 
 		// v1 message routes (uses g5_memo table directly)
 		gnuMemoRepo := gnurepo.NewMemoRepository(db)
-		v1MsgHandler := handler.NewV1MessageHandler(gnuMemoRepo, gnuMemberRepo)
+		v1MsgHandler := handler.NewV1MessageHandler(gnuMemoRepo, gnuMemberRepo, notiRepo)
 		v1Messages := router.Group("/api/v1/messages", middleware.JWTAuth(jwtManager))
 		v1Messages.GET("", v1MsgHandler.GetMessages)
 		v1Messages.GET("/unread-count", v1MsgHandler.GetUnreadCount)

--- a/internal/handler/message_handler.go
+++ b/internal/handler/message_handler.go
@@ -1,9 +1,11 @@
 package handler
 
 import (
+	"fmt"
 	"math"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
@@ -16,11 +18,12 @@ import (
 type V1MessageHandler struct {
 	memoRepo   gnurepo.MemoRepository
 	memberRepo gnurepo.MemberRepository
+	notiRepo   gnurepo.NotiRepository
 }
 
 // NewV1MessageHandler creates a new V1MessageHandler using g5_memo
-func NewV1MessageHandler(memoRepo gnurepo.MemoRepository, memberRepo gnurepo.MemberRepository) *V1MessageHandler {
-	return &V1MessageHandler{memoRepo: memoRepo, memberRepo: memberRepo}
+func NewV1MessageHandler(memoRepo gnurepo.MemoRepository, memberRepo gnurepo.MemberRepository, notiRepo gnurepo.NotiRepository) *V1MessageHandler {
+	return &V1MessageHandler{memoRepo: memoRepo, memberRepo: memberRepo, notiRepo: notiRepo}
 }
 
 // v1MessageResponse matches frontend Message type
@@ -215,6 +218,25 @@ func (h *V1MessageHandler) SendMessage(c *gin.Context) {
 	if nickMap == nil {
 		nickMap = make(map[string]string)
 	}
+
+	// 쪽지 알림 (비동기)
+	go func() {
+		senderNick := nickMap[mbID]
+		if senderNick == "" {
+			senderNick = mbID
+		}
+		_ = h.notiRepo.Create(&gnurepo.Notification{
+			PhToCase:   "memo",
+			PhFromCase: "memo",
+			MbID:       req.ReceiverID,
+			RelMbID:    mbID,
+			RelMbNick:  senderNick,
+			RelMsg:     fmt.Sprintf("%s님이 쪽지를 보냈습니다.", senderNick),
+			RelURL:     fmt.Sprintf("/member/messages/%d", memo.MeID),
+			PhReaded:   "N",
+			PhDatetime: time.Now(),
+		})
+	}()
 
 	common.V2Created(c, h.toV1Message(memo, nickMap))
 }


### PR DESCRIPTION
## Summary
- 쪽지 발송 시 수신자에게 알림 생성 (ph_to_case=memo)
- 새 글 작성 시 팔로워에게 알림 (ph_to_case=follow)
- 새 글 작성 시 게시판 구독자에게 알림 (ph_to_case=subscribe)

## Test plan
- [ ] 쪽지 보내기 → 수신자 알림 확인
- [ ] 팔로워가 있는 회원이 글 작성 → 팔로워 알림 확인
- [ ] 구독된 게시판에 글 작성 → 구독자 알림 확인