### PR TITLE
feat: 게시글 태그 저장/조회 구현

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -361,6 +361,7 @@ func main() {
 			gnuWriteRepo = gnurepo.NewWriteRepository(db)
 		}
 		gnuFileRepo := gnurepo.NewFileRepository(db)
+		gnuTagRepo := gnurepo.NewTagRepository(db)
 		gnuMemberRepo := gnurepo.NewMemberRepository(db)
 		scheduledDeleteRepo := gnurepo.NewScheduledDeleteRepository(db)
 
@@ -1467,6 +1468,11 @@ func main() {
 
 			postDetail := v1handler.TransformToV1PostDetail(post, isNotice)
 
+			// 태그 조회
+			if tags, err := gnuTagRepo.GetPostTags(slug, id); err == nil && len(tags) > 0 {
+				postDetail["tags"] = tags
+			}
+
 			// Admin sees full (unmasked) IP
 			if middleware.GetUserLevel(c) >= 10 {
 				v1handler.OverrideIPForAdminSingle(postDetail, post)
@@ -1732,15 +1738,16 @@ func main() {
 
 			// 요청 바디 파싱
 			var req struct {
-				Title    string  `json:"title" binding:"required"`
-				Content  string  `json:"content" binding:"required"`
-				Category *string `json:"category"`
-				IsSecret *bool   `json:"is_secret"`
-				Link1    *string `json:"link1"`
-				Link2    *string `json:"link2"`
-				Extra1   *string `json:"extra_1"`
-				Extra2   *string `json:"extra_2"`
-				Extra3   *string `json:"extra_3"`
+				Title    string   `json:"title" binding:"required"`
+				Content  string   `json:"content" binding:"required"`
+				Category *string  `json:"category"`
+				IsSecret *bool    `json:"is_secret"`
+				Link1    *string  `json:"link1"`
+				Link2    *string  `json:"link2"`
+				Extra1   *string  `json:"extra_1"`
+				Extra2   *string  `json:"extra_2"`
+				Extra3   *string  `json:"extra_3"`
+				Tags     []string `json:"tags"`
 			}
 			if err := c.ShouldBindJSON(&req); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "제목과 내용을 입력해주세요"})
@@ -1845,6 +1852,13 @@ func main() {
 
 			// wr_parent를 자기 자신의 wr_id로 UPDATE (gnuboard 규칙)
 			db.Table(tableName).Where("wr_id = ?", post.WrID).Update("wr_parent", post.WrID)
+
+			// 태그 저장 (g5_na_tag / g5_na_tag_log)
+			if len(req.Tags) > 0 {
+				if err := gnuTagRepo.SetPostTags(slug, post.WrID, req.Tags, mbID); err != nil {
+					fmt.Printf("[WARN] tag save failed for %s/%d: %v\n", slug, post.WrID, err)
+				}
+			}
 
 			// extra 필드 업데이트 (있는 경우)
 			extras := map[string]interface{}{}
@@ -2203,14 +2217,15 @@ func main() {
 
 			// 요청 바디 파싱
 			var req struct {
-				Title    *string `json:"title"`
-				Content  *string `json:"content"`
-				Category *string `json:"category"`
-				Link1    *string `json:"link1"`
-				Link2    *string `json:"link2"`
-				Extra1   *string `json:"extra_1"`
-				Extra2   *string `json:"extra_2"`
-				Extra3   *string `json:"extra_3"`
+				Title    *string  `json:"title"`
+				Content  *string  `json:"content"`
+				Category *string  `json:"category"`
+				Link1    *string  `json:"link1"`
+				Link2    *string  `json:"link2"`
+				Extra1   *string  `json:"extra_1"`
+				Extra2   *string  `json:"extra_2"`
+				Extra3   *string  `json:"extra_3"`
+				Tags     []string `json:"tags"`
 			}
 			if err := c.ShouldBindJSON(&req); err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "잘못된 요청입니다"})
@@ -2261,6 +2276,13 @@ func main() {
 			if err := db.Table(tableName).Where("wr_id = ?", postID).Updates(updates).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 수정 실패"})
 				return
+			}
+
+			// 태그 업데이트 (tags 필드가 전송된 경우)
+			if req.Tags != nil {
+				if err := gnuTagRepo.SetPostTags(slug, postID, req.Tags, userID); err != nil {
+					fmt.Printf("[WARN] tag update failed for %s/%d: %v\n", slug, postID, err)
+				}
 			}
 
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "수정 완료"})

