### PR TITLE
이용제한 만료 자동 복원 cron + 날짜 파서 보강

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4109,6 +4109,13 @@ func main() {
 		pluginManager.StartScheduler()
 		pkglogger.Info("Plugin Store & Marketplace initialized")
 
+		// Giving plugin API
+		givingHandler := handler.NewGivingHandler(db)
+		givingGroup := router.Group("/api/plugins/giving")
+		{
+			givingGroup.GET("/list", givingHandler.List)
+		}
+
 		// Internal cron endpoints (curl-based cron jobs)
 		cronHandler := cron.NewHandler(db)
 		cronGroup := router.Group("/api/internal/cron")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4123,6 +4123,7 @@ func main() {
 		cronGroup.POST("/update-member-levels", cronHandler.UpdateMemberLevels)
 		cronGroup.POST("/process-approved-reports", cronHandler.ProcessApprovedReports)
 		cronGroup.POST("/update-report-pattern", cronHandler.UpdateReportPattern)
+		cronGroup.POST("/discipline-release", cronHandler.DisciplineRelease)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(gnuWriteRepo, scheduledDeleteRepo)

--- a/internal/cron/discipline_release.go
+++ b/internal/cron/discipline_release.go
@@ -1,0 +1,84 @@
+package cron
+
+import (
+	"log"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// DisciplineReleaseResult contains the result of discipline release
+type DisciplineReleaseResult struct {
+	LevelRestoredCount    int      `json:"level_restored_count"`
+	LevelRestoredIDs      []string `json:"level_restored_ids"`
+	InterceptReleasedCount int     `json:"intercept_released_count"`
+	InterceptReleasedIDs   []string `json:"intercept_released_ids"`
+	ExecutedAt            string   `json:"executed_at"`
+}
+
+// runDisciplineRelease restores level and clears intercept for expired discipline records
+func runDisciplineRelease(db *gorm.DB) (*DisciplineReleaseResult, error) {
+	now := time.Now()
+	result := &DisciplineReleaseResult{
+		ExecutedAt: now.Format("2006-01-02 15:04:05"),
+	}
+
+	// 1. Restore levels for expired level-type disciplines
+	// Conditions: penalty_type includes 'level' or 'all', period > 0 (not permanent), expired, member still at level 1
+	type expiredDiscipline struct {
+		PenaltyMbID string `gorm:"column:penalty_mb_id"`
+		PrevLevel   int    `gorm:"column:prev_level"`
+	}
+
+	var expired []expiredDiscipline
+	if err := db.Raw(`
+		SELECT d.penalty_mb_id, d.prev_level
+		FROM g5_da_member_discipline d
+		JOIN g5_member m ON m.mb_id = d.penalty_mb_id
+		WHERE d.penalty_type IN ('level', 'all')
+		  AND d.penalty_period > 0
+		  AND d.penalty_period != -1
+		  AND m.mb_level <= 1
+		  AND DATE_ADD(d.penalty_date_from, INTERVAL d.penalty_period DAY) < NOW()
+	`).Scan(&expired).Error; err != nil {
+		return nil, err
+	}
+
+	for _, e := range expired {
+		if e.PrevLevel <= 1 {
+			e.PrevLevel = 2 // minimum restore level
+		}
+		if err := db.Table("g5_member").
+			Where("mb_id = ? AND mb_level <= 1", e.PenaltyMbID).
+			Update("mb_level", e.PrevLevel).Error; err != nil {
+			log.Printf("[Cron:discipline-release] failed to restore level for %s: %v", e.PenaltyMbID, err)
+			continue
+		}
+		result.LevelRestoredIDs = append(result.LevelRestoredIDs, e.PenaltyMbID)
+		result.LevelRestoredCount++
+	}
+
+	// 2. Clear expired intercept dates
+	var interceptIDs []string
+	if err := db.Raw(`
+		SELECT mb_id FROM g5_member
+		WHERE mb_intercept_date != '' AND mb_intercept_date != '0000-00-00'
+		  AND mb_intercept_date < ?
+		  AND mb_intercept_date NOT LIKE '9999%'
+	`, now.Format("20060102")).Scan(&interceptIDs).Error; err != nil {
+		return nil, err
+	}
+
+	if len(interceptIDs) > 0 {
+		if err := db.Table("g5_member").
+			Where("mb_id IN ?", interceptIDs).
+			Update("mb_intercept_date", "").Error; err != nil {
+			log.Printf("[Cron:discipline-release] failed to clear intercept dates: %v", err)
+		} else {
+			result.InterceptReleasedIDs = interceptIDs
+			result.InterceptReleasedCount = len(interceptIDs)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -84,6 +84,26 @@ func (h *Handler) ProcessApprovedReports(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
 }
 
+// DisciplineRelease handles POST /api/internal/cron/discipline-release
+// Restores levels and clears intercept dates for expired disciplines
+func (h *Handler) DisciplineRelease(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runDisciplineRelease(h.db)
+	if err != nil {
+		log.Printf("[Cron:discipline-release] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:discipline-release] levels restored: %d %v, intercepts released: %d %v",
+		result.LevelRestoredCount, result.LevelRestoredIDs,
+		result.InterceptReleasedCount, result.InterceptReleasedIDs)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
 // UpdateReportPattern handles POST /api/internal/cron/update-report-pattern
 func (h *Handler) UpdateReportPattern(c *gin.Context) {
 	if !h.verifySecret(c) {

--- a/internal/handler/giving_handler.go
+++ b/internal/handler/giving_handler.go
@@ -1,0 +1,128 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// GivingHandler handles giving plugin API endpoints
+type GivingHandler struct {
+	db *gorm.DB
+}
+
+// NewGivingHandler creates a new GivingHandler
+func NewGivingHandler(db *gorm.DB) *GivingHandler {
+	return &GivingHandler{db: db}
+}
+
+// GivingListItem represents a giving item in list response
+type GivingListItem struct {
+	ID               int    `json:"id"`
+	Title            string `json:"title"`
+	Extra5           string `json:"extra_5"`
+	ParticipantCount int    `json:"participant_count"`
+	IsUrgent         bool   `json:"is_urgent"`
+}
+
+// List returns giving posts filtered by tab (active/ended)
+// GET /api/plugins/giving/list?tab=active&limit=8&sort=urgent
+func (h *GivingHandler) List(c *gin.Context) {
+	tab := c.DefaultQuery("tab", "active")
+	sortBy := c.DefaultQuery("sort", "urgent")
+	limitStr := c.DefaultQuery("limit", "8")
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 || limit > 50 {
+		limit = 8
+	}
+
+	now := time.Now()
+
+	type givingRow struct {
+		WrID             int    `gorm:"column:wr_id"`
+		WrSubject        string `gorm:"column:wr_subject"`
+		Wr5              string `gorm:"column:wr_5"` // end_time
+		ParticipantCount int    `gorm:"column:participant_count"`
+	}
+
+	query := h.db.Table("g5_write_giving AS g").
+		Select(`g.wr_id, g.wr_subject, g.wr_5,
+			COALESCE((SELECT COUNT(DISTINCT b.mb_id) FROM g5_giving_bid b WHERE b.wr_id = g.wr_id), 0) AS participant_count`).
+		Where("g.wr_is_comment = 0")
+
+	nowStr := now.Format("2006-01-02T15:04")
+	switch tab {
+	case "active":
+		query = query.
+			Where("(g.wr_7 = '' OR g.wr_7 IS NULL)").
+			Where("g.wr_5 != '' AND g.wr_5 > ?", nowStr)
+	case "ended":
+		query = query.Where(
+			"(g.wr_5 != '' AND g.wr_5 <= ?) OR g.wr_7 = '2'", nowStr,
+		)
+	}
+
+	switch sortBy {
+	case "urgent":
+		query = query.Order("g.wr_5 ASC")
+	case "newest":
+		query = query.Order("g.wr_id DESC")
+	default:
+		query = query.Order("g.wr_5 ASC")
+	}
+
+	var rows []givingRow
+	if err := query.Limit(limit).Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch giving list",
+		})
+		return
+	}
+
+	items := make([]GivingListItem, 0, len(rows))
+	for _, r := range rows {
+		isUrgent := false
+		if r.Wr5 != "" {
+			if endTime, err := parseGivingTime(r.Wr5); err == nil {
+				diff := endTime.Sub(now)
+				isUrgent = diff > 0 && diff <= 24*time.Hour
+			}
+		}
+
+		items = append(items, GivingListItem{
+			ID:               r.WrID,
+			Title:            r.WrSubject,
+			Extra5:           r.Wr5,
+			ParticipantCount: r.ParticipantCount,
+			IsUrgent:         isUrgent,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    items,
+	})
+}
+
+// parseGivingTime parses various time formats used in giving posts
+func parseGivingTime(s string) (time.Time, error) {
+	formats := []string{
+		"2006-01-02T15:04",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+	}
+	loc, _ := time.LoadLocation("Asia/Seoul")
+	for _, f := range formats {
+		if t, err := time.ParseInLocation(f, s, loc); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse time: %s", s)
+}

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -111,7 +111,10 @@ func ArchiveBoardCheck() gin.HandlerFunc {
 	}
 }
 
-// parseInterceptDate parses mb_intercept_date which can be "2006-01-02 15:04:05" or "20060102" format.
+// parseInterceptDate parses mb_intercept_date which can be:
+//   - "2006-01-02 15:04:05" (datetime)
+//   - "20060102" (short date, varchar(8) native)
+//   - "2006-01-" (truncated YYYY-MM-DD stored in varchar(8))
 func parseInterceptDate(s string) (time.Time, error) {
 	if t, err := time.ParseInLocation(interceptDateFormat, s, time.Local); err == nil {
 		return t, nil
@@ -119,6 +122,14 @@ func parseInterceptDate(s string) (time.Time, error) {
 	if t, err := time.ParseInLocation(interceptDateShortFormat, s, time.Local); err == nil {
 		// Short format has no time component — treat as end of day
 		return t.Add(24*time.Hour - time.Second), nil
+	}
+	// Handle truncated "YYYY-MM-" format (varchar(8) truncation of "YYYY-MM-DD")
+	if len(s) == 8 && s[4] == '-' && s[7] == '-' {
+		if t, err := time.ParseInLocation("2006-01-", s, time.Local); err == nil {
+			// Truncated — treat as last day of that month (conservative: assume banned)
+			lastDay := t.AddDate(0, 1, -1)
+			return lastDay.Add(24*time.Hour - time.Second), nil
+		}
 	}
 	return time.Time{}, fmt.Errorf("unknown date format: %s", s)
 }


### PR DESCRIPTION
## Summary
- 레벨 강등 제재 만료 시 `prev_level`로 자동 복원하는 discipline-release cron 추가
- `mb_intercept_date` 만료 시 자동 초기화
- `parseInterceptDate`에 `YYYY-MM-` 잘린 날짜 형식 지원 추가 (varchar(8) 잘림 호환)

## 배경
- PHP에서 `mb_intercept_date`를 `YYYY-MM-DD` (10자)로 저장하면 varchar(8) 컬럼에서 `YYYY-MM-`으로 잘림
- 잘린 날짜는 파싱 실패 → 영구제재 회원도 이용제한 미적용
- 레벨 강등 후 기간 만료해도 레벨이 복원되지 않아 영구 차단 상태 발생

## DB 수정 사항 (이미 적용)
- `9999-12-` → `99991231` (영구제재 3명)
- `2026-03-` → `20260309` (5일 제재 2명)
- 만료된 레벨 강등 2명 (DONGWON, 하늘바람꿈) 즉시 복원 완료

## Test plan
- [ ] `POST /api/internal/cron/discipline-release?secret=XXX` 호출 시 정상 응답
- [ ] 만료된 레벨 강등 회원의 레벨이 `prev_level`로 복원되는지 확인
- [ ] 만료된 `mb_intercept_date`가 초기화되는지 확인
- [ ] `YYYY-MM-` 형식 날짜가 정상 파싱되는지 확인