### PR TITLE
fix: dev pod 에러 수정 및 N+1 쿼리 최적화

### DIFF
--- a/internal/domain/subscription.go
+++ b/internal/domain/subscription.go
@@ -10,7 +10,7 @@ type Subscription struct {
 	CurrentPeriodEnd   time.Time  `gorm:"column:current_period_end" json:"current_period_end"`
 	CanceledAt         *time.Time `gorm:"column:canceled_at" json:"canceled_at,omitempty"`
 
-	SiteID          string `gorm:"column:site_id;uniqueIndex" json:"site_id"`
+	SiteID          string `gorm:"column:site_id;type:varchar(255);uniqueIndex" json:"site_id"`
 	Plan            string `gorm:"column:plan" json:"plan"`                                   // free, pro, business, enterprise
 	Status          string `gorm:"column:status;default:active" json:"status"`                // active, past_due, canceled, trialing
 	PaymentProvider string `gorm:"column:payment_provider" json:"payment_provider"`           // stripe, toss, manual
@@ -32,7 +32,7 @@ type Invoice struct {
 	PeriodStart time.Time  `gorm:"column:period_start" json:"period_start"`
 	PeriodEnd   time.Time  `gorm:"column:period_end" json:"period_end"`
 
-	SiteID          string `gorm:"column:site_id;index" json:"site_id"`
+	SiteID          string `gorm:"column:site_id;type:varchar(255);index" json:"site_id"`
 	Status          string `gorm:"column:status;default:pending" json:"status"` // pending, paid, failed, refunded
 	PaymentProvider string `gorm:"column:payment_provider" json:"payment_provider"`
 	ExternalInvID   string `gorm:"column:external_inv_id" json:"external_inv_id"`

--- a/internal/repository/site_repo.go
+++ b/internal/repository/site_repo.go
@@ -106,6 +106,27 @@ func (r *SiteRepository) FindSettingsBySiteID(ctx context.Context, siteID string
 	return &settings, nil
 }
 
+// FindSettingsBySiteIDs retrieves settings for multiple sites in a single query
+func (r *SiteRepository) FindSettingsBySiteIDs(ctx context.Context, siteIDs []string) (map[string]*domain.SiteSettings, error) {
+	if len(siteIDs) == 0 {
+		return make(map[string]*domain.SiteSettings), nil
+	}
+
+	var settingsList []domain.SiteSettings
+	err := r.db.WithContext(ctx).
+		Where("site_id IN ?", siteIDs).
+		Find(&settingsList).Error
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*domain.SiteSettings, len(settingsList))
+	for i := range settingsList {
+		result[settingsList[i].SiteID] = &settingsList[i]
+	}
+	return result, nil
+}
+
 // CreateSettings creates initial site settings
 func (r *SiteRepository) CreateSettings(ctx context.Context, settings *domain.SiteSettings) error {
 	return r.db.WithContext(ctx).Create(settings).Error

--- a/internal/repository/v2/gnuboard_point_repo.go
+++ b/internal/repository/v2/gnuboard_point_repo.go
@@ -29,25 +29,20 @@ func (r *gnuboardPointRepository) GetSummary(mbID string) (*PointSummary, error)
 		return nil, err
 	}
 
-	// Calculate total earned and used from g5_point
-	var totalEarned, totalUsed int
-
-	// Sum positive points (earned)
+	// Calculate total earned and used in a single query
+	var result struct {
+		TotalEarned int
+		TotalUsed   int
+	}
 	r.db.Model(&gnuboard.G5Point{}).
-		Select("COALESCE(SUM(po_point), 0)").
-		Where("po_mb_id = ? AND po_point > 0", mbID).
-		Scan(&totalEarned)
-
-	// Sum negative points (used) - make it positive for display
-	r.db.Model(&gnuboard.G5Point{}).
-		Select("COALESCE(ABS(SUM(po_point)), 0)").
-		Where("po_mb_id = ? AND po_point < 0", mbID).
-		Scan(&totalUsed)
+		Select("COALESCE(SUM(CASE WHEN po_point > 0 THEN po_point ELSE 0 END), 0) as total_earned, COALESCE(SUM(CASE WHEN po_point < 0 THEN ABS(po_point) ELSE 0 END), 0) as total_used").
+		Where("po_mb_id = ?", mbID).
+		Scan(&result)
 
 	return &PointSummary{
 		TotalPoint:  member.MbPoint,
-		TotalEarned: totalEarned,
-		TotalUsed:   totalUsed,
+		TotalEarned: result.TotalEarned,
+		TotalUsed:   result.TotalUsed,
 	}, nil
 }
 