--- a/internal/domain/gnuboard/tag.go
+++ b/internal/domain/gnuboard/tag.go
@@ -1,0 +1,31 @@
+package gnuboard
+
+import "time"
+
+// G5NaTag represents a tag in g5_na_tag table (nariya tag system)
+type G5NaTag struct {
+	ID       int       `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	Type     int8      `gorm:"column:type;default:0" json:"type"`
+	Idx      string    `gorm:"column:idx;type:varchar(10)" json:"idx"`
+	Tag      string    `gorm:"column:tag;type:varchar(255)" json:"tag"`
+	Cnt      int       `gorm:"column:cnt;default:0" json:"cnt"`
+	RegDate  time.Time `gorm:"column:regdate" json:"regdate"`
+	LastDate time.Time `gorm:"column:lastdate" json:"lastdate"`
+}
+
+// TableName returns the table name
+func (G5NaTag) TableName() string { return "g5_na_tag" }
+
+// G5NaTagLog represents a post-tag mapping in g5_na_tag_log table
+type G5NaTagLog struct {
+	ID      int       `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	BoTable string    `gorm:"column:bo_table;type:varchar(20)" json:"bo_table"`
+	WrID    int       `gorm:"column:wr_id" json:"wr_id"`
+	TagID   int       `gorm:"column:tag_id" json:"tag_id"`
+	Tag     string    `gorm:"column:tag;type:varchar(255)" json:"tag"`
+	MbID    string    `gorm:"column:mb_id;type:varchar(255)" json:"mb_id"`
+	RegDate time.Time `gorm:"column:regdate" json:"regdate"`
+}
+
+// TableName returns the table name
+func (G5NaTagLog) TableName() string { return "g5_na_tag_log" }

