### PR TITLE
fix: promotions JOIN 쿼리 Redis 5분 캐시 적용

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3619,7 +3619,7 @@ func main() {
 		v2routes.SetupBanner(router, v2handler.NewBannerHandler(bannerRepo))
 
 		promotionRepo := v2repo.NewPromotionRepository(db)
-		v2routes.SetupPromotion(router, v2handler.NewPromotionHandler(promotionRepo))
+		v2routes.SetupPromotion(router, v2handler.NewPromotionHandler(promotionRepo, redisClient))
 
 		v2routes.SetupLicense(router, v2handler.NewLicenseHandler())
 

--- a/internal/handler/v2/promotion_handler.go
+++ b/internal/handler/v2/promotion_handler.go
@@ -1,37 +1,69 @@
 package v2
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 )
+
+const promotionCacheTTL = 5 * time.Minute
+const promotionCacheKeyPrefix = "promo:insert:"
 
 // PromotionHandler handles promotion post API endpoints
 type PromotionHandler struct {
 	promotionRepo v2repo.PromotionRepository
+	redis         *redis.Client
 }
 
 // NewPromotionHandler creates a new PromotionHandler
-func NewPromotionHandler(promotionRepo v2repo.PromotionRepository) *PromotionHandler {
-	return &PromotionHandler{promotionRepo: promotionRepo}
+func NewPromotionHandler(promotionRepo v2repo.PromotionRepository, redisClient ...*redis.Client) *PromotionHandler {
+	h := &PromotionHandler{promotionRepo: promotionRepo}
+	if len(redisClient) > 0 {
+		h.redis = redisClient[0]
+	}
+	return h
 }
 
 // GetInsertPosts handles GET /api/v1/promotion/posts/insert?count=N
-// Returns promotion posts to be inserted into board lists
-// TODO: v2 마이그레이션 - DB 재설계 후 /api/v2/promotion/posts/insert로 전환
+// Returns promotion posts to be inserted into board lists.
+// Results are cached in Redis for 5 minutes to reduce DB load.
 func (h *PromotionHandler) GetInsertPosts(c *gin.Context) {
 	count := 3 // default
 	if n, err := strconv.Atoi(c.Query("count")); err == nil && n > 0 && n <= 20 {
 		count = n
 	}
 
+	// Try Redis cache first
+	if h.redis != nil {
+		cacheKey := fmt.Sprintf("%s%d", promotionCacheKeyPrefix, count)
+		cached, err := h.redis.Get(context.Background(), cacheKey).Bytes()
+		if err == nil {
+			c.Data(http.StatusOK, "application/json", cached)
+			return
+		}
+	}
+
 	posts, err := h.promotionRepo.FindInsertPosts(count)
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "직홍 게시글 조회 실패", err)
 		return
+	}
+
+	// Cache the JSON response
+	if h.redis != nil {
+		resp := common.V2Response{Success: true, Data: posts}
+		if data, err := json.Marshal(resp); err == nil {
+			cacheKey := fmt.Sprintf("%s%d", promotionCacheKeyPrefix, count)
+			h.redis.Set(context.Background(), cacheKey, data, promotionCacheTTL)
+		}
 	}
 
 	common.V2Success(c, posts)


### PR DESCRIPTION
## Summary
- `FindInsertPosts()` (promotions + advertisers JOIN + ORDER BY RAND()) 결과를 Redis에 5분 캐시
- 슬로우 쿼리 1건(평균 2.2초) 해결
- `NewPromotionHandler`에 optional `redisClient` 파라미터 추가 (하위 호환)

## Test plan
- [ ] 첫 호출 시 DB 쿼리 실행 확인
- [ ] 5분 내 재호출 시 Redis 캐시 응답 확인 (빠른 응답)
- [ ] Redis 미연결 시 기존과 동일하게 DB 직접 조회