--- a/internal/repository/v2/point_repo.go
+++ b/internal/repository/v2/point_repo.go
@@ -100,25 +100,20 @@ func (r *pointRepository) GetSummary(userID uint64) (*PointSummary, error) {
 		return nil, err
 	}
 
-	// Calculate total earned and used from history
-	var totalEarned, totalUsed int
-
-	// Sum positive points (earned)
+	// Calculate total earned and used in a single query
+	var result struct {
+		TotalEarned int
+		TotalUsed   int
+	}
 	r.db.Model(&v2.V2Point{}).
-		Select("COALESCE(SUM(point), 0)").
-		Where("user_id = ? AND point > 0", userID).
-		Scan(&totalEarned)
-
-	// Sum negative points (used) - make it positive for display
-	r.db.Model(&v2.V2Point{}).
-		Select("COALESCE(ABS(SUM(point)), 0)").
-		Where("user_id = ? AND point < 0", userID).
-		Scan(&totalUsed)
+		Select("COALESCE(SUM(CASE WHEN point > 0 THEN point ELSE 0 END), 0) as total_earned, COALESCE(SUM(CASE WHEN point < 0 THEN ABS(point) ELSE 0 END), 0) as total_used").
+		Where("user_id = ?", userID).
+		Scan(&result)
 
 	return &PointSummary{
 		TotalPoint:  user.Point,
-		TotalEarned: totalEarned,
-		TotalUsed:   totalUsed,
+		TotalEarned: result.TotalEarned,
+		TotalUsed:   result.TotalUsed,
 	}, nil
 }
 

--- a/internal/service/site_service.go
+++ b/internal/service/site_service.go
@@ -210,14 +210,21 @@ func (s *SiteService) ListActive(ctx context.Context, limit, offset int) ([]doma
 		return nil, fmt.Errorf("failed to list sites: %w", err)
 	}
 
+	// Batch load settings for all sites in a single query
+	siteIDs := make([]string, len(sites))
+	for i, site := range sites {
+		siteIDs[i] = site.ID
+	}
+
+	settingsMap, err := s.repo.FindSettingsBySiteIDs(ctx, siteIDs)
+	if err != nil {
+		// Settings lookup failure is non-fatal, continue with empty map
+		settingsMap = make(map[string]*domain.SiteSettings)
+	}
+
 	responses := make([]domain.SiteResponse, 0, len(sites))
 	for _, site := range sites {
-		settings, err := s.repo.FindSettingsBySiteID(ctx, site.ID)
-		if err != nil {
-			// Settings not found is acceptable, continue with nil settings
-			settings = nil
-		}
-		resp := site.ToResponse(settings)
+		resp := site.ToResponse(settingsMap[site.ID])
 		responses = append(responses, *resp)
 	}
 


### PR DESCRIPTION
## Summary
- subscription.go: SiteID `type:varchar(255)` 추가 → BLOB/TEXT 인덱스 에러 해결
- site_service ListActive: N+1 쿼리 → 배치 조회 (1+N → 2 쿼리)
- point_repo, gnuboard_point_repo: GetSummary 3쿼리 → CASE WHEN 1쿼리로 통합

## 추가 작업 (코드 외)
- DB: 모든 g5_write_* 테이블에 `idx_list_page` 인덱스 추가 (온라인 DDL)
- Web: `git restore`로 canWrite() 회귀 복원

## Test plan
- [x] `make build` 성공
- [x] dev pod 재시작 후 에러 로그 0건 확인
- [x] `/free`, `/notice` 200 응답 확인