### PR TITLE
fix: Sphinx 검색 연결 — SPHINX_HOST 환경변수 사용

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -348,12 +348,16 @@ func main() {
 		siteRepo := repository.NewSiteRepository(db)
 
 		// Sphinx full-text search (SphinxQL on port 9306)
+		sphinxHost := os.Getenv("SPHINX_HOST")
+		if sphinxHost == "" {
+			sphinxHost = "127.0.0.1"
+		}
 		var sphinxClient *pkgsphinx.Client
-		if sc, err := pkgsphinx.New("127.0.0.1", 9306); err != nil {
+		if sc, err := pkgsphinx.New(sphinxHost, 9306); err != nil {
 			pkglogger.Info("Sphinx unavailable, falling back to MySQL LIKE: %v", err)
 		} else {
 			sphinxClient = sc
-			pkglogger.Info("Sphinx connected (127.0.0.1:9306)")
+			pkglogger.Info("Sphinx connected (%s:9306)", sphinxHost)
 		}
 
 		// Gnuboard repositories for v1 API (g5_* tables)


### PR DESCRIPTION
## Summary
- Sphinx 연결 시 하드코딩된 `127.0.0.1` 대신 `SPHINX_HOST` 환경변수 사용
- K8s Pod에서 호스트의 Sphinx(9306)에 접근 가능하도록 수정
- 기존: MySQL `LIKE '%keyword%'` 풀스캔 (6초+) → Sphinx 전문검색 (수ms)

## 원인
K8s Pod 매니페스트에 `SPHINX_HOST: status.hostIP` 설정이 이미 있었으나, Go 코드가 `127.0.0.1`을 하드코딩하여 Pod 내부에서 Sphinx 연결 실패 → MySQL LIKE fallback

## Test plan
- [ ] 배포 후 검색 API 응답시간 확인 (6초+ → 수ms)
- [ ] `kubectl logs`에서 `Sphinx connected (10.x.x.x:9306)` 확인
- [ ] `make build` 성공