### PR TITLE
feat: 제재 회원 글/댓글 차단 + 아카이브 게시판 보호

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -240,6 +240,9 @@ func main() {
 	// IP Protection
 	ipProtectCfg := middleware.LoadIPProtectionConfig()
 
+	// Ban check middleware (제재 회원 글/댓글 작성 차단)
+	banCheck := middleware.BanCheck(db)
+
 	// Plugin HookManager
 	pluginLogger := plugin.NewDefaultLogger("plugin")
 	_ = plugin.NewHookManager(pluginLogger)
@@ -387,7 +390,7 @@ func main() {
 		// expSvc := v2svc.NewExpService(v2UserRepo)
 		// v2Handler.SetExpService(expSvc)
 
-		v2routes.Setup(router, v2Handler, jwtManager, permChecker)
+		v2routes.Setup(router, v2Handler, jwtManager, permChecker, db)
 		v2routes.SetupAdminPosts(router, v2Handler, jwtManager)
 
 		// MyPage routes (point, exp, posts, comments, stats)
@@ -1218,6 +1221,7 @@ func main() {
 		// v1 boards routes → use Gnuboard g5_* tables
 		v1Boards := router.Group("/api/v1/boards")
 		v1Boards.Use(middleware.OptionalJWTAuth(jwtManager))
+		v1Boards.Use(middleware.ArchiveBoardCheck())
 
 		// Board extended settings repo & write restriction service (used by multiple handlers)
 		v2ExtendedSettingsRepo := v2repo.NewBoardExtendedSettingsRepository(db)
@@ -1730,7 +1734,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts - Create post in g5_write_{slug}
-		v1Boards.POST("/:slug/posts", middleware.JWTAuth(jwtManager), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts", middleware.JWTAuth(jwtManager), banCheck, middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
 			slug := c.Param("slug")
 
 			// 게시판 설정 조회
@@ -1960,7 +1964,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/comments - Create comment in g5_write_{slug}
-		v1Boards.POST("/:slug/posts/:id/comments", middleware.JWTAuth(jwtManager), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/comments", middleware.JWTAuth(jwtManager), banCheck, middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -2228,7 +2232,7 @@ func main() {
 		})
 
 		// PUT /api/v1/boards/:slug/posts/:id - Update post
-		v1Boards.PUT("/:slug/posts/:id", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.PUT("/:slug/posts/:id", middleware.JWTAuth(jwtManager), banCheck, func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -2325,7 +2329,7 @@ func main() {
 		})
 
 		// PUT /api/v1/boards/:slug/posts/:id/comments/:comment_id - Update comment
-		v1Boards.PUT("/:slug/posts/:id/comments/:comment_id", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.PUT("/:slug/posts/:id/comments/:comment_id", middleware.JWTAuth(jwtManager), banCheck, func(c *gin.Context) {
 			slug := c.Param("slug")
 			commentID, err := strconv.Atoi(c.Param("comment_id"))
 			if err != nil {

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -1,0 +1,124 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const (
+	interceptDateFormat     = "2006-01-02 15:04:05"
+	interceptDateShortFormat = "20060102"
+	claimBoardSlug          = "claim"
+	claimWindowDays         = 15
+)
+
+// BanCheck checks if the authenticated user is banned (mb_intercept_date).
+// Banned users cannot create or update posts/comments.
+// Exception: banned users can CREATE (POST only) on the claim board within 15 days of discipline start.
+func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		mbID := GetUserID(c)
+		if mbID == "" {
+			c.Next()
+			return
+		}
+
+		// PK lookup: get intercept date
+		var interceptDate string
+		err := gnuDB.Table("g5_member").
+			Select("mb_intercept_date").
+			Where("mb_id = ?", mbID).
+			Row().Scan(&interceptDate)
+		if err != nil || interceptDate == "" {
+			c.Next()
+			return
+		}
+
+		// Parse intercept date (end date of ban)
+		banEnd, parseErr := parseInterceptDate(interceptDate)
+		if parseErr != nil {
+			// Unparseable date — treat as not banned
+			c.Next()
+			return
+		}
+
+		now := time.Now()
+		if now.After(banEnd) {
+			// Ban expired
+			c.Next()
+			return
+		}
+
+		// User is currently banned — check claim board exception
+		slug := c.Param("slug")
+		if slug == claimBoardSlug && c.Request.Method == http.MethodPost {
+			// Claim board exception: allow POST within 15 days of discipline start
+			var penaltyDateFrom string
+			err := gnuDB.Raw(
+				"SELECT penalty_date_from FROM g5_da_member_discipline WHERE penalty_mb_id = ? ORDER BY id DESC LIMIT 1",
+				mbID,
+			).Row().Scan(&penaltyDateFrom)
+			if err == nil && penaltyDateFrom != "" {
+				if disciplineStart, e := time.ParseInLocation(interceptDateFormat, penaltyDateFrom, time.Local); e == nil {
+					if now.Sub(disciplineStart) <= time.Duration(claimWindowDays)*24*time.Hour {
+						c.Next()
+						return
+					}
+				}
+			}
+		}
+
+		// Block the request
+		banEndStr := banEnd.Format("2006-01-02 15:04:05")
+		if banEnd.Year() >= 9999 {
+			banEndStr = "영구 제재"
+		}
+		common.ErrorResponse(c, http.StatusForbidden,
+			"제재 기간 중에는 글을 작성할 수 없습니다. (해제일: "+banEndStr+")", nil)
+		c.Abort()
+	}
+}
+
+// archiveBoards is the set of board slugs that are read-only archives.
+var archiveBoards = map[string]bool{
+	"truthroom": true,
+}
+
+// ArchiveBoardCheck blocks PUT, PATCH, DELETE on archive boards (read-only).
+// POST (new posts/comments) is still allowed; only modification/deletion is blocked.
+func ArchiveBoardCheck() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		slug := c.Param("slug")
+		if !archiveBoards[slug] {
+			c.Next()
+			return
+		}
+
+		switch c.Request.Method {
+		case http.MethodPut, http.MethodPatch, http.MethodDelete:
+			common.ErrorResponse(c, http.StatusForbidden,
+				"아카이브 게시판에서는 수정/삭제가 불가능합니다.", nil)
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}
+
+// parseInterceptDate parses mb_intercept_date which can be "2006-01-02 15:04:05" or "20060102" format.
+func parseInterceptDate(s string) (time.Time, error) {
+	if t, err := time.ParseInLocation(interceptDateFormat, s, time.Local); err == nil {
+		return t, nil
+	}
+	if t, err := time.ParseInLocation(interceptDateShortFormat, s, time.Local); err == nil {
+		// Short format has no time component — treat as end of day
+		return t.Add(24*time.Hour - time.Second), nil
+	}
+	return time.Time{}, fmt.Errorf("unknown date format: %s", s)
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/damoang/angple-backend/internal/middleware"
 	"github.com/damoang/angple-backend/pkg/jwt"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // SetupAuth configures v2 authentication routes
@@ -25,9 +26,10 @@ func SetupAuth(router *gin.Engine, h *v2handler.V2AuthHandler, jwtManager *jwt.M
 }
 
 // Setup configures v2 API routes (new DB schema)
-func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, boardPermChecker middleware.BoardPermissionChecker) {
+func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, boardPermChecker middleware.BoardPermissionChecker, gnuDB *gorm.DB) {
 	api := router.Group("/api/v2")
 	auth := middleware.JWTAuth(jwtManager)
+	banCheck := middleware.BanCheck(gnuDB)
 
 	// Users
 	users := api.Group("/users")
@@ -38,15 +40,16 @@ func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, 
 	// Boards (OptionalJWTAuth로 인증된 사용자에게 permissions 제공)
 	boards := api.Group("/boards")
 	boards.Use(middleware.OptionalJWTAuth(jwtManager))
+	boards.Use(middleware.ArchiveBoardCheck())
 	boards.GET("", h.ListBoards)
 	boards.GET("/:slug", h.GetBoard)
 
 	// Posts (nested under boards)
 	boardPosts := boards.Group("/:slug/posts")
 	boardPosts.GET("", h.ListPosts)
-	boardPosts.POST("", auth, middleware.RequireWrite(boardPermChecker), h.CreatePost)
+	boardPosts.POST("", auth, banCheck, middleware.RequireWrite(boardPermChecker), h.CreatePost)
 	boardPosts.GET("/:id", h.GetPost)
-	boardPosts.PUT("/:id", auth, h.UpdatePost)
+	boardPosts.PUT("/:id", auth, banCheck, h.UpdatePost)
 	boardPosts.DELETE("/:id", auth, h.DeletePost)
 	boardPosts.PATCH("/:id/soft-delete", auth, h.SoftDeletePost)
 	boardPosts.POST("/:id/restore", auth, middleware.RequireAdmin(), h.RestorePost)
@@ -57,8 +60,8 @@ func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, 
 	// Comments (nested under posts)
 	comments := boardPosts.Group("/:id/comments")
 	comments.GET("", h.ListComments)
-	comments.POST("", auth, middleware.RequireComment(boardPermChecker), h.CreateComment)
-	comments.PUT("/:comment_id", auth, h.UpdateComment)
+	comments.POST("", auth, banCheck, middleware.RequireComment(boardPermChecker), h.CreateComment)
+	comments.PUT("/:comment_id", auth, banCheck, h.UpdateComment)
 	comments.DELETE("/:comment_id", auth, h.DeleteComment)
 }
 


### PR DESCRIPTION
## Summary
- 제재 회원(mb_intercept_date) 글/댓글 작성 및 수정 차단하는 BanCheck 미들웨어 추가
- 소명게시판(claim) 예외: 제재 시작 15일 이내 POST(작성)만 허용, 수정/삭제 불가
- 아카이브 게시판(truthroom) PUT/PATCH/DELETE 차단하는 ArchiveBoardCheck 미들웨어 추가
- v1, v2 라우트 모두 적용

## 변경 파일
- `internal/middleware/ban_check.go` — BanCheck + ArchiveBoardCheck 미들웨어 (신규)
- `cmd/api/main.go` — v1 라우트 적용, banCheck/ArchiveBoardCheck 추가
- `internal/routes/v2/routes.go` — v2 라우트 적용

## Test plan
- [ ] 제재 회원 → 일반 게시판 글/댓글 작성 → 403
- [ ] 제재 회원 → 일반 게시판 글/댓글 수정 → 403
- [ ] 제재 회원 → claim 게시판 작성(15일 이내) → 성공
- [ ] 제재 회원 → claim 게시판 수정 → 403
- [ ] 정상 회원/만료된 제재 → 모든 작업 정상
- [ ] truthroom 수정/삭제 → 403
- [ ] truthroom 조회/작성 → 정상
- [ ] `make build` 성공