### PR TITLE
feat: ECR 빌드 완료 시 Telegram/Discord 알림 추가

### DIFF
--- a/.github/workflows/deploy-ecr.yml
+++ b/.github/workflows/deploy-ecr.yml
@@ -70,6 +70,34 @@ jobs:
           cache-from: type=gha,scope=backend-api
           cache-to: type=gha,mode=max,scope=backend-api
 
+      - name: Notify build ready (Telegram)
+        if: success()
+        run: |
+          SHORT_SHA="${{ github.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s')
+          MSG="📦 백엔드 이미지 빌드 완료
+
+          커밋: ${SHORT_SHA} - ${COMMIT_MSG}
+          이미지: angple-backend:sha-${SHORT_SHA}
+
+          ➡️ ops.damoang.net/deploy 에서 배포 가능"
+
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_TOKEN }}/sendMessage" \
+            --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
+            --data-urlencode "text=${MSG}" >/dev/null 2>&1 || true
+
+      - name: Notify build ready (Discord)
+        if: success()
+        run: |
+          SHORT_SHA="${{ github.sha }}"
+          SHORT_SHA="${SHORT_SHA:0:7}"
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s')
+
+          curl -s -H "Content-Type: application/json" \
+            -d "{\"embeds\":[{\"title\":\"📦 백엔드 이미지 빌드 완료\",\"description\":\"커밋: \`${SHORT_SHA}\` - ${COMMIT_MSG}\\n이미지: \`angple-backend:sha-${SHORT_SHA}\`\\n\\n➡️ [배포 대시보드](https://ops.damoang.net/deploy)에서 배포 가능\",\"color\":3447003,\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}]}" \
+            "${{ secrets.DISCORD_WEBHOOK }}" >/dev/null 2>&1 || true
+
   deploy:
     name: Deploy to K8s
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ECR 이미지 빌드 완료 후 Telegram과 Discord로 알림 전송
- 커밋 SHA, 메시지, 이미지 태그 정보 포함
- Discord에는 ops.damoang.net/deploy 배포 대시보드 링크 포함

## Changes
- `.github/workflows/deploy-ecr.yml`: build job에 Telegram/Discord 알림 step 추가