### PR TITLE
feat: 삭제 예약 상태 API Redis 캐시 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2464,6 +2464,9 @@ func main() {
 				return
 			}
 
+			// 캐시 무효화
+			middleware.InvalidateCacheByPath(redisClient, fmt.Sprintf("/api/v1/boards/%s/posts/%d/delete-status", slug, postID))
+
 			c.JSON(http.StatusOK, gin.H{
 				"success":       true,
 				"message":       fmt.Sprintf("댓글이 %d개 있어 %d분 후 삭제됩니다", commentCount, delayMinutes),
@@ -2626,6 +2629,9 @@ func main() {
 				return
 			}
 
+			// 캐시 무효화
+			middleware.InvalidateCacheByPath(redisClient, fmt.Sprintf("/api/v1/boards/%s/posts/%d/delete-status", slug, commentID))
+
 			c.JSON(http.StatusOK, gin.H{
 				"success":       true,
 				"message":       fmt.Sprintf("답글이 %d개 있어 %d분 후 삭제됩니다", replyCount, delayMinutes),
@@ -2663,11 +2669,14 @@ func main() {
 				return
 			}
 
+			// 캐시 무효화
+			middleware.InvalidateCacheByPath(redisClient, fmt.Sprintf("/api/v1/boards/%s/posts/%d/delete-status", slug, wrID))
+
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제가 취소되었습니다"})
 		})
 
 		// GET /api/v1/boards/:slug/posts/:id/delete-status - Check scheduled delete status
-		v1Boards.GET("/:slug/posts/:id/delete-status", func(c *gin.Context) {
+		v1Boards.GET("/:slug/posts/:id/delete-status", middleware.CacheWithTTL(redisClient, 30*time.Second), func(c *gin.Context) {
 			slug := c.Param("slug")
 			wrID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {

--- a/internal/middleware/cache.go
+++ b/internal/middleware/cache.go
@@ -112,6 +112,15 @@ func InvalidateCache(redisClient *redis.Client, prefix string) {
 	}
 }
 
+// InvalidateCacheByPath deletes the cache entry for a specific path
+func InvalidateCacheByPath(redisClient *redis.Client, path string) {
+	if redisClient == nil {
+		return
+	}
+	key := DefaultCacheConfig().KeyPrefix + cacheKey(path, "")
+	redisClient.Del(context.Background(), key)
+}
+
 func cacheKey(path, query string) string {
 	raw := path
 	if query != "" {


### PR DESCRIPTION
## Summary
- `delete-status` 엔드포인트에 30초 TTL Redis 캐시 적용 (대부분 `{"scheduled":false}` 응답 캐싱)
- 삭제 예약/취소 시 `InvalidateCacheByPath`로 해당 캐시 즉시 무효화
- `InvalidateCacheByPath` 헬퍼 함수 추가 (`cache.go`)

## Test plan
- [ ] 삭제 예약 후 delete-status 응답에 `X-Cache: MISS` 확인
- [ ] 동일 요청 재호출 시 `X-Cache: HIT` 확인
- [ ] 삭제 취소 후 캐시 무효화되어 `X-Cache: MISS` 전환 확인