### PR TITLE
feat: 게시글 검색을 Sphinx 전문검색으로 전환

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/damoang/angple-backend/internal/ws"
 	pkgcache "github.com/damoang/angple-backend/pkg/cache"
 	pkges "github.com/damoang/angple-backend/pkg/elasticsearch"
+	pkgsphinx "github.com/damoang/angple-backend/pkg/sphinx"
 	"github.com/damoang/angple-backend/pkg/i18n"
 	"github.com/damoang/angple-backend/pkg/jwt"
 	pkglogger "github.com/damoang/angple-backend/pkg/logger"
@@ -318,9 +319,23 @@ func main() {
 		v2UserRepo := v2repo.NewUserRepository(db)
 		siteRepo := repository.NewSiteRepository(db)
 
+		// Sphinx full-text search (SphinxQL on port 9306)
+		var sphinxClient *pkgsphinx.Client
+		if sc, err := pkgsphinx.New("127.0.0.1", 9306); err != nil {
+			pkglogger.Info("Sphinx unavailable, falling back to MySQL LIKE: %v", err)
+		} else {
+			sphinxClient = sc
+			pkglogger.Info("Sphinx connected (127.0.0.1:9306)")
+		}
+
 		// Gnuboard repositories for v1 API (g5_* tables)
 		gnuBoardRepo := gnurepo.NewBoardRepository(db)
-		gnuWriteRepo := gnurepo.NewWriteRepository(db)
+		var gnuWriteRepo gnurepo.WriteRepository
+		if sphinxClient != nil {
+			gnuWriteRepo = gnurepo.NewWriteRepositoryWithSphinx(db, sphinxClient)
+		} else {
+			gnuWriteRepo = gnurepo.NewWriteRepository(db)
+		}
 		gnuFileRepo := gnurepo.NewFileRepository(db)
 		gnuMemberRepo := gnurepo.NewMemberRepository(db)
 

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -170,6 +170,7 @@ func TransformToV1Board(b *gnuboard.G5Board) map[string]any {
 		"use_good":       b.BoUseGood == 1,
 		"use_nogood":     b.BoUseNogood == 1,
 		"use_secret":     b.BoUseSecret > 0,
+		"use_sns":        b.BoUseSns,
 		"post_count":     b.BoCountWrite,
 		"comment_count":  b.BoCountComment,
 	}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"github.com/damoang/angple-backend/pkg/sphinx"
 	"gorm.io/gorm"
 )
 
@@ -78,12 +79,18 @@ type WriteRepository interface {
 }
 
 type writeRepository struct {
-	db *gorm.DB
+	db     *gorm.DB
+	sphinx *sphinx.Client
 }
 
 // NewWriteRepository creates a new Gnuboard WriteRepository
 func NewWriteRepository(db *gorm.DB) WriteRepository {
 	return &writeRepository{db: db}
+}
+
+// NewWriteRepositoryWithSphinx creates a WriteRepository with Sphinx search support.
+func NewWriteRepositoryWithSphinx(db *gorm.DB, sphinxClient *sphinx.Client) WriteRepository {
+	return &writeRepository{db: db, sphinx: sphinxClient}
 }
 
 // tableName generates the dynamic table name for a board
@@ -262,55 +269,57 @@ func (r *writeRepository) SearchPostsFiltered(boardID string, searchField, searc
 	return posts, total, err
 }
 
-// SearchPosts retrieves posts matching search criteria (sfl/stx) with pagination
+// SearchPosts retrieves posts matching search criteria (sfl/stx) with pagination.
+// Uses Sphinx full-text search when available, falls back to MySQL LIKE.
 func (r *writeRepository) SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
+	// Try Sphinx first
+	if r.sphinx != nil {
+		result, err := r.sphinx.Search(boardID, searchField, searchQuery, page, limit)
+		if err == nil && result != nil {
+			if len(result.IDs) == 0 {
+				return nil, result.TotalFound, nil
+			}
+			// Fetch full post data from MySQL by IDs (preserving Sphinx order)
+			var posts []*gnuboard.G5Write
+			table := tableName(boardID)
+			if err := r.db.Table(table).
+				Select(coreColumns).
+				Where("wr_id IN ? AND wr_deleted_at IS NULL", result.IDs).
+				Find(&posts).Error; err != nil {
+				return nil, 0, err
+			}
+			// Reorder posts to match Sphinx result order
+			postMap := make(map[int]*gnuboard.G5Write, len(posts))
+			for _, p := range posts {
+				postMap[p.WrID] = p
+			}
+			ordered := make([]*gnuboard.G5Write, 0, len(result.IDs))
+			for _, id := range result.IDs {
+				if p, ok := postMap[id]; ok {
+					ordered = append(ordered, p)
+				}
+			}
+			return ordered, result.TotalFound, nil
+		}
+		// Sphinx error: fall through to MySQL LIKE
+	}
+
+	// Fallback: MySQL LIKE search
 	var posts []*gnuboard.G5Write
 	var total int64
 
 	offset := (page - 1) * limit
 	table := tableName(boardID)
 
-	// Build search condition based on field
-	var searchCond string
-	var searchArgs []interface{}
-	likeQuery := "%" + searchQuery + "%"
-
-	switch searchField {
-	case "title":
-		searchCond = "wr_subject LIKE ?"
-		searchArgs = []interface{}{likeQuery}
-	case "content":
-		searchCond = "wr_content LIKE ?"
-		searchArgs = []interface{}{likeQuery}
-	case "title_content":
-		searchCond = "(wr_subject LIKE ? OR wr_content LIKE ?)"
-		searchArgs = []interface{}{likeQuery, likeQuery}
-	case "author":
-		searchCond = "(wr_name LIKE ? OR mb_id LIKE ?)"
-		searchArgs = []interface{}{likeQuery, likeQuery}
-	default:
-		searchCond = "(wr_subject LIKE ? OR wr_content LIKE ?)"
-		searchArgs = []interface{}{likeQuery, likeQuery}
-	}
-
+	searchCond, searchArgs := buildSearchCondition(searchField, searchQuery)
 	baseCond := "wr_is_comment = 0 AND wr_deleted_at IS NULL AND " + searchCond
 	baseArgs := searchArgs
 
