### PR TITLE
fix: Go 버전 1.25로 업데이트

### DIFF
--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Cache Go modules
         uses: actions/cache@v4


### PR DESCRIPTION
go.mod에서 go 1.25.0을 요구하지만 ghcr-deploy.yml 워크플로우에서 go 1.24를 사용하여 빌드가 실패하는 문제를 수정합니다.

- `go-version: '1.24'` → `go-version: '1.25'`