### PR TITLE
fix: wr_deleted_at 쿼리용 idx_list_deleted 인덱스 추가

### DIFF
--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -33,6 +33,9 @@ func Run(db *gorm.DB) error {
 	if err := FixListPageIndexes(db); err != nil {
 		return err
 	}
+	if err := AddListDeletedIndexes(db); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/migration/soft_delete.go
+++ b/internal/migration/soft_delete.go
@@ -145,6 +145,45 @@ func FixListPageIndexes(db *gorm.DB) error {
 	return nil
 }
 
+// AddListDeletedIndexes adds idx_list_deleted (wr_is_comment, wr_deleted_at, wr_num, wr_reply)
+// to all board tables. This covers queries that filter by wr_deleted_at (e.g. damoang-backend).
+func AddListDeletedIndexes(db *gorm.DB) error {
+	var boardIDs []string
+	if err := db.Table("g5_board").Pluck("bo_table", &boardIDs).Error; err != nil {
+		return fmt.Errorf("failed to get board IDs: %w", err)
+	}
+
+	addedCount := 0
+	for _, boardID := range boardIDs {
+		table := fmt.Sprintf("g5_write_%s", boardID)
+
+		// Check if idx_list_deleted already exists
+		var exists int64
+		db.Raw(`
+			SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+			WHERE TABLE_SCHEMA = DATABASE()
+			AND TABLE_NAME = ?
+			AND INDEX_NAME = 'idx_list_deleted'
+		`, table).Scan(&exists)
+
+		if exists > 0 {
+			continue
+		}
+
+		sql := fmt.Sprintf(`ALTER TABLE %s ADD INDEX idx_list_deleted (wr_is_comment, wr_deleted_at, wr_num, wr_reply), ALGORITHM=INPLACE, LOCK=NONE`, table)
+		if err := db.Exec(sql).Error; err != nil {
+			log.Printf("[Migration] Warning: Failed to add idx_list_deleted on %s: %v", table, err)
+			continue
+		}
+		addedCount++
+	}
+
+	if addedCount > 0 {
+		log.Printf("[Migration] Added idx_list_deleted on %d tables", addedCount)
+	}
+	return nil
+}
+
 // CreateWriteRevisionsTable creates the g5_write_revisions table for post history tracking
 func CreateWriteRevisionsTable(db *gorm.DB) error {
 	// Check if table already exists


### PR DESCRIPTION
## Summary
- 모든 게시판 테이블에 `idx_list_deleted (wr_is_comment, wr_deleted_at, wr_num, wr_reply)` 인덱스 추가
- `wr_deleted_at IS NULL` 필터를 사용하는 쿼리(damoang-backend)의 슬로우 쿼리 해결
- ALGORITHM=INPLACE, LOCK=NONE으로 무중단 적용
- 기존 `idx_list_page (wr_is_comment, wr_num, wr_reply)`와 함께 유지하여 두 패턴 모두 커버

## Test plan
- [ ] 서버 시작 시 마이그레이션 로그에서 idx_list_deleted 추가 확인
- [ ] 목록 쿼리 EXPLAIN에서 idx_list_deleted 사용 확인
- [ ] 슬로우 쿼리 로그에서 wr_deleted_at 조건 쿼리 감소 확인