### PR TITLE
fix: Gateway Dockerfile Go 1.25로 업데이트

### DIFF
--- a/deployments/docker/gateway.Dockerfile
+++ b/deployments/docker/gateway.Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - cross-compile without QEMU emulation
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Gateway Dockerfile의 Go 버전을 1.24에서 1.25로 업데이트합니다.