### PR TITLE
feat: v1 게시글 목록 검색 기능 추가 (sfl/stx)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1628,12 +1628,12 @@ func main() {
 					_ = notiRepo.Create(&gnurepo.Notification{
 						PhToCase: "follow", PhFromCase: "write", BoTable: slug,
 						WrID: post.WrID, MbID: fid, RelMbID: mbID,
-						RelMbNick:    authorName,
-						RelMsg:       fmt.Sprintf("%s님이 새 글을 작성했습니다: %s", authorName, subject),
-						RelURL:       fmt.Sprintf("/%s/%d", slug, post.WrID),
-						PhReaded:     "N",
-						PhDatetime:   now,
-						WrParent:     post.WrID,
+						RelMbNick:  authorName,
+						RelMsg:     fmt.Sprintf("%s님이 새 글을 작성했습니다: %s", authorName, subject),
+						RelURL:     fmt.Sprintf("/%s/%d", slug, post.WrID),
+						PhReaded:   "N",
+						PhDatetime: now,
+						WrParent:   post.WrID,
 					})
 				}
 
@@ -1651,12 +1651,12 @@ func main() {
 					_ = notiRepo.Create(&gnurepo.Notification{
 						PhToCase: "subscribe", PhFromCase: "write", BoTable: slug,
 						WrID: post.WrID, MbID: sid, RelMbID: mbID,
-						RelMbNick:    authorName,
-						RelMsg:       fmt.Sprintf("%s 게시판에 새 글: %s", slug, subject),
-						RelURL:       fmt.Sprintf("/%s/%d", slug, post.WrID),
-						PhReaded:     "N",
-						PhDatetime:   now,
-						WrParent:     post.WrID,
+						RelMbNick:  authorName,
+						RelMsg:     fmt.Sprintf("%s 게시판에 새 글: %s", slug, subject),
+						RelURL:     fmt.Sprintf("/%s/%d", slug, post.WrID),
+						PhReaded:   "N",
+						PhDatetime: now,
+						WrParent:   post.WrID,
 					})
 				}
 			}()

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1083,8 +1083,13 @@ func main() {
 				limit = 20
 			}
 
-			// Try cache first
-			if cacheService != nil {
+			// Search parameters
+			sfl := c.Query("sfl") // search field: title, content, title_content, author
+			stx := c.Query("stx") // search text
+			isSearching := sfl != "" && stx != ""
+
+			// Try cache first (only for non-search requests)
+			if !isSearching && cacheService != nil {
 				if cached, err := cacheService.GetPosts(ctx, slug, page, limit); err == nil {
 					c.Header("X-Cache", "HIT")
 					c.Data(http.StatusOK, "application/json", cached)
@@ -1100,7 +1105,13 @@ func main() {
 			}
 
 			// Get posts from g5_write_{slug}
-			posts, total, err := gnuWriteRepo.FindPosts(slug, page, limit)
+			var posts []*gnuboard.G5Write
+			var total int64
+			if isSearching {
+				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
+			} else {
+				posts, total, err = gnuWriteRepo.FindPosts(slug, page, limit)
+			}
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{"success": true, "data": []any{}, "meta": gin.H{"total": 0, "page": page, "limit": limit}})
 				return
@@ -1149,8 +1160,8 @@ func main() {
 				"meta":    gin.H{"board_id": slug, "page": page, "limit": limit, "total": total},
 			}
 
-			// Cache the response
-			if cacheService != nil {
+			// Cache the response (only for non-search requests)
+			if !isSearching && cacheService != nil {
 				_ = cacheService.SetPosts(ctx, slug, page, limit, response)
 			}
 

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -48,6 +48,7 @@ var coreColumns = []string{
 type WriteRepository interface {
 	// Posts
 	FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error)
+	SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	FindPostByID(boardID string, wrID int) (*gnuboard.G5Write, error)
 	FindPostByIDIncludeDeleted(boardID string, wrID int) (*gnuboard.G5Write, error)
 	FindNotices(boardID string, noticeIDs []int) ([]*gnuboard.G5Write, error)
@@ -135,6 +136,67 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	err := r.db.Table(table).
 		Select(coreColumns).
 		Where("wr_is_comment = 0 AND wr_deleted_at IS NULL").
+		Order(orderClause).
+		Offset(offset).
+		Limit(limit).
+		Find(&posts).Error
+
+	return posts, total, err
+}
+
+// SearchPosts retrieves posts matching search criteria (sfl/stx) with pagination
+func (r *writeRepository) SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
+	var posts []*gnuboard.G5Write
+	var total int64
+
+	offset := (page - 1) * limit
+	table := tableName(boardID)
+
+	// Build search condition based on field
+	var searchCond string
+	var searchArgs []interface{}
+	likeQuery := "%" + searchQuery + "%"
+
+	switch searchField {
+	case "title":
+		searchCond = "wr_subject LIKE ?"
+		searchArgs = []interface{}{likeQuery}
+	case "content":
+		searchCond = "wr_content LIKE ?"
+		searchArgs = []interface{}{likeQuery}
+	case "title_content":
+		searchCond = "(wr_subject LIKE ? OR wr_content LIKE ?)"
+		searchArgs = []interface{}{likeQuery, likeQuery}
+	case "author":
+		searchCond = "(wr_name LIKE ? OR mb_id LIKE ?)"
+		searchArgs = []interface{}{likeQuery, likeQuery}
+	default:
+		searchCond = "(wr_subject LIKE ? OR wr_content LIKE ?)"
+		searchArgs = []interface{}{likeQuery, likeQuery}
+	}
+
+	baseCond := "wr_is_comment = 0 AND wr_deleted_at IS NULL AND " + searchCond
+	baseArgs := searchArgs
+
+	// Count
+	if err := r.db.Table(table).Where(baseCond, baseArgs...).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Order
+	orderClause := "wr_num, wr_reply"
+	now := time.Now()
+	if cached, ok := sortFieldCache.Load(boardID); ok {
+		if entry, valid := cached.(*cachedSortField); valid && now.Before(entry.expiresAt) {
+			if entry.field != "" {
+				orderClause = entry.field
+			}
+		}
+	}
+
+	err := r.db.Table(table).
+		Select(coreColumns).
+		Where(baseCond, baseArgs...).
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).


### PR DESCRIPTION
## Summary
- `GET /api/v1/boards/:slug/posts`에서 `sfl`(검색 필드), `stx`(검색어) 쿼리 파라미터 지원
- `WriteRepository`에 `SearchPosts` 메서드 추가
- 지원 검색 필드: `title`, `content`, `title_content`, `author`
- 검색 요청 시 캐시 bypass 처리

## Context
프론트엔드에서 `sfl=title&stx=keyword`를 이미 정확히 전달하고 있었으나, 백엔드 v1 핸들러가 파라미터를 읽지 않아 제목 필터링이 동작하지 않는 문제 수정

## Test plan
- [ ] `curl "http://localhost:8081/api/v1/boards/free/posts?sfl=title&stx=테스트"` → 제목에 "테스트" 포함된 글만 반환
- [ ] `sfl=content&stx=검색어` → 내용 검색
- [ ] `sfl=author&stx=닉네임` → 작성자 검색
- [ ] `sfl=title_content&stx=키워드` → 제목+내용 검색
- [ ] 검색 없는 일반 목록 조회는 기존과 동일하게 동작 (캐시 포함)