### PR TITLE
fix: 헤더 전용 메뉴도 sidebar API에 포함

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -418,7 +418,7 @@ func main() {
 		v1Auth.GET("/profile", middleware.JWTAuth(jwtManager), v2AuthHandler.GetMe)
 		router.GET("/api/v1/menus/sidebar", func(c *gin.Context) {
 			var menus []domain.Menu
-			if err := db.Where("is_active = ? AND show_in_sidebar = ?", true, true).
+			if err := db.Where("is_active = ? AND (show_in_sidebar = ? OR show_in_header = ?)", true, true, true).
 				Order("order_num ASC, id ASC").Find(&menus).Error; err != nil {
 				c.JSON(http.StatusOK, gin.H{"success": true, "data": []any{}})
 				return


### PR DESCRIPTION
## Summary
- 메뉴 sidebar API 쿼리를 `show_in_sidebar = true` → `show_in_sidebar = true OR show_in_header = true`로 변경
- 헤더에만 표시되는 메뉴(홈, 피드)도 API 응답에 포함되도록 수정