-	// Count
 	if err := r.db.Table(table).Where(baseCond, baseArgs...).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
-	// Order
-	orderClause := "wr_num, wr_reply"
-	now := time.Now()
-	if cached, ok := sortFieldCache.Load(boardID); ok {
-		if entry, valid := cached.(*cachedSortField); valid && now.Before(entry.expiresAt) {
-			if entry.field != "" {
-				orderClause = entry.field
-			}
-		}
-	}
+	orderClause := r.getSortField(boardID)
 
 	err := r.db.Table(table).
 		Select(coreColumns).

--- a/pkg/sphinx/sphinx.go
+++ b/pkg/sphinx/sphinx.go
@@ -1,0 +1,125 @@
+package sphinx
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Client wraps a SphinxQL connection (MySQL protocol on port 9306).
+type Client struct {
+	db *sql.DB
+}
+
+// SearchResult holds Sphinx search results.
+type SearchResult struct {
+	IDs        []int // matched wr_id list (ordered by relevance or wr_id DESC)
+	TotalFound int64 // total matching documents
+}
+
+// New creates a new Sphinx client connecting via SphinxQL.
+func New(host string, port int) (*Client, error) {
+	dsn := fmt.Sprintf("tcp(%s:%d)/", host, port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("sphinx connect: %w", err)
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("sphinx ping: %w", err)
+	}
+	return &Client{db: db}, nil
+}
+
+// buildMatchExpr builds a Sphinx MATCH expression from search field and query.
+func buildMatchExpr(searchField, searchQuery string) string {
+	// Escape special Sphinx characters
+	escaped := escapeSphinx(searchQuery)
+	switch searchField {
+	case "title":
+		return fmt.Sprintf("@wr_subject %s", escaped)
+	case "content":
+		return fmt.Sprintf("@wr_content %s", escaped)
+	case "title_content":
+		return fmt.Sprintf("@(wr_subject,wr_content) %s", escaped)
+	case "author":
+		return fmt.Sprintf("@(wr_name,mb_id) %s", escaped)
+	default:
+		return fmt.Sprintf("@(wr_subject,wr_content) %s", escaped)
+	}
+}
+
+// escapeSphinx escapes special characters for SphinxQL MATCH expressions.
+func escapeSphinx(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`'`, `\'`,
+		`"`, `\"`,
+		`(`, `\(`,
+		`)`, `\)`,
+		`|`, `\|`,
+		`-`, `\-`,
+		`!`, `\!`,
+		`~`, `\~`,
+		`&`, `\&`,
+		`/`, `\/`,
+		`^`, `\^`,
+		`$`, `\$`,
+		`=`, `\=`,
+		`<`, `\<`,
+	)
+	return replacer.Replace(s)
+}
+
+// Search queries Sphinx for matching post IDs using the distributed index (main + delta).
+func (c *Client) Search(boardID, searchField, searchQuery string, page, limit int) (*SearchResult, error) {
+	index := fmt.Sprintf("g5_write_%s_dist", boardID)
+	matchExpr := buildMatchExpr(searchField, searchQuery)
+	offset := (page - 1) * limit
+
+	query := fmt.Sprintf(
+		"SELECT wr_id FROM %s WHERE MATCH('%s') AND wr_is_comment=0 ORDER BY wr_id DESC LIMIT %d, %d OPTION max_matches=10000",
+		index, matchExpr, offset, limit,
+	)
+
+	rows, err := c.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("sphinx query: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []int
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("sphinx scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+
+	// Get total_found from SHOW META
+	var totalFound int64
+	metaRows, err := c.db.Query("SHOW META")
+	if err == nil {
+		defer metaRows.Close()
+		for metaRows.Next() {
+			var name, value string
+			if err := metaRows.Scan(&name, &value); err == nil {
+				if name == "total_found" {
+					fmt.Sscanf(value, "%d", &totalFound)
+				}
+			}
+		}
+	}
+
+	return &SearchResult{IDs: ids, TotalFound: totalFound}, nil
+}
+
+// Close closes the SphinxQL connection.
+func (c *Client) Close() error {
+	return c.db.Close()
+}


### PR DESCRIPTION
## Summary

- 기존 MySQL `LIKE '%keyword%'` 풀스캔 검색을 **Sphinx 전문검색**으로 전환
- SphinxQL (MySQL 프로토콜, 9306 포트)로 `wr_id` 목록 + `total_found` 조회 → MySQL에서 실제 데이터 fetch
- Sphinx 장애 시 MySQL LIKE fallback 자동 전환
- 검색 유형 전체 지원: `title`, `content`, `title_content`, `author`

## Performance

| 방식 | 응답 시간 |
|------|----------|
| MySQL LIKE (기존) | ~200ms+ (대용량 테이블 풀스캔) |
| Sphinx (변경 후) | **~24ms** |

## Test plan

- [x] `make build` 컴파일 확인
- [x] dev 배포 후 `title_content` 검색 정상 확인 (total: 9853)
- [x] `title`, `author` 검색 정상 확인
- [x] 응답 시간 24ms 확인
- [ ] Sphinx 미연결 시 MySQL LIKE fallback 동작 확인