### PR TITLE
fix: 배포 완료 텔레그램 알림 git checkout 의존성 제거

### DIFF
--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -215,13 +215,14 @@ jobs:
         env:
           IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         run: |
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          COMMIT_MSG=$(git log -1 --pretty=format:'%s')
+          COMMIT_MSG=$(echo "${{ github.event.head_commit.message }}" | head -1)
 
           MSG="🚀 angple-backend 배포 완료
 
-          커밋: ${SHORT_SHA} - ${COMMIT_MSG}
+          커밋: ${GITHUB_SHA:0:7} - ${COMMIT_MSG}
           Tag: ${IMAGE_TAG}"
+
+          MSG=$(echo "$MSG" | sed 's/^          //')
 
           curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \


### PR DESCRIPTION
## Summary
- deploy-production 잡에서 텔레그램 알림 시 `git log` 대신 `github.event.head_commit.message` 사용
- checkout 없는 잡에서도 커밋 메시지 정상 표시

## 원인
- deploy-production 잡에 checkout 스텝이 없어서 `git log` 실행 시 exit code 128 발생

## 수정
- `git log -1 --pretty=format:'%s'` → `${{ github.event.head_commit.message }}`
- 들여쓰기 제거 sed 추가