### PR TITLE
fix: DB 연결 재시도 + 운영환경 DB 필수 (502 재발 방지)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -132,10 +132,24 @@ func main() {
 	}
 	config.LogResolved(cfg)
 
-	// MySQL 연결
-	db, err := initDB(cfg)
+	// MySQL 연결 (DNS 실패 등 일시적 장애에 대비하여 최대 5회 재시도)
+	var db *gorm.DB
+	for attempt := 1; attempt <= 5; attempt++ {
+		db, err = initDB(cfg)
+		if err == nil {
+			break
+		}
+		pkglogger.Info("DB connection attempt %d/5 failed: %v", attempt, err)
+		if attempt < 5 {
+			time.Sleep(time.Duration(attempt) * 2 * time.Second) // 2s, 4s, 6s, 8s backoff
+		}
+	}
 	if err != nil {
-		pkglogger.Info("Warning: Failed to connect to database: %v (continuing without DB)", err)
+		appEnv := os.Getenv("APP_ENV")
+		if appEnv == "production" || appEnv == "staging" {
+			log.Fatalf("CRITICAL: All DB connection attempts failed: %v (aborting — DB required in %s)", err, appEnv)
+		}
+		pkglogger.Info("CRITICAL: All DB connection attempts failed: %v (continuing without DB)", err)
 		db = nil
 	} else {
 		pkglogger.Info("Connected to MySQL")


### PR DESCRIPTION
## Summary

CoreDNS 메모리 부족 → DNS 해석 실패 → DB 연결 불가 → API 미등록 → 502 장애 재발 방지.

- DB 연결 최대 5회 재시도 (exponential backoff 2s~8s)
- production/staging에서 DB 연결 전부 실패 시 `log.Fatalf` → K8s CrashLoopBackOff → DNS 복구 후 자동 재연결
- 개발환경은 기존 동작 유지 (DB 없이 시작 가능)

## 인프라 조치 (이미 완료)

- CoreDNS 메모리: 170Mi → 256Mi 상향
- 운영 전체 파드 rollout restart 완료

## Test plan

- [x] `make build` 컴파일 확인
- [x] dev 배포 정상 동작 확인
- [ ] DB 연결 실패 시 재시도 로그 확인