### PR TITLE
feat: 관리자에게 삭제된 댓글 표시

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1531,11 +1531,14 @@ func main() {
 			}
 
 			// Get comments from g5_write_{slug} where wr_parent = id and wr_is_comment = 1
-			var blockedIDs []string
-			if middleware.GetUserLevel(c) < 10 {
-				blockedIDs = getBlockedIDs(c.Request.Context(), middleware.GetUserID(c))
+			var comments []*gnuboard.G5Write
+			if middleware.GetUserLevel(c) >= 10 {
+				// 관리자: 삭제된 댓글 포함 전체 조회
+				comments, err = gnuWriteRepo.FindCommentsIncludeDeleted(slug, id)
+			} else {
+				blockedIDs := getBlockedIDs(c.Request.Context(), middleware.GetUserID(c))
+				comments, err = gnuWriteRepo.FindCommentsFiltered(slug, id, blockedIDs)
 			}
-			comments, err := gnuWriteRepo.FindCommentsFiltered(slug, id, blockedIDs)
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{"success": true, "data": []any{}})
 				return


### PR DESCRIPTION
## Summary
- 관리자(level >= 10)는 삭제된 댓글도 조회 가능하도록 `FindCommentsIncludeDeleted` 사용
- 일반 유저는 기존대로 `FindCommentsFiltered`로 삭제된 댓글 제외

## Test plan
- [ ] 관리자 계정으로 삭제된 댓글이 있는 게시물 조회 → 삭제된 댓글 표시 확인
- [ ] 일반 유저로 동일 게시물 조회 → 삭제된 댓글 미표시 확인