--- a/internal/repository/gnuboard/tag_repo.go
+++ b/internal/repository/gnuboard/tag_repo.go
@@ -1,0 +1,132 @@
+package gnuboard
+
+import (
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+)
+
+// TagRepository handles g5_na_tag / g5_na_tag_log operations
+type TagRepository interface {
+	GetPostTags(boTable string, wrID int) ([]string, error)
+	GetPostsTagsBatch(boTable string, wrIDs []int) (map[int][]string, error)
+	SetPostTags(boTable string, wrID int, tags []string, mbID string) error
+	DeletePostTags(boTable string, wrID int) error
+}
+
+type tagRepository struct {
+	db *gorm.DB
+}
+
+// NewTagRepository creates a new TagRepository
+func NewTagRepository(db *gorm.DB) TagRepository {
+	return &tagRepository{db: db}
+}
+
+// GetPostTags returns tag names for a post
+func (r *tagRepository) GetPostTags(boTable string, wrID int) ([]string, error) {
+	var logs []gnuboard.G5NaTagLog
+	err := r.db.Where("bo_table = ? AND wr_id = ?", boTable, wrID).Find(&logs).Error
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]string, len(logs))
+	for i, l := range logs {
+		tags[i] = l.Tag
+	}
+	return tags, nil
+}
+
+// GetPostsTagsBatch returns tags for multiple posts at once
+func (r *tagRepository) GetPostsTagsBatch(boTable string, wrIDs []int) (map[int][]string, error) {
+	if len(wrIDs) == 0 {
+		return nil, nil
+	}
+	var logs []gnuboard.G5NaTagLog
+	err := r.db.Where("bo_table = ? AND wr_id IN ?", boTable, wrIDs).Find(&logs).Error
+	if err != nil {
+		return nil, err
+	}
+	tagMap := make(map[int][]string)
+	for _, l := range logs {
+		tagMap[l.WrID] = append(tagMap[l.WrID], l.Tag)
+	}
+	return tagMap, nil
+}
+
+// SetPostTags replaces all tags for a post
+func (r *tagRepository) SetPostTags(boTable string, wrID int, tags []string, mbID string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// Delete existing tag logs for this post
+		if err := tx.Where("bo_table = ? AND wr_id = ?", boTable, wrID).
+			Delete(&gnuboard.G5NaTagLog{}).Error; err != nil {
+			return err
+		}
+
+		now := time.Now()
+
+		for _, tagName := range tags {
+			tagName = strings.TrimSpace(tagName)
+			if tagName == "" {
+				continue
+			}
+
+			// Find or create the tag in g5_na_tag
+			var tag gnuboard.G5NaTag
+			err := tx.Where("tag = ? AND type = 0", tagName).First(&tag).Error
+			if err != nil {
+				// Create new tag
+				tag = gnuboard.G5NaTag{
+					Type:     0,
+					Idx:      firstChar(tagName),
+					Tag:      tagName,
+					Cnt:      0,
+					RegDate:  now,
+					LastDate: now,
+				}
+				if err := tx.Create(&tag).Error; err != nil {
+					return err
+				}
+			}
+
+			// Create tag log entry
+			log := gnuboard.G5NaTagLog{
+				BoTable: boTable,
+				WrID:    wrID,
+				TagID:   tag.ID,
+				Tag:     tagName,
+				MbID:    mbID,
+				RegDate: now,
+			}
+			if err := tx.Create(&log).Error; err != nil {
+				return err
+			}
+
+			// Update tag count and lastdate
+			tx.Model(&gnuboard.G5NaTag{}).Where("id = ?", tag.ID).Updates(map[string]interface{}{
+				"cnt":      gorm.Expr("(SELECT COUNT(*) FROM g5_na_tag_log WHERE tag_id = ?)", tag.ID),
+				"lastdate": now,
+			})
+		}
+
+		return nil
+	})
+}
+
+// DeletePostTags removes all tag logs for a post
+func (r *tagRepository) DeletePostTags(boTable string, wrID int) error {
+	return r.db.Where("bo_table = ? AND wr_id = ?", boTable, wrID).
+		Delete(&gnuboard.G5NaTagLog{}).Error
+}
+
+// firstChar returns the first character of a string for the idx field
+func firstChar(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return string(r)
+}

