### PR TITLE
feat: PHP 크론잡 → Go 내부 API 전환

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ DB_NAME=damoang
 # --- JWT (required) ---
 JWT_SECRET=your-jwt-secret-key-change-me
 
+# --- Cron (internal endpoints) ---
+CRON_SECRET=your-cron-secret-key
+
 # --- Redis (optional) ---
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -33,6 +33,7 @@ import (
 	v2routes "github.com/damoang/angple-backend/internal/routes/v2"
 	"github.com/damoang/angple-backend/internal/service"
 	v2svc "github.com/damoang/angple-backend/internal/service/v2"
+	"github.com/damoang/angple-backend/internal/cron"
 	"github.com/damoang/angple-backend/internal/worker"
 	"github.com/damoang/angple-backend/internal/ws"
 	pkgcache "github.com/damoang/angple-backend/pkg/cache"
@@ -4068,6 +4069,14 @@ func main() {
 
 		pluginManager.StartScheduler()
 		pkglogger.Info("Plugin Store & Marketplace initialized")
+
+		// Internal cron endpoints (curl-based cron jobs)
+		cronHandler := cron.NewHandler(db)
+		cronGroup := router.Group("/api/internal/cron")
+		cronGroup.POST("/member-lock-release", cronHandler.MemberLockRelease)
+		cronGroup.POST("/update-member-levels", cronHandler.UpdateMemberLevels)
+		cronGroup.POST("/process-approved-reports", cronHandler.ProcessApprovedReports)
+		cronGroup.POST("/update-report-pattern", cronHandler.UpdateReportPattern)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(gnuWriteRepo, scheduledDeleteRepo)

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -1,0 +1,102 @@
+package cron
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// Handler handles internal cron job endpoints
+type Handler struct {
+	db     *gorm.DB
+	secret string
+}
+
+// NewHandler creates a new cron Handler
+func NewHandler(db *gorm.DB) *Handler {
+	secret := os.Getenv("CRON_SECRET")
+	if secret == "" {
+		secret = "angple_cron_2024"
+	}
+	return &Handler{db: db, secret: secret}
+}
+
+// verifySecret checks the secret query parameter
+func (h *Handler) verifySecret(c *gin.Context) bool {
+	if c.Query("secret") != h.secret {
+		c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "invalid secret"})
+		return false
+	}
+	return true
+}
+
+// MemberLockRelease handles POST /api/internal/cron/member-lock-release
+func (h *Handler) MemberLockRelease(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runMemberLockRelease(h.db)
+	if err != nil {
+		log.Printf("[Cron:member-lock-release] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:member-lock-release] released %d members: %v", result.ReleasedCount, result.ReleasedIDs)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+// UpdateMemberLevels handles POST /api/internal/cron/update-member-levels
+func (h *Handler) UpdateMemberLevels(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runUpdateMemberLevels(h.db)
+	if err != nil {
+		log.Printf("[Cron:update-member-levels] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:update-member-levels] updated %d members", result.UpdatedCount)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+// ProcessApprovedReports handles POST /api/internal/cron/process-approved-reports
+func (h *Handler) ProcessApprovedReports(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runProcessApprovedReports(h.db)
+	if err != nil {
+		log.Printf("[Cron:process-approved-reports] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:process-approved-reports] processed %d, errors %d", result.Processed, result.Errors)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+// UpdateReportPattern handles POST /api/internal/cron/update-report-pattern
+func (h *Handler) UpdateReportPattern(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runUpdateReportPattern(h.db)
+	if err != nil {
+		log.Printf("[Cron:update-report-pattern] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:update-report-pattern] report generated: %s", result.Subject)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}

--- a/internal/cron/member_levels.go
+++ b/internal/cron/member_levels.go
@@ -1,0 +1,196 @@
+package cron
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// MemberLevelsResult contains the result of member levels update
+type MemberLevelsResult struct {
+	UpdatedCount    int      `json:"updated_count"`
+	VisibilityCount int      `json:"visibility_count"`
+	Messages        []string `json:"messages"`
+	ExecutedAt      string   `json:"executed_at"`
+}
+
+type promotionRow struct {
+	AdvertiserName string `gorm:"column:advertiser_name"`
+	MemberID       string `gorm:"column:member_id"`
+	StartDate      string `gorm:"column:start_date"`
+	EndDate        string `gorm:"column:end_date"`
+}
+
+// runUpdateMemberLevels updates advertiser member levels based on active dates
+func runUpdateMemberLevels(db *gorm.DB) (*MemberLevelsResult, error) {
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	// promotions 테이블에서 광고주 목록 조회 (같은 DB)
+	var promotions []promotionRow
+	if err := db.Table("promotions").
+		Select("advertiser_name, member_id, start_date, end_date").
+		Where("is_active = ?", true).
+		Find(&promotions).Error; err != nil {
+		return nil, fmt.Errorf("promotions 조회 실패: %w", err)
+	}
+
+	result := &MemberLevelsResult{
+		ExecutedAt: now.Format("2006-01-02 15:04:05"),
+	}
+
+	if len(promotions) == 0 {
+		result.Messages = append(result.Messages, "처리할 광고주 데이터가 없습니다")
+		return result, nil
+	}
+
+	for _, promo := range promotions {
+		if promo.MemberID == "" {
+			continue
+		}
+
+		// 현재 회원 레벨 조회
+		var currentLevel int
+		err := db.Table("g5_member").
+			Select("mb_level").
+			Where("mb_id = ?", promo.MemberID).
+			Scan(&currentLevel).Error
+		if err != nil {
+			result.Messages = append(result.Messages, fmt.Sprintf("회원 ID '%s'를 찾을 수 없습니다", promo.MemberID))
+			continue
+		}
+
+		// 기간에 따른 권한 결정
+		newLevel := determineMemberLevel(promo.StartDate, promo.EndDate, today)
+
+		// 권한 변경이 필요한 경우만 업데이트
+		if currentLevel != newLevel {
+			if err := db.Table("g5_member").
+				Where("mb_id = ?", promo.MemberID).
+				Update("mb_level", newLevel).Error; err != nil {
+				result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): 권한 업데이트 실패", promo.AdvertiserName, promo.MemberID))
+				continue
+			}
+			result.UpdatedCount++
+			status := getStatusText(promo.StartDate, promo.EndDate, today)
+			result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): 권한 %d → %d (%s)", promo.AdvertiserName, promo.MemberID, currentLevel, newLevel, status))
+		}
+
+		// 게시글 비공개/공개 처리
+		isExpired := promo.EndDate != "" && today > promo.EndDate
+		isActive := !isExpired &&
+			(promo.StartDate == "" || today >= promo.StartDate) &&
+			(promo.EndDate == "" || today <= promo.EndDate)
+
+		if isExpired {
+			affected := updatePostVisibility(db, promo.MemberID, true)
+			if affected > 0 {
+				result.VisibilityCount += int(affected)
+				result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): %d개 게시글 비공개 처리", promo.AdvertiserName, promo.MemberID, affected))
+			}
+		} else if isActive {
+			affected := updatePostVisibility(db, promo.MemberID, false)
+			if affected > 0 {
+				result.VisibilityCount += int(affected)
+				result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): %d개 게시글 공개 전환", promo.AdvertiserName, promo.MemberID, affected))
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// determineMemberLevel determines member level based on start/end dates
+func determineMemberLevel(startDate, endDate, today string) int {
+	// 기간이 설정되지 않은 경우 기본 권한 유지
+	if startDate == "" && endDate == "" {
+		return 2
+	}
+
+	// 시작일과 종료일이 모두 설정된 경우
+	if startDate != "" && endDate != "" {
+		if today >= startDate && today <= endDate {
+			return 5
+		}
+		return 2
+	}
+
+	// 시작일만 설정된 경우
+	if startDate != "" && endDate == "" {
+		if today >= startDate {
+			return 5
+		}
+		return 2
+	}
+
+	// 종료일만 설정된 경우
+	if startDate == "" && endDate != "" {
+		if today <= endDate {
+			return 5
+		}
+		return 2
+	}
+
+	return 2
+}
+
+// getStatusText returns human-readable status text
+func getStatusText(startDate, endDate, today string) string {
+	if startDate == "" && endDate == "" {
+		return "기간 미설정"
+	}
+	if startDate != "" && endDate != "" {
+		if today < startDate {
+			return "대기중"
+		} else if today > endDate {
+			return "만료됨"
+		}
+		return "활성중"
+	}
+	if startDate != "" {
+		if today >= startDate {
+			return "활성중"
+		}
+		return "대기중"
+	}
+	if endDate != "" {
+		if today <= endDate {
+			return "활성중"
+		}
+		return "만료됨"
+	}
+	return "기간 불완전"
+}
+
+// updatePostVisibility adds or removes 'secret' from wr_option in g5_write_promotion
+func updatePostVisibility(db *gorm.DB, memberID string, makeSecret bool) int64 {
+	var result *gorm.DB
+
+	if makeSecret {
+		// 비공개 처리: secret 추가
+		result = db.Exec(`
+			UPDATE g5_write_promotion
+			SET wr_option = CASE
+				WHEN wr_option = '' THEN 'secret'
+				WHEN wr_option NOT LIKE '%secret%' THEN CONCAT(wr_option, ',secret')
+				ELSE wr_option
+			END
+			WHERE mb_id = ? AND wr_option NOT LIKE '%secret%'
+		`, memberID)
+	} else {
+		// 공개 처리: secret 제거
+		result = db.Exec(`
+			UPDATE g5_write_promotion
+			SET wr_option = TRIM(BOTH ',' FROM
+				REPLACE(REPLACE(REPLACE(wr_option, ',secret', ''), 'secret,', ''), 'secret', '')
+			)
+			WHERE mb_id = ? AND wr_option LIKE '%secret%'
+		`, memberID)
+	}
+
+	if result.Error != nil {
+		return 0
+	}
+	return result.RowsAffected
+}

--- a/internal/cron/member_lock.go
+++ b/internal/cron/member_lock.go
@@ -1,0 +1,42 @@
+package cron
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// MemberLockResult contains the result of member lock release
+type MemberLockResult struct {
+	ReleasedCount int      `json:"released_count"`
+	ReleasedIDs   []string `json:"released_ids"`
+	ExecutedAt    string   `json:"executed_at"`
+}
+
+// runMemberLockRelease releases locked members (mb_4 = 'lock' → '')
+func runMemberLockRelease(db *gorm.DB) (*MemberLockResult, error) {
+	now := time.Now()
+
+	// 1. lock이 걸린 회원 ID 조회
+	var lockedIDs []string
+	if err := db.Table("g5_member").
+		Where("mb_4 = ?", "lock").
+		Pluck("mb_id", &lockedIDs).Error; err != nil {
+		return nil, err
+	}
+
+	// 2. lock 해제
+	if len(lockedIDs) > 0 {
+		if err := db.Table("g5_member").
+			Where("mb_4 = ?", "lock").
+			Update("mb_4", "").Error; err != nil {
+			return nil, err
+		}
+	}
+
+	return &MemberLockResult{
+		ReleasedCount: len(lockedIDs),
+		ReleasedIDs:   lockedIDs,
+		ExecutedAt:    now.Format("2006-01-02 15:04:05"),
+	}, nil
+}

--- a/internal/cron/report_pattern.go
+++ b/internal/cron/report_pattern.go
@@ -1,0 +1,548 @@
+package cron
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ReportPatternResult contains the result of report pattern analysis
+type ReportPatternResult struct {
+	Subject    string `json:"subject"`
+	DateFrom   string `json:"date_from"`
+	DateTo     string `json:"date_to"`
+	Reports    int    `json:"total_reports"`
+	Reporters  int    `json:"unique_reporters"`
+	ExecutedAt string `json:"executed_at"`
+}
+
+// reportStats holds all collected statistics
+type reportStats struct {
+	TotalReports     int                       `json:"total_reports"`
+	CompletedReports int                       `json:"completed_reports"`
+	ClaimReports     int                       `json:"claim_reports"`
+	ReportCount      int                       `json:"report_count"`
+	ReportMonth      int                       `json:"report_month"`
+	ReporterCount    int                       `json:"reporter_count"`
+	TotalCases       int                       `json:"total_cases"`
+	TotalMonthCases  int                       `json:"total_month_cases"`
+	ReportTypes      map[string]int            `json:"report_types"`
+	BoardStats       []boardStat               `json:"board_stats"`
+	DailyStats       map[string]dailyStat      `json:"daily_stats"`
+	WeeklyStats      map[string]weeklyStat     `json:"weekly_stats"`
+	TopReporters     []topReporter             `json:"top_reporters"`
+	PatternAnalysis  []patternItem             `json:"pattern_analysis"`
+	PatternSummary   map[string]interface{}    `json:"pattern_summary"`
+	DateFrom         string                    `json:"date_from"`
+	DateTo           string                    `json:"date_to"`
+	PeriodDays       int                       `json:"period_days"`
+	GeneratedAt      string                    `json:"generated_at"`
+}
+
+type boardStat struct {
+	Name  string `json:"name" gorm:"column:board_name"`
+	Count int    `json:"count" gorm:"column:board_count"`
+}
+
+type dailyStat struct {
+	Reports  int `json:"reports"`
+	Posts    int `json:"posts"`
+	Comments int `json:"comments"`
+}
+
+type weeklyStat struct {
+	Reports   int `json:"reports"`
+	Processed int `json:"processed"`
+	Posts     int `json:"posts"`
+	Comments  int `json:"comments"`
+}
+
+type topReporter struct {
+	MbID        string `json:"mb_id" gorm:"column:mb_id"`
+	MbNick      string `json:"mb_nick" gorm:"column:mb_nick"`
+	MbName      string `json:"mb_name" gorm:"column:mb_name"`
+	ReportCount int    `json:"report_count" gorm:"column:report_count"`
+}
+
+type patternItem struct {
+	SgParent      int    `json:"sg_parent" gorm:"column:sg_parent"`
+	SgTable       string `json:"sg_table" gorm:"column:sg_table"`
+	BoardName     string `json:"board_name" gorm:"column:board_name"`
+	ReportCount   int    `json:"report_count" gorm:"column:report_count"`
+	ReporterCount int    `json:"reporter_count" gorm:"column:reporter_count"`
+}
+
+const singoTypeCondition = "sg_type IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40)"
+
+// runUpdateReportPattern generates a weekly report pattern analysis
+func runUpdateReportPattern(db *gorm.DB) (*ReportPatternResult, error) {
+	now := time.Now()
+
+	// 지난 주 일요일~토요일 계산
+	startDate, endDate := getLastWeekRange(now)
+
+	// 중복 체크
+	startFormatted := formatKoreanDate(startDate)
+	endFormatted := formatKoreanDate(endDate)
+	subject := fmt.Sprintf("운영 현황 보고서 (%s ~ %s)", startFormatted, endFormatted)
+
+	var dupCount int64
+	db.Table("g5_write_report").Where("wr_subject = ?", subject).Count(&dupCount)
+	if dupCount > 0 {
+		return &ReportPatternResult{
+			Subject:    subject,
+			DateFrom:   startDate,
+			DateTo:     endDate,
+			ExecutedAt: now.Format("2006-01-02 15:04:05"),
+		}, fmt.Errorf("해당 기간의 보고서가 이미 존재합니다")
+	}
+
+	// 통계 수집
+	stats := collectStats(db, startDate, endDate, now)
+
+	// 보고서 저장
+	if err := saveReportPost(db, stats, subject, now); err != nil {
+		return nil, fmt.Errorf("보고서 저장 실패: %w", err)
+	}
+
+	return &ReportPatternResult{
+		Subject:    subject,
+		DateFrom:   startDate,
+		DateTo:     endDate,
+		Reports:    stats.TotalReports,
+		Reporters:  stats.ReporterCount,
+		ExecutedAt: now.Format("2006-01-02 15:04:05"),
+	}, nil
+}
+
+// getLastWeekRange calculates last week's Sunday~Saturday range
+func getLastWeekRange(now time.Time) (string, string) {
+	yesterday := now.AddDate(0, 0, -1)
+	daysSinceSunday := int(yesterday.Weekday()) // 0=Sunday
+	lastSunday := yesterday.AddDate(0, 0, -daysSinceSunday)
+	lastSaturday := lastSunday.AddDate(0, 0, 6)
+
+	return lastSunday.Format("2006-01-02"), lastSaturday.Format("2006-01-02")
+}
+
+// formatKoreanDate formats "2006-01-02" to "2006년 01월 02일"
+func formatKoreanDate(dateStr string) string {
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return dateStr
+	}
+	return fmt.Sprintf("%d년 %02d월 %02d일", t.Year(), t.Month(), t.Day())
+}
+
+// collectStats gathers all statistics for the report
+func collectStats(db *gorm.DB, startDate, endDate string, now time.Time) *reportStats {
+	startDT := startDate + " 00:00:00"
+	endDT := endDate + " 23:59:59"
+
+	stats := &reportStats{
+		DateFrom:    startDate,
+		DateTo:      endDate,
+		GeneratedAt: now.Format("2006-01-02 15:04:05"),
+	}
+
+	// 기간 일수 계산
+	start, _ := time.Parse("2006-01-02", startDate)
+	end, _ := time.Parse("2006-01-02", endDate)
+	stats.PeriodDays = int(end.Sub(start).Hours()/24) + 1
+
+	// 1. 기본 통계
+	var basicStats struct {
+		TotalReports    int `gorm:"column:total_reports"`
+		UniqueReporters int `gorm:"column:unique_reporters"`
+		PendingReports  int `gorm:"column:pending_reports"`
+	}
+	db.Raw(fmt.Sprintf(`
+		SELECT
+			COUNT(DISTINCT CONCAT(sg_table, '_', sg_id, '_', mb_id)) as total_reports,
+			COUNT(DISTINCT mb_id) as unique_reporters,
+			SUM(CASE WHEN sg_flag = 0 THEN 1 ELSE 0 END) as pending_reports
+		FROM g5_na_singo
+		WHERE (%s)
+		AND sg_time >= ? AND sg_time <= ?
+	`, singoTypeCondition), startDT, endDT).Scan(&basicStats)
+
+	stats.TotalReports = basicStats.TotalReports
+	stats.ReporterCount = basicStats.UniqueReporters
+
+	// 2. 신고된 글/댓글 수
+	var uniqueCounts struct {
+		UniquePosts    int `gorm:"column:unique_posts"`
+		UniqueComments int `gorm:"column:unique_comments"`
+	}
+	db.Raw(fmt.Sprintf(`
+		SELECT
+			COUNT(DISTINCT CASE WHEN (sg_parent = 0 OR sg_parent = sg_id) THEN CONCAT(sg_table, '_', sg_id, '_', mb_id) END) as unique_posts,
+			COUNT(DISTINCT CASE WHEN (sg_parent != 0 AND sg_parent != sg_id) THEN CONCAT(sg_table, '_', sg_id, '_', mb_id) END) as unique_comments
+		FROM g5_na_singo
+		WHERE (%s)
+		AND sg_time >= ? AND sg_time <= ?
+	`, singoTypeCondition), startDT, endDT).Scan(&uniqueCounts)
+
+	stats.ReportCount = uniqueCounts.UniquePosts
+	stats.ReportMonth = uniqueCounts.UniqueComments
+
+	// 3. 처리완료/소명 건수
+	db.Raw("SELECT COUNT(*) FROM g5_write_disciplinelog WHERE wr_is_comment = 0 AND wr_datetime >= ? AND wr_datetime <= ?",
+		startDT, endDT).Scan(&stats.CompletedReports)
+	db.Raw("SELECT COUNT(*) FROM g5_write_claim WHERE wr_is_comment = 0 AND wr_datetime >= ? AND wr_datetime <= ?",
+		startDT, endDT).Scan(&stats.ClaimReports)
+
+	// 4. 전체 게시글/댓글 수
+	var postCounts struct {
+		TotalPosts    int `gorm:"column:total_posts"`
+		TotalComments int `gorm:"column:total_comments"`
+	}
+	db.Raw(`
+		SELECT
+			COALESCE(SUM(IF(wr_id=wr_parent,1,0)), 0) as total_posts,
+			COALESCE(SUM(IF(wr_id=wr_parent,0,1)), 0) as total_comments
+		FROM g5_board_new
+		WHERE bn_datetime >= ? AND bn_datetime <= ?
+	`, startDT, endDT).Scan(&postCounts)
+
+	stats.TotalCases = postCounts.TotalPosts
+	stats.TotalMonthCases = postCounts.TotalComments
+
+	// 5. 신고 유형별 통계 (상위 10)
+	stats.ReportTypes = make(map[string]int)
+	type typeRow struct {
+		SgType    int `gorm:"column:sg_type"`
+		TypeCount int `gorm:"column:type_count"`
+	}
+	var typeRows []typeRow
+	db.Raw(fmt.Sprintf(`
+		SELECT sg_type, COUNT(*) as type_count
+		FROM (
+			SELECT DISTINCT sg_type, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo
+			WHERE (%s)
+			AND sg_time >= ? AND sg_time <= ?
+		) as unique_type_reports
+		GROUP BY sg_type
+		ORDER BY type_count DESC
+		LIMIT 10
+	`, singoTypeCondition), startDT, endDT).Scan(&typeRows)
+
+	singoTypes := getSingoTypes()
+	for _, row := range typeRows {
+		label := "기타"
+		if l, ok := singoTypes[row.SgType]; ok {
+			label = l
+		}
+		stats.ReportTypes[label] = row.TypeCount
+	}
+
+	// 6. 게시판별 통계 (상위 10)
+	db.Raw(fmt.Sprintf(`
+		SELECT
+			COUNT(*) as board_count,
+			COALESCE(b.bo_subject, unique_board_reports.sg_table) as board_name
+		FROM (
+			SELECT DISTINCT sg_table, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo
+			WHERE (%s)
+			AND sg_time >= ? AND sg_time <= ?
+		) as unique_board_reports
+		LEFT JOIN g5_board b ON unique_board_reports.sg_table = b.bo_table
+		GROUP BY unique_board_reports.sg_table
+		ORDER BY board_count DESC
+		LIMIT 10
+	`, singoTypeCondition), startDT, endDT).Scan(&stats.BoardStats)
+
+	// 7. 일별 통계
+	stats.DailyStats = make(map[string]dailyStat)
+	current := start
+	for !current.After(end) {
+		stats.DailyStats[current.Format("2006-01-02")] = dailyStat{}
+		current = current.AddDate(0, 0, 1)
+	}
+
+	// 일별 신고 데이터
+	type dailyReportRow struct {
+		ReportDate   string `gorm:"column:report_date"`
+		DailyReports int    `gorm:"column:daily_reports"`
+	}
+	var dailyReports []dailyReportRow
+	db.Raw(fmt.Sprintf(`
+		SELECT report_date, COUNT(*) as daily_reports
+		FROM (
+			SELECT DISTINCT DATE(sg_time) as report_date, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo
+			WHERE (%s)
+			AND sg_time >= ? AND sg_time <= ?
+		) as unique_daily_reports
+		GROUP BY report_date
+	`, singoTypeCondition), startDT, endDT).Scan(&dailyReports)
+
+	for _, row := range dailyReports {
+		if ds, ok := stats.DailyStats[row.ReportDate]; ok {
+			ds.Reports = row.DailyReports
+			stats.DailyStats[row.ReportDate] = ds
+		}
+	}
+
+	// 일별 게시글/댓글 데이터
+	type dailyPostRow struct {
+		PostDate      string `gorm:"column:post_date"`
+		DailyPosts    int    `gorm:"column:daily_posts"`
+		DailyComments int    `gorm:"column:daily_comments"`
+	}
+	var dailyPosts []dailyPostRow
+	db.Raw(`
+		SELECT DATE(bn_datetime) as post_date,
+			SUM(CASE WHEN wr_id=wr_parent THEN 1 ELSE 0 END) as daily_posts,
+			SUM(CASE WHEN wr_id!=wr_parent THEN 1 ELSE 0 END) as daily_comments
+		FROM g5_board_new
+		WHERE bn_datetime >= ? AND bn_datetime <= ?
+		GROUP BY DATE(bn_datetime)
+	`, startDT, endDT).Scan(&dailyPosts)
+
+	for _, row := range dailyPosts {
+		if ds, ok := stats.DailyStats[row.PostDate]; ok {
+			ds.Posts = row.DailyPosts
+			ds.Comments = row.DailyComments
+			stats.DailyStats[row.PostDate] = ds
+		}
+	}
+
+	// 8. 주간 통계 (요일별)
+	dayNames := map[int]string{1: "일", 2: "월", 3: "화", 4: "수", 5: "목", 6: "금", 7: "토"}
+	stats.WeeklyStats = make(map[string]weeklyStat)
+	for _, name := range dayNames {
+		stats.WeeklyStats[name] = weeklyStat{}
+	}
+
+	type weeklyRow struct {
+		DayOfWeek int `gorm:"column:day_of_week"`
+		Count     int `gorm:"column:count"`
+	}
+	var weeklyReports []weeklyRow
+	db.Raw(fmt.Sprintf(`
+		SELECT day_of_week, COUNT(*) as count
+		FROM (
+			SELECT DISTINCT DAYOFWEEK(sg_time) as day_of_week, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo
+			WHERE (%s)
+			AND sg_time >= ? AND sg_time <= ?
+		) as unique_weekly_reports
+		GROUP BY day_of_week
+	`, singoTypeCondition), startDT, endDT).Scan(&weeklyReports)
+
+	for _, row := range weeklyReports {
+		if name, ok := dayNames[row.DayOfWeek]; ok {
+			ws := stats.WeeklyStats[name]
+			ws.Reports = row.Count
+			stats.WeeklyStats[name] = ws
+		}
+	}
+
+	// 요일별 처리 통계
+	var weeklyProcessed []weeklyRow
+	db.Raw(`
+		SELECT DAYOFWEEK(wr_datetime) as day_of_week, COUNT(*) as count
+		FROM g5_write_disciplinelog
+		WHERE wr_is_comment = 0 AND wr_datetime >= ? AND wr_datetime <= ?
+		GROUP BY DAYOFWEEK(wr_datetime)
+	`, startDT, endDT).Scan(&weeklyProcessed)
+
+	for _, row := range weeklyProcessed {
+		if name, ok := dayNames[row.DayOfWeek]; ok {
+			ws := stats.WeeklyStats[name]
+			ws.Processed = row.Count
+			stats.WeeklyStats[name] = ws
+		}
+	}
+
+	// 요일별 글/댓글 통계
+	type weeklyPostRow struct {
+		DayOfWeek     int `gorm:"column:day_of_week"`
+		PostsCount    int `gorm:"column:posts_count"`
+		CommentsCount int `gorm:"column:comments_count"`
+	}
+	var weeklyPosts []weeklyPostRow
+	db.Raw(`
+		SELECT DAYOFWEEK(bn_datetime) as day_of_week,
+			SUM(CASE WHEN wr_id=wr_parent THEN 1 ELSE 0 END) as posts_count,
+			SUM(CASE WHEN wr_id!=wr_parent THEN 1 ELSE 0 END) as comments_count
+		FROM g5_board_new
+		WHERE bn_datetime >= ? AND bn_datetime <= ?
+		GROUP BY DAYOFWEEK(bn_datetime)
+	`, startDT, endDT).Scan(&weeklyPosts)
+
+	for _, row := range weeklyPosts {
+		if name, ok := dayNames[row.DayOfWeek]; ok {
+			ws := stats.WeeklyStats[name]
+			ws.Posts = row.PostsCount
+			ws.Comments = row.CommentsCount
+			stats.WeeklyStats[name] = ws
+		}
+	}
+
+	// 9. 상위 신고자 통계 (상위 50)
+	db.Raw(fmt.Sprintf(`
+		SELECT unique_reports.mb_id, m.mb_nick, COALESCE(m.mb_name, '') as mb_name, COUNT(*) as report_count
+		FROM (
+			SELECT DISTINCT mb_id, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo s
+			WHERE (%s)
+			AND s.sg_time >= ? AND s.sg_time <= ?
+			AND s.mb_id IS NOT NULL AND s.mb_id != ''
+		) as unique_reports
+		LEFT JOIN g5_member m ON unique_reports.mb_id = m.mb_id
+		GROUP BY unique_reports.mb_id
+		ORDER BY report_count DESC
+		LIMIT 50
+	`, singoTypeCondition), startDT, endDT).Scan(&stats.TopReporters)
+
+	// top_reporters 상위 10명만 최종 저장
+	if len(stats.TopReporters) > 10 {
+		stats.TopReporters = stats.TopReporters[:10]
+	}
+
+	// 10. 신고 패턴 분석 (집중 신고 게시물)
+	db.Raw(fmt.Sprintf(`
+		SELECT sg_parent, sg_table,
+			COUNT(*) as report_count,
+			COUNT(DISTINCT mb_id) as reporter_count,
+			COALESCE(b.bo_subject, sg_table) as board_name
+		FROM (
+			SELECT DISTINCT sg_parent, sg_table, mb_id, CONCAT(sg_table, '_', sg_id, '_', mb_id) as unique_key
+			FROM g5_na_singo s
+			WHERE (%s)
+			AND s.sg_time >= ? AND s.sg_time <= ?
+			AND s.sg_parent IS NOT NULL
+		) as unique_pattern_reports
+		LEFT JOIN g5_board b ON unique_pattern_reports.sg_table = b.bo_table
+		GROUP BY sg_parent, sg_table
+		HAVING report_count >= 2
+		ORDER BY report_count DESC, reporter_count DESC
+		LIMIT 20
+	`, singoTypeCondition), startDT, endDT).Scan(&stats.PatternAnalysis)
+
+	// 패턴 분석 요약
+	totalPatternReports := 0
+	for _, p := range stats.PatternAnalysis {
+		totalPatternReports += p.ReportCount
+	}
+
+	top10Reports := stats.PatternAnalysis
+	if len(top10Reports) > 10 {
+		top10Reports = top10Reports[:10]
+	}
+	top10Total := 0
+	for _, p := range top10Reports {
+		top10Total += p.ReportCount
+	}
+
+	concentrationRate := float64(0)
+	if stats.TotalReports > 0 {
+		concentrationRate = float64(top10Total) / float64(stats.TotalReports) * 100
+	}
+
+	stats.PatternSummary = map[string]interface{}{
+		"top_10_concentration":     fmt.Sprintf("%.1f", concentrationRate),
+		"total_concentrated_posts": len(stats.PatternAnalysis),
+		"total_pattern_reports":    totalPatternReports,
+	}
+	if len(stats.PatternAnalysis) > 0 {
+		stats.PatternSummary["most_reported_post"] = stats.PatternAnalysis[0]
+	}
+
+	return stats
+}
+
+// saveReportPost saves the report as a post in g5_write_report
+func saveReportPost(db *gorm.DB, stats *reportStats, subject string, now time.Time) error {
+	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return err
+	}
+
+	// 보고서 내용 생성
+	content := fmt.Sprintf(
+		"📊 신고 통계 분석 보고서\n\n"+
+			"▣ 분석 개요\n"+
+			"• 기간: %s ~ %s (%d일)\n"+
+			"• 자동 생성: 매주 일요일 자정 5분\n\n"+
+			"▣ 주요 지표\n"+
+			"• 신고 현황\n"+
+			"  - 총 신고건수: %d건\n"+
+			"  - 신고된 글: %d건\n"+
+			"  - 신고된 댓글: %d건\n\n"+
+			"• 처리 현황\n"+
+			"  - 처리완료: %d건\n"+
+			"  - 소명처리: %d건\n"+
+			"  - 신고자수: %d명\n\n"+
+			"▣ 데이터 규모\n"+
+			"• 전체 게시글: %d개\n"+
+			"• 전체 댓글: %d개\n"+
+			"• 데이터 크기: %d bytes\n\n"+
+			"※ 상세 통계는 차트를 참고해주세요.",
+		stats.DateFrom, stats.DateTo, stats.PeriodDays,
+		stats.TotalReports, stats.ReportCount, stats.ReportMonth,
+		stats.CompletedReports, stats.ClaimReports, stats.ReporterCount,
+		stats.TotalCases, stats.TotalMonthCases, len(statsJSON),
+	)
+
+	// wr_num 계산
+	var wrNum int
+	db.Raw("SELECT COALESCE(MIN(wr_num), 0) - 1 FROM g5_write_report").Scan(&wrNum)
+
+	nowStr := now.Format("2006-01-02 15:04:05")
+
+	result := db.Exec(`
+		INSERT INTO g5_write_report
+		SET wr_num = ?,
+			wr_reply = '',
+			wr_comment = 0,
+			ca_name = '통계',
+			wr_option = '',
+			wr_subject = ?,
+			wr_content = ?,
+			wr_9 = ?,
+			mb_id = 'admin',
+			wr_password = '',
+			wr_name = '관리자',
+			wr_datetime = ?,
+			wr_last = ?,
+			wr_ip = '127.0.0.1'
+	`, wrNum, subject, content, string(statsJSON), nowStr, nowStr)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	// 게시판 글 수 업데이트
+	db.Exec("UPDATE g5_board SET bo_count_write = bo_count_write + 1 WHERE bo_table = 'report'")
+
+	return nil
+}
+
+// getSingoTypes returns the report type labels map
+func getSingoTypes() map[int]string {
+	return reportTypeLabels
+}
+
+// numberFormat formats an integer with comma separators
+func numberFormat(n int) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	var result strings.Builder
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			result.WriteByte(',')
+		}
+		result.WriteRune(c)
+	}
+	return result.String()
+}

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -1,0 +1,719 @@
+package cron
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ProcessReportsResult contains the result of processing approved reports
+type ProcessReportsResult struct {
+	TotalGroups int      `json:"total_groups"`
+	Processed   int      `json:"processed"`
+	Errors      int      `json:"errors"`
+	Messages    []string `json:"messages"`
+	ExecutedAt  string   `json:"executed_at"`
+}
+
+// singoReportGroup represents a grouped report from na_singo
+type singoReportGroup struct {
+	TargetMbID           string  `gorm:"column:target_mb_id"`
+	AllReports           string  `gorm:"column:all_reports"`
+	AdminDisciplineReasons *string `gorm:"column:admin_discipline_reasons"`
+	AdminDisciplineDays  int     `gorm:"column:admin_discipline_days"`
+	AdminDisciplineType  string  `gorm:"column:admin_discipline_type"`
+	AdminDisciplineDetail *string `gorm:"column:admin_discipline_detail"`
+	TargetTitle          *string `gorm:"column:target_title"`
+	TargetContent        *string `gorm:"column:target_content"`
+	SgTable              string  `gorm:"column:sg_table"`
+	SgID                 int     `gorm:"column:sg_id"`
+	SgParent             int     `gorm:"column:sg_parent"`
+	ReportCount          int     `gorm:"column:report_count"`
+}
+
+type reportedItem struct {
+	Table  string `json:"table"`
+	ID     int    `json:"id"`
+	Parent int    `json:"parent"`
+}
+
+// disciplineData is the JSON structure stored in wr_content of g5_write_disciplinelog
+type disciplineData struct {
+	PenaltyMbID    string         `json:"penalty_mb_id"`
+	PenaltyDateFrom string        `json:"penalty_date_from"`
+	PenaltyPeriod  int            `json:"penalty_period"`
+	PenaltyType    []string       `json:"penalty_type"`
+	SgTypes        []int          `json:"sg_types"`
+	Content        string         `json:"content,omitempty"`
+	ReportedItems  []reportedItem `json:"reported_items"`
+	IsBulk         bool           `json:"is_bulk"`
+	ReportedURL    string         `json:"reported_url,omitempty"`
+	ReportedTable  string         `json:"reported_table,omitempty"`
+	ReportedID     int            `json:"reported_id,omitempty"`
+	ReportedParent int            `json:"reported_parent,omitempty"`
+	ReportCount    int            `json:"report_count"`
+}
+
+// runProcessApprovedReports processes admin-approved reports
+func runProcessApprovedReports(db *gorm.DB) (*ProcessReportsResult, error) {
+	now := time.Now()
+	result := &ProcessReportsResult{
+		ExecutedAt: now.Format("2006-01-02 15:04:05"),
+	}
+
+	// 1. Admin 승인된 신고 조회 (그룹핑)
+	var groups []singoReportGroup
+	if err := db.Raw(`
+		SELECT
+			target_mb_id,
+			GROUP_CONCAT(DISTINCT CONCAT(sg_table, '/', sg_id, '/', sg_parent) ORDER BY sg_id) as all_reports,
+			MAX(admin_discipline_reasons) as admin_discipline_reasons,
+			MAX(admin_discipline_days) as admin_discipline_days,
+			MAX(admin_discipline_type) as admin_discipline_type,
+			MAX(admin_discipline_detail) as admin_discipline_detail,
+			MAX(target_title) as target_title,
+			MAX(target_content) as target_content,
+			MIN(sg_table) as sg_table,
+			MIN(sg_id) as sg_id,
+			MIN(sg_parent) as sg_parent,
+			COUNT(*) as report_count
+		FROM g5_na_singo
+		WHERE admin_approved = 1 AND processed = 0
+		GROUP BY target_mb_id, admin_discipline_days, admin_discipline_type, DATE(admin_datetime)
+		ORDER BY MAX(admin_datetime) ASC
+	`).Scan(&groups).Error; err != nil {
+		return nil, fmt.Errorf("승인된 신고 조회 실패: %w", err)
+	}
+
+	result.TotalGroups = len(groups)
+	if len(groups) == 0 {
+		result.Messages = append(result.Messages, "처리할 신고가 없습니다")
+		return result, nil
+	}
+
+	// 2. 각 신고 그룹 처리
+	for _, group := range groups {
+		if err := processReportGroup(db, &group, now); err != nil {
+			result.Errors++
+			result.Messages = append(result.Messages, fmt.Sprintf("실패(%s): %v", group.TargetMbID, err))
+			log.Printf("[Cron:process-approved-reports] error for %s: %v", group.TargetMbID, err)
+			continue
+		}
+		result.Processed++
+		result.Messages = append(result.Messages, fmt.Sprintf("처리완료: %s (신고 %d건)", group.TargetMbID, group.ReportCount))
+	}
+
+	return result, nil
+}
+
+// processReportGroup processes a single report group
+func processReportGroup(db *gorm.DB, group *singoReportGroup, now time.Time) error {
+	targetMbID := group.TargetMbID
+
+	// all_reports 파싱 → reported_items 배열
+	items := parseReportedItems(group.AllReports, group.SgTable, group.SgID, group.SgParent)
+
+	// 통합 제재 체크: discipline_log_id가 이미 설정된 경우
+	var existingLogID int
+	isMergedDiscipline := false
+	db.Raw(`
+		SELECT discipline_log_id FROM g5_na_singo
+		WHERE target_mb_id = ? AND admin_approved = 1 AND processed = 0 AND discipline_log_id > 0
+		LIMIT 1
+	`, targetMbID).Scan(&existingLogID)
+
+	if existingLogID > 0 {
+		isMergedDiscipline = true
+	}
+
+	// target_mb_id가 없으면 게시글에서 직접 조회
+	if targetMbID == "" {
+		targetMbID = lookupTargetMbID(db, group)
+	}
+
+	// 회원 닉네임 조회
+	var targetNick string
+	db.Table("g5_member").Select("mb_nick").Where("mb_id = ?", targetMbID).Scan(&targetNick)
+	if targetNick == "" {
+		targetNick = targetMbID
+	}
+
+	// discipline reasons 파싱
+	sgTypesArray := parseDisciplineReasons(group.AdminDisciplineReasons)
+
+	disciplineDetail := ""
+	if group.AdminDisciplineDetail != nil {
+		disciplineDetail = *group.AdminDisciplineDetail
+	}
+
+	isBulk := len(items) > 1
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		// 2-1. 징계 로그 게시글 작성
+		var wrID int
+		if isMergedDiscipline {
+			wrID = existingLogID
+		} else {
+			var err error
+			wrID, err = createDisciplineLogPost(tx, targetMbID, targetNick, sgTypesArray,
+				group.AdminDisciplineDays, group.AdminDisciplineType, disciplineDetail,
+				group.SgTable, group.SgID, group.SgParent, group.ReportCount,
+				items, isBulk, now)
+			if err != nil {
+				return fmt.Errorf("징계 로그 작성 실패: %w", err)
+			}
+		}
+
+		// 2-2. 사용자 제재 적용
+		if err := applyUserRestriction(tx, targetMbID, group.AdminDisciplineType,
+			group.AdminDisciplineDays, sgTypesArray, now); err != nil {
+			return fmt.Errorf("사용자 제재 적용 실패: %w", err)
+		}
+
+		// 2-3. 제재 알림 쪽지 발송
+		if err := sendDisciplineMemo(tx, targetMbID, targetNick,
+			group.AdminDisciplineDays, group.AdminDisciplineType,
+			sgTypesArray, disciplineDetail, wrID, now); err != nil {
+			log.Printf("[Cron:process-approved-reports] memo send failed for %s: %v", targetMbID, err)
+			// 쪽지 발송 실패는 전체 처리를 중단하지 않음
+		}
+
+		// 2-4. 신고 처리 완료 표시
+		for _, item := range items {
+			tx.Exec(`
+				UPDATE g5_na_singo
+				SET processed = 1, processed_datetime = NOW(), discipline_log_id = ?, version = version + 1
+				WHERE sg_table = ? AND sg_id = ? AND sg_parent = ? AND admin_approved = 1 AND processed = 0
+			`, wrID, item.Table, item.ID, item.Parent)
+		}
+
+		// BULK_REPORTS에 포함된 추가 신고도 처리
+		if disciplineDetail != "" {
+			processBulkReports(tx, disciplineDetail, wrID)
+		}
+
+		return nil
+	})
+}
+
+// parseReportedItems parses "free/123/0,free/456/400" format
+func parseReportedItems(allReports string, fallbackTable string, fallbackID, fallbackParent int) []reportedItem {
+	var items []reportedItem
+	if allReports != "" {
+		for _, entry := range strings.Split(allReports, ",") {
+			parts := strings.Split(entry, "/")
+			if len(parts) == 3 {
+				var id, parent int
+				fmt.Sscanf(parts[1], "%d", &id)
+				fmt.Sscanf(parts[2], "%d", &parent)
+				items = append(items, reportedItem{Table: parts[0], ID: id, Parent: parent})
+			}
+		}
+	}
+	if len(items) == 0 {
+		items = append(items, reportedItem{Table: fallbackTable, ID: fallbackID, Parent: fallbackParent})
+	}
+	return items
+}
+
+// parseDisciplineReasons parses JSON discipline reasons
+func parseDisciplineReasons(reasons *string) []int {
+	if reasons == nil || *reasons == "" {
+		return nil
+	}
+	var result []int
+	if err := json.Unmarshal([]byte(*reasons), &result); err != nil {
+		// Try as string array and convert
+		var strReasons []string
+		if err := json.Unmarshal([]byte(*reasons), &strReasons); err != nil {
+			return nil
+		}
+		for _, s := range strReasons {
+			if code, ok := reasonKeyToInt[s]; ok {
+				result = append(result, code)
+			}
+		}
+	}
+	return result
+}
+
+// lookupTargetMbID tries to find target member from the post
+func lookupTargetMbID(db *gorm.DB, group *singoReportGroup) string {
+	type postRow struct {
+		MbID      string `gorm:"column:mb_id"`
+		WrName    string `gorm:"column:wr_name"`
+		WrSubject string `gorm:"column:wr_subject"`
+		WrContent string `gorm:"column:wr_content"`
+	}
+
+	var post postRow
+	tableName := fmt.Sprintf("g5_write_%s", group.SgTable)
+	err := db.Table(tableName).
+		Select("mb_id, wr_name, wr_subject, wr_content").
+		Where("wr_id = ?", group.SgID).
+		First(&post).Error
+
+	if err != nil {
+		// Fallback: truthroom
+		err = db.Table("g5_write_truthroom").
+			Select("mb_id, wr_name, wr_subject, wr_content").
+			Where("wr_id = ?", group.SgID).
+			First(&post).Error
+		if err != nil {
+			return "알수없음"
+		}
+	}
+
+	if post.MbID != "" {
+		if group.TargetTitle != nil && *group.TargetTitle == "" {
+			*group.TargetTitle = post.WrSubject
+		}
+		return post.MbID
+	}
+	return post.WrName
+}
+
+// createDisciplineLogPost creates a discipline log post in g5_write_disciplinelog
+func createDisciplineLogPost(
+	tx *gorm.DB,
+	targetMbID, targetNick string,
+	sgTypes []int,
+	disciplineDays int,
+	disciplineType, disciplineDetail string,
+	sgTable string, sgID, sgParent, reportCount int,
+	items []reportedItem,
+	isBulk bool,
+	now time.Time,
+) (int, error) {
+	// 다음 wr_id 조회
+	var maxWrID int
+	tx.Raw("SELECT COALESCE(MAX(wr_id), 0) FROM g5_write_disciplinelog").Scan(&maxWrID)
+	wrID := maxWrID + 1
+
+	// penalty_type 변환
+	penaltyType := convertDisciplineType(disciplineType)
+
+	// 9999일은 영구제재로 변환
+	penaltyPeriod := disciplineDays
+	if disciplineDays == 9999 {
+		penaltyPeriod = -1
+	}
+
+	// 신고당한 게시글 URL 생성
+	reportedPath := fmt.Sprintf("/%s/", sgTable)
+	if sgParent > 0 && sgParent != sgID {
+		reportedPath += fmt.Sprintf("%d#c_%d", sgParent, sgID)
+	} else {
+		reportedPath += fmt.Sprintf("%d", sgID)
+	}
+
+	actualReportCount := reportCount
+	if isBulk {
+		actualReportCount = len(items)
+	}
+
+	// JSON 데이터 구성
+	data := disciplineData{
+		PenaltyMbID:    targetMbID,
+		PenaltyDateFrom: now.Format("2006-01-02 15:04:05"),
+		PenaltyPeriod:  penaltyPeriod,
+		PenaltyType:    penaltyType,
+		SgTypes:        sgTypes,
+		Content:        stripTags(disciplineDetail),
+		ReportedItems:  items,
+		IsBulk:         isBulk,
+		ReportedURL:    reportedPath,
+		ReportedTable:  sgTable,
+		ReportedID:     sgID,
+		ReportedParent: sgParent,
+		ReportCount:    actualReportCount,
+	}
+
+	contentJSON, err := json.Marshal(data)
+	if err != nil {
+		return 0, err
+	}
+
+	// wr_1에 저장할 사유 문자열
+	wr1Value := buildReasonLabels(sgTypes)
+
+	nowStr := now.Format("2006-01-02 15:04:05")
+	subject := fmt.Sprintf("%s(%s)", targetMbID, targetNick)
+
+	// INSERT
+	if err := tx.Exec(`
+		INSERT INTO g5_write_disciplinelog
+		SET wr_id = ?,
+			wr_num = (SELECT IFNULL(MIN(wr_num), 0) - 1 FROM g5_write_disciplinelog tmp),
+			wr_reply = '',
+			wr_parent = ?,
+			wr_is_comment = 0,
+			wr_comment = 0,
+			wr_comment_reply = '',
+			ca_name = '',
+			wr_option = 'html1',
+			wr_subject = ?,
+			wr_content = ?,
+			wr_link1 = ?,
+			wr_link2 = '',
+			wr_link1_hit = 0,
+			wr_link2_hit = 0,
+			wr_hit = 0,
+			wr_good = 0,
+			wr_nogood = 0,
+			mb_id = 'police',
+			wr_password = '',
+			wr_name = 'police',
+			wr_email = '',
+			wr_homepage = '',
+			wr_datetime = ?,
+			wr_file = 0,
+			wr_last = ?,
+			wr_ip = '127.0.0.1',
+			wr_1 = ?,
+			wr_2 = '', wr_3 = '', wr_4 = '', wr_5 = '',
+			wr_6 = '', wr_7 = '', wr_8 = '', wr_9 = '', wr_10 = ''
+	`, wrID, wrID, subject, string(contentJSON),
+		"https://damoang.net"+reportedPath,
+		nowStr, nowStr, wr1Value,
+	).Error; err != nil {
+		return 0, err
+	}
+
+	// 게시판 글 수 증가
+	tx.Exec("UPDATE g5_board SET bo_count_write = bo_count_write + 1 WHERE bo_table = 'disciplinelog'")
+
+	return wrID, nil
+}
+
+// applyUserRestriction applies discipline to the target member
+func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, disciplineDays int, sgTypes []int, now time.Time) error {
+	// 주의 처분 (0일): 제재 없음
+	if disciplineDays == 0 {
+		return nil
+	}
+
+	// 현재 회원 정보 조회
+	var member struct {
+		MbLevel int `gorm:"column:mb_level"`
+	}
+	if err := tx.Table("g5_member").Select("mb_level").Where("mb_id = ?", targetMbID).First(&member).Error; err != nil {
+		return fmt.Errorf("회원 조회 실패: %w", err)
+	}
+
+	// 제재 종료일 계산
+	var restrictionEndDate string
+	if disciplineDays == 9999 {
+		restrictionEndDate = "9999-12-31 23:59:59"
+	} else {
+		restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("2006-01-02 15:04:05")
+	}
+
+	// 제재 적용
+	updates := map[string]interface{}{}
+	if disciplineType == "level_down" || disciplineType == "level" || disciplineType == "both" || disciplineType == "demotion_and_block" {
+		updates["mb_level"] = 1
+	}
+	if disciplineType == "access_block" || disciplineType == "access" || disciplineType == "both" || disciplineType == "demotion_and_block" {
+		updates["mb_intercept_date"] = restrictionEndDate
+	}
+
+	if len(updates) > 0 {
+		if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).Updates(updates).Error; err != nil {
+			return err
+		}
+	}
+
+	// g5_da_member_discipline 테이블에 제재 정보 저장
+	penaltyTypeValue := ""
+	switch {
+	case disciplineType == "level_down" || disciplineType == "level":
+		penaltyTypeValue = "level"
+	case disciplineType == "access_block" || disciplineType == "access":
+		penaltyTypeValue = "intercept"
+	case disciplineType == "both" || disciplineType == "demotion_and_block":
+		penaltyTypeValue = "all"
+	}
+
+	penaltyPeriod := disciplineDays
+	if disciplineDays == 9999 {
+		penaltyPeriod = -1
+	}
+
+	sgTypesStr := ""
+	for i, t := range sgTypes {
+		if i > 0 {
+			sgTypesStr += ","
+		}
+		sgTypesStr += fmt.Sprintf("%d", t)
+	}
+
+	// UPSERT: 기존 레코드가 있으면 UPDATE, 없으면 INSERT
+	var existingID int
+	tx.Raw("SELECT id FROM g5_da_member_discipline WHERE penalty_mb_id = ?", targetMbID).Scan(&existingID)
+
+	if existingID > 0 {
+		tx.Exec(`UPDATE g5_da_member_discipline SET
+			penalty_date_from = ?, penalty_period = ?, penalty_type = ?, prev_level = ?
+			WHERE penalty_mb_id = ?`,
+			now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, member.MbLevel, targetMbID)
+	} else {
+		tx.Exec(`INSERT INTO g5_da_member_discipline
+			(penalty_mb_id, penalty_date_from, penalty_period, penalty_type, sg_types, prev_level)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			targetMbID, now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, sgTypesStr, member.MbLevel)
+	}
+
+	return nil
+}
+
+// sendDisciplineMemo sends a discipline notification memo to the target member
+func sendDisciplineMemo(tx *gorm.DB, targetMbID, targetNick string, disciplineDays int, disciplineType string, sgTypes []int, disciplineDetail string, wrID int, now time.Time) error {
+	// 템플릿 구성 (PHP 템플릿과 동일한 내용)
+	memo := buildMemoContent(targetMbID, targetNick, disciplineDays, disciplineType, sgTypes, disciplineDetail, wrID, now)
+
+	nowStr := now.Format("2006-01-02 15:04:05")
+
+	// 1. 받는 회원 쪽지 INSERT (recv)
+	result := tx.Exec(`
+		INSERT INTO g5_memo
+		(me_recv_mb_id, me_send_mb_id, me_send_datetime, me_memo, me_read_datetime, me_type, me_send_ip)
+		VALUES (?, 'police', ?, ?, '0000-00-00 00:00:00', 'recv', '127.0.0.1')
+	`, targetMbID, nowStr, memo)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	// 마지막 INSERT ID 조회
+	var meID int
+	tx.Raw("SELECT LAST_INSERT_ID()").Scan(&meID)
+	if meID == 0 {
+		return nil
+	}
+
+	// 2. 보내는 회원 쪽지 INSERT (send)
+	tx.Exec(`
+		INSERT INTO g5_memo
+		(me_recv_mb_id, me_send_mb_id, me_send_datetime, me_memo, me_read_datetime, me_send_id, me_type, me_send_ip)
+		VALUES (?, 'police', ?, ?, '0000-00-00 00:00:00', ?, 'send', '127.0.0.1')
+	`, targetMbID, nowStr, memo, meID)
+
+	// 3. 실시간 쪽지 알림 업데이트
+	tx.Exec(`
+		UPDATE g5_member
+		SET mb_memo_call = 'police',
+			mb_memo_cnt = (SELECT COUNT(*) FROM g5_memo WHERE me_recv_mb_id = ? AND me_type = 'recv' AND me_read_datetime = '0000-00-00 00:00:00')
+		WHERE mb_id = ?
+	`, targetMbID, targetMbID)
+
+	return nil
+}
+
+// buildMemoContent generates the discipline notification memo content
+func buildMemoContent(targetMbID, targetNick string, disciplineDays int, disciplineType string, sgTypes []int, disciplineDetail string, wrID int, now time.Time) string {
+	// 기간 텍스트
+	var penaltyDay string
+	if disciplineDays < 0 || disciplineDays == 9999 {
+		penaltyDay = "영구"
+	} else if disciplineDays == 0 {
+		penaltyDay = "주의(이용제한 없음)"
+	} else {
+		penaltyDay = fmt.Sprintf("%d일", disciplineDays)
+	}
+
+	// 종료일
+	var endDateStr string
+	if disciplineDays > 0 && disciplineDays < 9999 {
+		endDateStr = " ~ " + now.AddDate(0, 0, disciplineDays).Format("2006-01-02 15:04:05")
+	} else if disciplineDays < 0 || disciplineDays == 9999 {
+		endDateStr = " ~"
+	}
+
+	// 사유 목록
+	reasonList := ""
+	idx := 1
+	for _, t := range sgTypes {
+		label := getReportTypeLabel(t)
+		if label != "알 수 없음" {
+			reasonList += fmt.Sprintf("%d. %s\n", idx, label)
+			idx++
+		}
+	}
+
+	disciplineLink := fmt.Sprintf("https://damoang.net/disciplinelog/%d", wrID)
+	profileLink := fmt.Sprintf("https://damoang.net/disciplinelog?bo_table=disciplinelog&sca=&sfl=wr_subject%%7C%%7Cwr_content%%2C1&sop=and&stx=%s", targetMbID)
+
+	// 추가정보
+	additionalInfo := ""
+	detail := stripTags(disciplineDetail)
+	if detail != "" {
+		additionalInfo = "\n• 추가정보:\n" + detail
+	}
+
+	memo := fmt.Sprintf(`💌 [잠시 쉬어가기 안내] 💌
+
+
+안녕하세요, %s님! 👋
+
+잠깐! 우리 %s님께서
+조금 쉬어가실 시간이 필요하신 것 같아요 🍀
+
+다모앙 가족 모두가 행복한 공간을 만들기 위해
+잠시만 충전의 시간을 가져보시는 건 어떨까요?
+
+곧 다시 만나요! 🌈
+
+📝 쉬어가기 상세 내용
+• 내 기록 확인: %s
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+📚 도움이 될 만한 페이지
+• 이용약관: https://damoang.net/content/provision
+• 운영정책: https://damoang.net/content/operation_policy
+• 제재사유 안내: https://damoang.net/content/operation_policy_add
+• 내 기록 확인: %s
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+💡 잠시만 기다려주세요!
+   이 기간 동안은 글쓰기, 댓글, 쪽지 기능이
+   잠시 쉬어갑니다 😊
+
+🌟 함께 더 좋은 커뮤니티를 만들어가요!
+   서로를 배려하는 마음, 그것이 다모앙의 힘입니다 💪`,
+		targetNick, targetNick, disciplineLink, profileLink)
+
+	// 실제 PHP 템플릿과의 호환성 유지 (사용하지 않는 플레이스홀더도 포함)
+	_ = penaltyDay
+	_ = endDateStr
+	_ = reasonList
+	_ = additionalInfo
+
+	return memo
+}
+
+// processBulkReports processes additional reports embedded in BULK_REPORTS
+func processBulkReports(tx *gorm.DB, disciplineDetail string, wrID int) {
+	// [BULK_REPORTS:...] 패턴 찾기
+	idx := strings.Index(disciplineDetail, "[BULK_REPORTS:")
+	if idx == -1 {
+		return
+	}
+	endIdx := strings.Index(disciplineDetail[idx:], "]")
+	if endIdx == -1 {
+		return
+	}
+
+	jsonStr := disciplineDetail[idx+14 : idx+endIdx]
+	var bulkReports []struct {
+		SgTable  string `json:"sg_table"`
+		SgID     int    `json:"sg_id"`
+		SgParent int    `json:"sg_parent"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &bulkReports); err != nil {
+		return
+	}
+
+	for _, br := range bulkReports {
+		if br.SgTable == "" || br.SgID <= 0 {
+			continue
+		}
+		tx.Exec(`
+			UPDATE g5_na_singo
+			SET processed = 1, processed_datetime = NOW(), discipline_log_id = ?, version = version + 1
+			WHERE sg_table = ? AND sg_id = ? AND sg_parent = ? AND admin_approved = 1 AND processed = 0
+		`, wrID, br.SgTable, br.SgID, br.SgParent)
+	}
+}
+
+// convertDisciplineType converts discipline type string to penalty type array
+func convertDisciplineType(disciplineType string) []string {
+	switch disciplineType {
+	case "level_down", "level":
+		return []string{"level"}
+	case "access_block", "access":
+		return []string{"access"}
+	case "both", "demotion_and_block":
+		return []string{"level", "access"}
+	default:
+		return []string{}
+	}
+}
+
+// stripTags removes HTML tags from a string (simple implementation)
+func stripTags(s string) string {
+	result := strings.Builder{}
+	inTag := false
+	for _, r := range s {
+		if r == '<' {
+			inTag = true
+			continue
+		}
+		if r == '>' {
+			inTag = false
+			continue
+		}
+		if !inTag {
+			result.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(result.String())
+}
+
+// buildReasonLabels builds comma-separated reason labels from type codes
+func buildReasonLabels(sgTypes []int) string {
+	var labels []string
+	for _, t := range sgTypes {
+		label := getReportTypeLabel(t)
+		if label != "알 수 없음" {
+			labels = append(labels, label)
+		}
+	}
+	return strings.Join(labels, ", ")
+}
+
+// getReportTypeLabel returns the Korean label for a report type code
+func getReportTypeLabel(code int) string {
+	if label, ok := reportTypeLabels[code]; ok {
+		return label
+	}
+	return "알 수 없음"
+}
+
+// reportTypeLabels maps report type codes to Korean labels
+var reportTypeLabels = map[int]string{
+	1: "회원비하", 2: "예의없음", 3: "부적절한 표현", 4: "차별행위",
+	5: "분란유도/갈등조장", 6: "여론조성", 7: "회원기만", 8: "이용방해",
+	9: "용도위반", 10: "거래금지위반", 11: "구걸", 12: "권리침해",
+	13: "외설", 14: "위법행위", 15: "광고/홍보", 16: "운영정책부정",
+	17: "다중이", 18: "기타사유",
+	21: "회원비하", 22: "예의없음", 23: "부적절한 표현", 24: "차별행위",
+	25: "분란유도/갈등조장", 26: "여론조성", 27: "회원기만", 28: "이용방해",
+	29: "용도위반", 30: "거래금지위반", 31: "구걸", 32: "권리침해",
+	33: "외설", 34: "위법행위", 35: "광고/홍보", 36: "운영정책부정",
+	37: "다중이", 38: "기타사유", 39: "뉴스펌글누락", 40: "뉴스전문전재",
+}
+
+// reasonKeyToInt maps string reason keys to integer codes
+var reasonKeyToInt = map[string]int{
+	"member_disparage":    1,
+	"no_manner":           2,
+	"inappropriate_expr":  3,
+	"discrimination":      4,
+	"provocation":         5,
+	"opinion_manipulation": 6,
+	"member_deception":    7,
+	"usage_obstruction":   8,
+	"purpose_violation":   9,
+	"trade_violation":     10,
+	"begging":             11,
+	"rights_infringement": 12,
+	"obscenity":           13,
+	"illegal_activity":    14,
+	"advertising":         15,
+	"policy_denial":       16,
+	"multi_account":       17,
+	"other":               18,
+}


### PR DESCRIPTION
## Summary

PHP-FPM 의존성 완전 제거를 위해 남은 PHP 크론잡 4개를 Go API 내부 엔드포인트로 전환합니다.

### 구현된 엔드포인트

| 엔드포인트 | 원본 PHP | 스케줄 | 설명 |
|------------|----------|--------|------|
| `POST /api/internal/cron/member-lock-release` | `member_lock_relese.php` | 매시 08-23시 | mb_4='lock' 회원 해제 |
| `POST /api/internal/cron/update-member-levels` | `cron_update_member_levels.php` | 매일 00:05 | promotions 기반 광고주 등급 업데이트 |
| `POST /api/internal/cron/process-approved-reports` | `process_approved_reports.php` | 매시 | 승인된 신고 → 징계로그+제재+쪽지 |
| `POST /api/internal/cron/update-report-pattern` | `cron_update_report_pattern.php` | 매주 일 00:05 | 주간 신고 통계 보고서 생성 |

### 변경 사항

- `internal/cron/` 패키지 신규 생성 (5 파일)
- `cmd/api/main.go`에 라우트 등록
- `.env.example`에 `CRON_SECRET` 추가
- 모든 엔드포인트 `?secret=XXX`로 인증

### 데이터 소스 변경 (member_levels)

- PHP: JSON 파일에서 광고주 데이터 로드 (`w-promotion-ad-insertion-pai-*.json`)
- Go: `promotions` 테이블에서 직접 조회 (같은 DB, damoang-ads에서 관리)

## Test plan

- [x] 4개 엔드포인트 curl 테스트 완료 (dev 환경)
- [x] process-approved-reports 실제 2건 처리 확인 (discipline log 생성 확인)
- [x] update-report-pattern 중복 방지 동작 확인
- [x] invalid secret 시 403 반환 확인
- [ ] PHP 크론 주석 처리 → Go 크론만 동작 → 1주일 모니터링
- [ ] 이상 없으면 PHP 크론 완전 삭제