### PR TITLE
feat: admin 쪽지 차단 + 이용제한 중 쪽지/삭제 차단 + disciplinelog 해제 표시

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3610,7 +3610,7 @@ func main() {
 		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager)
 		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager)
 		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
-		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager)
+		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
 
 		// v1 message routes (uses g5_memo table directly)
 		gnuMemoRepo := gnurepo.NewMemoRepository(db)
@@ -3619,7 +3619,7 @@ func main() {
 		v1Messages.GET("", v1MsgHandler.GetMessages)
 		v1Messages.GET("/unread-count", v1MsgHandler.GetUnreadCount)
 		v1Messages.GET("/:id", v1MsgHandler.GetMessage)
-		v1Messages.POST("", v1MsgHandler.SendMessage)
+		v1Messages.POST("", banCheck, v1MsgHandler.SendMessage)
 		v1Messages.DELETE("/:id", v1MsgHandler.DeleteMessage)
 
 		// Banner, Promotion, License (v1 + v2 dual routes)

--- a/internal/domain/v2/discipline_log.go
+++ b/internal/domain/v2/discipline_log.go
@@ -126,6 +126,7 @@ type DisciplineLogListResponse struct {
 	MemberNickname  string   `json:"member_nickname"`
 	PenaltyPeriod   int      `json:"penalty_period"`
 	PenaltyDateFrom string   `json:"penalty_date_from"`
+	PenaltyDateTo   *string  `json:"penalty_date_to,omitempty"`
 	ViolationTypes  []int    `json:"violation_types"`
 	ViolationTitles []string `json:"violation_titles"`
 }
@@ -164,7 +165,7 @@ func (d *DisciplineLog) ToListResponse() DisciplineLogListResponse {
 		}
 	}
 
-	return DisciplineLogListResponse{
+	resp := DisciplineLogListResponse{
 		ID:              d.ID,
 		MemberID:        d.MemberID,
 		MemberNickname:  d.MemberNickname,
@@ -173,6 +174,11 @@ func (d *DisciplineLog) ToListResponse() DisciplineLogListResponse {
 		ViolationTypes:  d.ViolationTypes,
 		ViolationTitles: titles,
 	}
+	if d.PenaltyDateTo != nil {
+		to := d.PenaltyDateTo.Format("2006-01-02")
+		resp.PenaltyDateTo = &to
+	}
+	return resp
 }
 
 // ToDetailResponse converts DisciplineLog to detail response

--- a/internal/handler/message_handler.go
+++ b/internal/handler/message_handler.go
@@ -201,6 +201,12 @@ func (h *V1MessageHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
+	// Block messages to admin account
+	if req.ReceiverID == "admin" {
+		common.V2ErrorResponse(c, http.StatusForbidden, "관리자에게는 쪽지를 보낼 수 없습니다", nil)
+		return
+	}
+
 	// Verify receiver exists
 	_, err := h.memberRepo.FindByID(req.ReceiverID)
 	if err != nil {

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -79,7 +79,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			banEndStr = "영구 제재"
 		}
 		common.ErrorResponse(c, http.StatusForbidden,
-			"제재 기간 중에는 글을 작성할 수 없습니다. (해제일: "+banEndStr+")", nil)
+			"이용제한 기간 중에는 해당 기능을 사용할 수 없습니다. (해제일: "+banEndStr+")", nil)
 		c.Abort()
 	}
 }

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -50,8 +50,8 @@ func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, 
 	boardPosts.POST("", auth, banCheck, middleware.RequireWrite(boardPermChecker), h.CreatePost)
 	boardPosts.GET("/:id", h.GetPost)
 	boardPosts.PUT("/:id", auth, banCheck, h.UpdatePost)
-	boardPosts.DELETE("/:id", auth, h.DeletePost)
-	boardPosts.PATCH("/:id/soft-delete", auth, h.SoftDeletePost)
+	boardPosts.DELETE("/:id", auth, banCheck, h.DeletePost)
+	boardPosts.PATCH("/:id/soft-delete", auth, banCheck, h.SoftDeletePost)
 	boardPosts.POST("/:id/restore", auth, middleware.RequireAdmin(), h.RestorePost)
 	boardPosts.DELETE("/:id/permanent", auth, middleware.RequireAdmin(), h.PermanentDeletePost)
 	boardPosts.GET("/:id/revisions", auth, h.GetPostRevisions)
@@ -62,7 +62,7 @@ func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, 
 	comments.GET("", h.ListComments)
 	comments.POST("", auth, banCheck, middleware.RequireComment(boardPermChecker), h.CreateComment)
 	comments.PUT("/:comment_id", auth, banCheck, h.UpdateComment)
-	comments.DELETE("/:comment_id", auth, h.DeleteComment)
+	comments.DELETE("/:comment_id", auth, banCheck, h.DeleteComment)
 }
 
 // SetupAdminPosts configures v2 admin post routes (deleted posts)
@@ -152,11 +152,15 @@ func SetupBlock(router *gin.Engine, h *v2handler.BlockHandler, jwtManager *jwt.M
 }
 
 // SetupMessage configures v2 message routes
-func SetupMessage(router *gin.Engine, h *v2handler.MessageHandler, jwtManager *jwt.Manager) {
+func SetupMessage(router *gin.Engine, h *v2handler.MessageHandler, jwtManager *jwt.Manager, gnuDB ...*gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)
 
 	messages := router.Group("/api/v2/messages", auth)
-	messages.POST("", h.SendMessage)
+	if len(gnuDB) > 0 && gnuDB[0] != nil {
+		messages.POST("", middleware.BanCheck(gnuDB[0]), h.SendMessage)
+	} else {
+		messages.POST("", h.SendMessage)
+	}
 	messages.GET("/inbox", h.GetInbox)
 	messages.GET("/sent", h.GetSent)
 	messages.GET("/:id", h.GetMessage)


### PR DESCRIPTION
## Summary
- admin 계정에게 쪽지 발신 차단 (백엔드 403 반환)
- BanCheck 미들웨어를 쪽지 발신(v1+v2), 글/댓글 삭제에도 적용
- disciplinelog 리스트 API에 penalty_date_to 필드 추가 (해제 표시용)
- BanCheck 에러 메시지를 범용적으로 변경

## Test plan
- [ ] admin에게 쪽지 보내기 → 403 에러 확인
- [ ] 이용제한 회원으로 쪽지/글삭제 시도 → 차단 확인
- [ ] disciplinelog API에서 penalty_date_to 반환 확인