--- a/internal/repository/gnuboard/tag_repo.go
+++ b/internal/repository/gnuboard/tag_repo.go
@@ -59,57 +59,90 @@ func (r *tagRepository) GetPostsTagsBatch(boTable string, wrIDs []int) (map[int]
 
 // SetPostTags replaces all tags for a post
 func (r *tagRepository) SetPostTags(boTable string, wrID int, tags []string, mbID string) error {
+	// Normalize and deduplicate
+	normalized := make([]string, 0, len(tags))
+	seen := make(map[string]bool)
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t != "" && !seen[t] {
+			normalized = append(normalized, t)
+			seen[t] = true
+		}
+	}
+
 	return r.db.Transaction(func(tx *gorm.DB) error {
-		// Delete existing tag logs for this post
+		// 1. Get existing tag_ids before delete (for cnt update later)
+		var oldTagIDs []int
+		tx.Model(&gnuboard.G5NaTagLog{}).
+			Where("bo_table = ? AND wr_id = ?", boTable, wrID).
+			Pluck("tag_id", &oldTagIDs)
+
+		// 2. Delete existing tag logs
 		if err := tx.Where("bo_table = ? AND wr_id = ?", boTable, wrID).
 			Delete(&gnuboard.G5NaTagLog{}).Error; err != nil {
 			return err
 		}
 
+		if len(normalized) == 0 {
+			// Only need to update old tag counts
+			if len(oldTagIDs) > 0 {
+				tx.Exec("UPDATE g5_na_tag SET cnt = (SELECT COUNT(*) FROM g5_na_tag_log WHERE tag_id = g5_na_tag.id) WHERE id IN ?", oldTagIDs)
+			}
+			return nil
+		}
+
 		now := time.Now()
 
-		for _, tagName := range tags {
-			tagName = strings.TrimSpace(tagName)
-			if tagName == "" {
-				continue
-			}
+		// 3. Batch find existing tags (1 query instead of N)
+		var existingTags []gnuboard.G5NaTag
+		tx.Where("tag IN ? AND type = 0", normalized).Find(&existingTags)
+		tagMap := make(map[string]gnuboard.G5NaTag, len(existingTags))
+		for _, t := range existingTags {
+			tagMap[t.Tag] = t
+		}
 
-			// Find or create the tag in g5_na_tag
-			var tag gnuboard.G5NaTag
-			err := tx.Where("tag = ? AND type = 0", tagName).First(&tag).Error
-			if err != nil {
-				// Create new tag
+		// 4. Create missing tags + build log entries
+		var newTagIDs []int
+		for _, tagName := range normalized {
+			tag, exists := tagMap[tagName]
+			if !exists {
 				tag = gnuboard.G5NaTag{
-					Type:     0,
-					Idx:      firstChar(tagName),
-					Tag:      tagName,
-					Cnt:      0,
-					RegDate:  now,
-					LastDate: now,
+					Type: 0, Idx: firstChar(tagName), Tag: tagName,
+					Cnt: 0, RegDate: now, LastDate: now,
 				}
 				if err := tx.Create(&tag).Error; err != nil {
 					return err
 				}
+				tagMap[tagName] = tag
 			}
 
-			// Create tag log entry
-			log := gnuboard.G5NaTagLog{
-				BoTable: boTable,
-				WrID:    wrID,
-				TagID:   tag.ID,
-				Tag:     tagName,
-				MbID:    mbID,
-				RegDate: now,
+			// Insert tag log
+			logEntry := gnuboard.G5NaTagLog{
+				BoTable: boTable, WrID: wrID, TagID: tag.ID,
+				Tag: tagName, MbID: mbID, RegDate: now,
 			}
-			if err := tx.Create(&log).Error; err != nil {
+			if err := tx.Create(&logEntry).Error; err != nil {
 				return err
 			}
+			newTagIDs = append(newTagIDs, tag.ID)
+		}
 
-			// Update tag count and lastdate
-			tx.Model(&gnuboard.G5NaTag{}).Where("id = ?", tag.ID).Updates(map[string]interface{}{
-				"cnt":      gorm.Expr("(SELECT COUNT(*) FROM g5_na_tag_log WHERE tag_id = ?)", tag.ID),
-				"lastdate": now,
-			})
+		// 5. Batch update cnt + lastdate for all affected tags (1 query)
+		allAffectedIDs := make(map[int]bool)
+		for _, id := range oldTagIDs {
+			allAffectedIDs[id] = true
+		}
+		for _, id := range newTagIDs {
+			allAffectedIDs[id] = true
+		}
+		ids := make([]int, 0, len(allAffectedIDs))
+		for id := range allAffectedIDs {
+			ids = append(ids, id)
+		}
+		if len(ids) > 0 {
+			tx.Exec(`UPDATE g5_na_tag SET
+				cnt = (SELECT COUNT(*) FROM g5_na_tag_log WHERE tag_id = g5_na_tag.id),
+				lastdate = ? WHERE id IN ?`, now, ids)
 		}
 
 		return nil


### PR DESCRIPTION
## Summary
- 게시글 작성/수정 시 `tags` 배열을 받아 `g5_na_tag` + `g5_na_tag_log` 테이블에 저장
- 게시글 상세 조회 응답에 `tags` 필드 포함
- gnuboard nariya 태그 시스템과 100% 호환
- 프론트엔드 태그 입력 UI는 이미 구현 완료 (post-form.svelte + tag-input.svelte)

## 변경 파일
- `cmd/api/main.go` — CreatePost, UpdatePost, GetPost에 태그 로직 추가
- `internal/domain/gnuboard/tag.go` — G5NaTag, G5NaTagLog 모델
- `internal/repository/gnuboard/tag_repo.go` — TagRepository (CRUD)

## Test plan
- [ ] 글 작성 시 태그 입력 → DB 저장 확인
- [ ] 글 수정 시 태그 변경 → DB 업데이트 확인
- [ ] 글 상세 조회 시 tags 배열 응답 확인
- [ ] 기존 g5_na_tag 데이터(25,000건)와 충돌 없음 확인