### PR TITLE
feat: 삭제 게시물 개선 — 관리자 본문+리비전, 삭제 지연 조정, 인덱스

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1490,8 +1490,22 @@ func main() {
 				v1handler.OverrideIPForAdminSingle(postDetail, post)
 			}
 
+			// 삭제된 글: 일반 유저는 본문 숨김, 관리자는 본문 + 리비전 이력 표시
+			if post.WrDeletedAt != nil {
+				if middleware.GetUserLevel(c) >= 10 {
+					// 관리자: 리비전 이력 조회
+					var revisions []map[string]any
+					db.Raw("SELECT id, version, change_type, title, content, edited_by, edited_by_name, edited_at, metadata FROM g5_write_revisions WHERE board_id = ? AND wr_id = ? ORDER BY version DESC", slug, id).Scan(&revisions)
+					postDetail["revisions"] = revisions
+				} else {
+					// 일반 유저: 본문 숨김
+					postDetail["content"] = ""
+					postDetail["title"] = "[삭제된 게시물입니다]"
+				}
+			}
+
 			// 비밀글 접근 제어: 작성자 또는 관리자만 내용 열람 가능
-			if strings.Contains(post.WrOption, "secret") {
+			if post.WrDeletedAt == nil && strings.Contains(post.WrOption, "secret") {
 				currentUserID := middleware.GetUserID(c)
 				currentUserLevel := middleware.GetUserLevel(c)
 				isAuthor := currentUserID != "" && currentUserID == post.MbID
@@ -2499,19 +2513,9 @@ func main() {
 				return
 			}
 
-			// 일반 사용자: 댓글 수에 따라 지연 삭제 적용
+			// 일반 사용자: 무조건 지연 소프트 삭제
 			commentCount := post.WrComment
 			delayMinutes := gnuboard.CalculateDelay(commentCount)
-
-			if delayMinutes == 0 {
-				// 댓글 없으면 즉시 삭제
-				if err := gnuWriteRepo.SoftDeletePost(slug, postID, userID); err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
-					return
-				}
-				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
-				return
-			}
 
 			// 이미 삭제 예약된 경우 체크
 			existing, _ := scheduledDeleteRepo.FindByPost(slug, postID)

--- a/internal/domain/gnuboard/scheduled_delete.go
+++ b/internal/domain/gnuboard/scheduled_delete.go
@@ -27,15 +27,15 @@ func (ScheduledDelete) TableName() string {
 func CalculateDelay(replyCount int) int {
 	switch {
 	case replyCount == 0:
-		return 0
+		return 10
 	case replyCount <= 4:
-		return 5
-	case replyCount <= 9:
 		return 30
+	case replyCount <= 9:
+		return 60
 	case replyCount <= 29:
-		return 120
+		return 180
 	case replyCount <= 99:
-		return 360
+		return 720
 	default:
 		return 1440
 	}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -30,6 +30,9 @@ func Run(db *gorm.DB) error {
 	if err := CreateScheduledDeletesTable(db); err != nil {
 		return err
 	}
+	if err := FixListPageIndexes(db); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/migration/soft_delete.go
+++ b/internal/migration/soft_delete.go
@@ -105,6 +105,46 @@ func CreateScheduledDeletesTable(db *gorm.DB) error {
 	return nil
 }
 
+// FixListPageIndexes removes wr_deleted_at from idx_list_page on all board tables.
+// Since list queries no longer filter by wr_deleted_at, the index should be (wr_is_comment, wr_num, wr_reply).
+func FixListPageIndexes(db *gorm.DB) error {
+	var boardIDs []string
+	if err := db.Table("g5_board").Pluck("bo_table", &boardIDs).Error; err != nil {
+		return fmt.Errorf("failed to get board IDs: %w", err)
+	}
+
+	fixedCount := 0
+	for _, boardID := range boardIDs {
+		table := fmt.Sprintf("g5_write_%s", boardID)
+
+		// Check if idx_list_page exists and contains wr_deleted_at
+		var hasDeletedAt int64
+		db.Raw(`
+			SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+			WHERE TABLE_SCHEMA = DATABASE()
+			AND TABLE_NAME = ?
+			AND INDEX_NAME = 'idx_list_page'
+			AND COLUMN_NAME = 'wr_deleted_at'
+		`, table).Scan(&hasDeletedAt)
+
+		if hasDeletedAt == 0 {
+			continue
+		}
+
+		sql := fmt.Sprintf(`ALTER TABLE %s DROP INDEX idx_list_page, ADD INDEX idx_list_page (wr_is_comment, wr_num, wr_reply), ALGORITHM=INPLACE, LOCK=NONE`, table)
+		if err := db.Exec(sql).Error; err != nil {
+			log.Printf("[Migration] Warning: Failed to fix idx_list_page on %s: %v", table, err)
+			continue
+		}
+		fixedCount++
+	}
+
+	if fixedCount > 0 {
+		log.Printf("[Migration] Fixed idx_list_page on %d tables (removed wr_deleted_at)", fixedCount)
+	}
+	return nil
+}
+
 // CreateWriteRevisionsTable creates the g5_write_revisions table for post history tracking
 func CreateWriteRevisionsTable(db *gorm.DB) error {
 	// Check if table already exists


### PR DESCRIPTION
## Summary
- 삭제된 글 상세: 관리자는 본문+리비전 이력 인라인 표시, 일반 유저는 본문 숨김
- CalculateDelay 조정: 댓글 없는 글도 10분 지연, 최대 24시간
- 일반 유저 즉시 삭제 경로 제거 (모든 삭제는 지연 소프트 삭제)
- FixListPageIndexes 마이그레이션 추가 (idx_list_page에서 wr_deleted_at 제거)
- 프로덕션 DB 9개 테이블 인덱스 수정 완료

## Test plan
- [ ] 일반 유저 글 삭제 시 즉시 삭제 안 되고 지연 적용 확인
- [ ] 관리자 삭제된 글 상세 → 본문 + 리비전 이력 표시 확인
- [ ] 일반 유저 삭제된 글 상세 → 본문 숨김, 댓글만 표시 확인
- [ ] 각 게시판 목록 조회 성능 정상 확인 (인덱스 적용)