### PR TITLE
perf: 백엔드 Docker 빌드 속도 최적화

### DIFF
--- a/.github/workflows/deploy-ecr.yml
+++ b/.github/workflows/deploy-ecr.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build-and-deploy:
     name: Build & Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: inputs.confirm == 'deploy'
 
     steps:
@@ -44,9 +44,6 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build-and-push:
     name: Build & Push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,13 +26,20 @@ jobs:
         with:
           go-version: '1.24'
 
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run tests
         env:
           CGO_ENABLED: "1"
         run: go test -v $(go list ./... | grep -v /plugins/ | grep -v /tests/integration)
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,8 +57,10 @@ jobs:
           context: .
           file: deployments/docker/api.Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-api:latest
+          cache-from: type=gha,scope=ghcr-api
+          cache-to: type=gha,mode=max,scope=ghcr-api
 
       - name: Build and push Gateway
         uses: docker/build-push-action@v6
@@ -59,8 +68,10 @@ jobs:
           context: .
           file: deployments/docker/gateway.Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-gateway:latest
+          cache-from: type=gha,scope=ghcr-gateway
+          cache-to: type=gha,mode=max,scope=ghcr-gateway
 
   deploy:
     name: Deploy to Dev Server


### PR DESCRIPTION
## 요약

Docker 빌드 워크플로우의 불필요한 오버헤드를 제거하여 빌드 속도를 개선합니다.

### 변경사항

**ghcr-deploy.yml (Dev 배포)**
- `ubuntu-latest` (x86) → `ubuntu-24.04-arm` (ARM64 네이티브) 러너로 변경
- QEMU 에뮬레이션 스텝 제거 — 네이티브 빌드이므로 불필요
- `linux/amd64` 빌드 제거 — K8s 클러스터가 ARM64 단일 노드이므로 amd64 이미지 불필요
- Go 모듈 캐시 추가 (`actions/cache@v4`) — 테스트 실행 시 의존성 다운로드 시간 절약
- GHA 빌드 캐시 추가 (`cache-from`/`cache-to`) — Docker 레이어 캐시로 반복 빌드 속도 향상

**deploy-ecr.yml (Prod 배포)**
- `ubuntu-latest` (x86) → `ubuntu-24.04-arm` (ARM64 네이티브) 러너로 변경
- QEMU 스텝 제거 — 이미 arm64만 빌드하고 있었으나 QEMU 셋업이 남아있던 것 정리

### 기대 효과

- QEMU 크로스 컴파일 제거로 빌드 시간 대폭 단축 (특히 Go 컴파일)
- amd64 중복 빌드 제거로 GHCR 빌드 시간 약 50% 절감
- GHA 캐시 활용으로 반복 빌드 시 추가 시간 절약