### PR TITLE
feat: 알림 개인화 설정 API (#7786)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -738,11 +738,14 @@ func main() {
 		})
 		// v1 notifications (g5_na_noti)
 		notiRepo := gnurepo.NewNotiRepository(db)
-		notiHandler := handler.NewNotiHandler(notiRepo)
+		notiPrefRepo := gnurepo.NewNotiPreferenceRepository(db)
+		notiHandler := handler.NewNotiHandler(notiRepo, notiPrefRepo)
 		notiGroup := router.Group("/api/v1/notifications", middleware.JWTAuth(jwtManager))
 		notiGroup.GET("/unread-count", notiHandler.GetUnreadCount)
 		notiGroup.GET("", notiHandler.GetNotifications)
 		notiGroup.GET("/grouped", notiHandler.GetGroupedNotifications)
+		notiGroup.GET("/preferences", notiHandler.GetPreferences)
+		notiGroup.PUT("/preferences", notiHandler.UpdatePreferences)
 		notiGroup.POST("/:id/read", notiHandler.MarkAsRead)
 		notiGroup.POST("/read-all", notiHandler.MarkAllAsRead)
 		notiGroup.POST("/group/read", notiHandler.MarkGroupAsRead)
@@ -1882,6 +1885,9 @@ func main() {
 				var followerIDs []string
 				db.Table("g5_member_follow").Select("mb_id").Where("target_id = ?", mbID).Pluck("mb_id", &followerIDs)
 				for _, fid := range followerIDs {
+					if pref, _ := notiPrefRepo.Get(fid); !pref.NotiFollow {
+						continue
+					}
 					_ = notiRepo.Create(&gnurepo.Notification{
 						PhToCase: "follow", PhFromCase: "write", BoTable: slug,
 						WrID: post.WrID, MbID: fid, RelMbID: mbID,
@@ -1904,6 +1910,9 @@ func main() {
 				for _, sid := range subscriberIDs {
 					if followerSet[sid] {
 						continue // 이미 팔로워 알림 받음
+					}
+					if pref, _ := notiPrefRepo.Get(sid); !pref.NotiFollow {
+						continue
 					}
 					_ = notiRepo.Create(&gnurepo.Notification{
 						PhToCase: "subscribe", PhFromCase: "write", BoTable: slug,
@@ -2121,15 +2130,38 @@ func main() {
 				if req.ParentID != nil && *req.ParentID > 0 {
 					var parentAuthorMbID string
 					if err := db.Table(tableName).Select("mb_id").Where("wr_id = ?", *req.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != mbID {
+						if pref, _ := notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
+							_ = notiRepo.Create(&gnurepo.Notification{
+								PhToCase:      "comment_reply",
+								PhFromCase:    "comment",
+								BoTable:       slug,
+								WrID:          comment.WrID,
+								MbID:          parentAuthorMbID,
+								RelMbID:       mbID,
+								RelMbNick:     authorName,
+								RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", authorName),
+								RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
+								PhReaded:      "N",
+								PhDatetime:    now,
+								ParentSubject: postAuthor.WrSubject,
+								WrParent:      postID,
+							})
+						}
+					}
+				}
+
+				// 게시글 작성자에게 알림 (자기 댓글은 제외)
+				if postAuthor.MbID != mbID {
+					if pref, _ := notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
 						_ = notiRepo.Create(&gnurepo.Notification{
-							PhToCase:      "comment_reply",
+							PhToCase:      "comment",
 							PhFromCase:    "comment",
 							BoTable:       slug,
 							WrID:          comment.WrID,
-							MbID:          parentAuthorMbID,
+							MbID:          postAuthor.MbID,
 							RelMbID:       mbID,
 							RelMbNick:     authorName,
-							RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", authorName),
+							RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", authorName),
 							RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
 							PhReaded:      "N",
 							PhDatetime:    now,
@@ -2137,25 +2169,6 @@ func main() {
 							WrParent:      postID,
 						})
 					}
-				}
-
-				// 게시글 작성자에게 알림 (자기 댓글은 제외)
-				if postAuthor.MbID != mbID {
-					_ = notiRepo.Create(&gnurepo.Notification{
-						PhToCase:      "comment",
-						PhFromCase:    "comment",
-						BoTable:       slug,
-						WrID:          comment.WrID,
-						MbID:          postAuthor.MbID,
-						RelMbID:       mbID,
-						RelMbNick:     authorName,
-						RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", authorName),
-						RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
-						PhReaded:      "N",
-						PhDatetime:    now,
-						ParentSubject: postAuthor.WrSubject,
-						WrParent:      postID,
-					})
 				}
 			}()
 

--- a/internal/handler/noti_handler.go
+++ b/internal/handler/noti_handler.go
@@ -17,12 +17,13 @@ import (
 
 // NotiHandler handles /api/v1/notifications endpoints using g5_na_noti
 type NotiHandler struct {
-	repo gnurepo.NotiRepository
+	repo     gnurepo.NotiRepository
+	prefRepo gnurepo.NotiPreferenceRepository
 }
 
 // NewNotiHandler creates a new NotiHandler
-func NewNotiHandler(repo gnurepo.NotiRepository) *NotiHandler {
-	return &NotiHandler{repo: repo}
+func NewNotiHandler(repo gnurepo.NotiRepository, prefRepo gnurepo.NotiPreferenceRepository) *NotiHandler {
+	return &NotiHandler{repo: repo, prefRepo: prefRepo}
 }
 
 // v1NotificationResponse matches frontend Notification type
@@ -393,6 +394,104 @@ func (h *NotiHandler) MarkGroupAsRead(c *gin.Context) {
 		return
 	}
 	common.V2Success(c, gin.H{"message": "그룹 읽음 처리 완료"})
+}
+
+// notiPreferenceResponse is the response for notification preferences
+type notiPreferenceResponse struct {
+	NotiComment   bool `json:"noti_comment"`
+	NotiReply     bool `json:"noti_reply"`
+	NotiMention   bool `json:"noti_mention"`
+	NotiLike      bool `json:"noti_like"`
+	NotiFollow    bool `json:"noti_follow"`
+	LikeThreshold int  `json:"like_threshold"`
+}
+
+// GetPreferences handles GET /api/v1/notifications/preferences
+func (h *NotiHandler) GetPreferences(c *gin.Context) {
+	mbID := middleware.GetUserID(c)
+	if mbID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	pref, err := h.prefRepo.Get(mbID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "알림 설정 조회 실패", err)
+		return
+	}
+
+	common.V2Success(c, notiPreferenceResponse{
+		NotiComment:   pref.NotiComment,
+		NotiReply:     pref.NotiReply,
+		NotiMention:   pref.NotiMention,
+		NotiLike:      pref.NotiLike,
+		NotiFollow:    pref.NotiFollow,
+		LikeThreshold: pref.LikeThreshold,
+	})
+}
+
+// UpdatePreferences handles PUT /api/v1/notifications/preferences
+func (h *NotiHandler) UpdatePreferences(c *gin.Context) {
+	mbID := middleware.GetUserID(c)
+	if mbID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	var req struct {
+		NotiComment   *bool `json:"noti_comment"`
+		NotiReply     *bool `json:"noti_reply"`
+		NotiMention   *bool `json:"noti_mention"`
+		NotiLike      *bool `json:"noti_like"`
+		NotiFollow    *bool `json:"noti_follow"`
+		LikeThreshold *int  `json:"like_threshold"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
+		return
+	}
+
+	pref, err := h.prefRepo.Get(mbID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "알림 설정 조회 실패", err)
+		return
+	}
+
+	if req.NotiComment != nil {
+		pref.NotiComment = *req.NotiComment
+	}
+	if req.NotiReply != nil {
+		pref.NotiReply = *req.NotiReply
+	}
+	if req.NotiMention != nil {
+		pref.NotiMention = *req.NotiMention
+	}
+	if req.NotiLike != nil {
+		pref.NotiLike = *req.NotiLike
+	}
+	if req.NotiFollow != nil {
+		pref.NotiFollow = *req.NotiFollow
+	}
+	if req.LikeThreshold != nil {
+		if *req.LikeThreshold < 1 {
+			*req.LikeThreshold = 1
+		}
+		pref.LikeThreshold = *req.LikeThreshold
+	}
+
+	if err := h.prefRepo.Upsert(pref); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "알림 설정 저장 실패", err)
+		return
+	}
+
+	common.V2Success(c, notiPreferenceResponse{
+		NotiComment:   pref.NotiComment,
+		NotiReply:     pref.NotiReply,
+		NotiMention:   pref.NotiMention,
+		NotiLike:      pref.NotiLike,
+		NotiFollow:    pref.NotiFollow,
+		LikeThreshold: pref.LikeThreshold,
+	})
 }
 
 // DeleteGroup handles DELETE /api/v1/notifications/group

--- a/internal/repository/gnuboard/noti_preference.go
+++ b/internal/repository/gnuboard/noti_preference.go
@@ -1,0 +1,70 @@
+package gnuboard
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// NotiPreference represents a row in g5_noti_preference table
+type NotiPreference struct {
+	MbID          string    `gorm:"column:mb_id;primaryKey"`
+	NotiComment   bool      `gorm:"column:noti_comment;default:1"`
+	NotiReply     bool      `gorm:"column:noti_reply;default:1"`
+	NotiMention   bool      `gorm:"column:noti_mention;default:1"`
+	NotiLike      bool      `gorm:"column:noti_like;default:1"`
+	NotiFollow    bool      `gorm:"column:noti_follow;default:1"`
+	LikeThreshold int       `gorm:"column:like_threshold;default:1"`
+	UpdatedAt     time.Time `gorm:"column:updated_at"`
+}
+
+// TableName returns the g5_noti_preference table name
+func (NotiPreference) TableName() string { return "g5_noti_preference" }
+
+// NotiPreferenceRepository handles CRUD for notification preferences
+type NotiPreferenceRepository interface {
+	Get(mbID string) (*NotiPreference, error)
+	Upsert(pref *NotiPreference) error
+}
+
+type notiPreferenceRepository struct {
+	db *gorm.DB
+}
+
+// NewNotiPreferenceRepository creates a new NotiPreferenceRepository
+func NewNotiPreferenceRepository(db *gorm.DB) NotiPreferenceRepository {
+	return &notiPreferenceRepository{db: db}
+}
+
+// Get retrieves a user's notification preferences. Returns defaults if not found.
+func (r *notiPreferenceRepository) Get(mbID string) (*NotiPreference, error) {
+	var pref NotiPreference
+	err := r.db.Where("mb_id = ?", mbID).First(&pref).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return &NotiPreference{
+				MbID:          mbID,
+				NotiComment:   true,
+				NotiReply:     true,
+				NotiMention:   true,
+				NotiLike:      true,
+				NotiFollow:    true,
+				LikeThreshold: 1,
+			}, nil
+		}
+		return nil, err
+	}
+	return &pref, nil
+}
+
+// Upsert inserts or updates a user's notification preferences
+func (r *notiPreferenceRepository) Upsert(pref *NotiPreference) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "mb_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"noti_comment", "noti_reply", "noti_mention",
+			"noti_like", "noti_follow", "like_threshold",
+		}),
+	}).Create(pref).Error
+}


### PR DESCRIPTION
## Summary
- `g5_noti_preference` 테이블 기반 알림 종류별 수신 ON/OFF 설정
- `GET/PUT /api/v1/notifications/preferences` 엔드포인트 추가
- 알림 생성 시 수신자 preference 체크 (댓글, 답글, 팔로우/구독)
- 추천 임계값(`like_threshold`) 설정 지원

## Test plan
- [ ] `GET /api/v1/notifications/preferences` 기본값 반환 확인
- [ ] `PUT /api/v1/notifications/preferences` 설정 저장/조회 확인
- [ ] 댓글 알림 OFF 시 댓글 작성해도 알림 미생성 확인
- [ ] 팔로우 알림 OFF 시 팔로워 글 작성해도 알림 미생성 확인