### PR TITLE
feat: XP 시스템 고도화

### DIFF
--- a/.docker/mysql/init/14-xp-indexes.sql
+++ b/.docker/mysql/init/14-xp-indexes.sql
@@ -1,0 +1,8 @@
+-- g5_na_xp 인덱스 추가
+-- HasTodayAction 쿼리: WHERE mb_id = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?
+-- DATE() 함수 대신 범위 쿼리 사용으로 인덱스 활용 가능
+CREATE INDEX IF NOT EXISTS idx_mb_action_date ON g5_na_xp (mb_id, xp_rel_action, xp_datetime);
+
+-- GetHistory 쿼리: WHERE mb_id = ? ORDER BY xp_datetime DESC
+-- 기존 mb_id 단일 인덱스 대신 복합 인덱스로 filesort 방지
+CREATE INDEX IF NOT EXISTS idx_mb_datetime ON g5_na_xp (mb_id, xp_datetime DESC);

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -390,9 +390,7 @@ func main() {
 		v2Handler.SetNotiRepository(gnurepo.NewNotiRepository(db))
 		v2Handler.SetGnuDB(db)
 
-		// TODO: 경험치 서비스 구현 후 활성화
-		// expSvc := v2svc.NewExpService(v2UserRepo)
-		// v2Handler.SetExpService(expSvc)
+		// XP: DI into V2Handler (set after expRepo is created below)
 
 		v2routes.Setup(router, v2Handler, jwtManager, permChecker, db)
 		v2routes.SetupAdminPosts(router, v2Handler, jwtManager)
@@ -402,6 +400,10 @@ func main() {
 		gnuPointRepo := v2repo.NewGnuboardPointRepository(db)
 		pointHandler := v2handler.NewPointHandler(gnuPointRepo)
 		expHandler := v2handler.NewExpHandler(v2ExpRepo)
+		expHandler.SetNotiRepository(gnurepo.NewNotiRepository(db))
+
+		// Inject expRepo into V2Handler for write/comment XP
+		v2Handler.SetExpRepository(v2ExpRepo)
 		myPageRepo := gnurepo.NewMyPageRepository(db, gnuBoardRepo)
 		myPageHandler := handler.NewMyPageHandler(myPageRepo)
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)

--- a/internal/handler/v2/exp_handler.go
+++ b/internal/handler/v2/exp_handler.go
@@ -1,24 +1,56 @@
 package v2
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/middleware"
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/gin-gonic/gin"
 )
 
 // ExpHandler handles experience point-related endpoints
 type ExpHandler struct {
-	expRepo v2repo.ExpRepository
+	expRepo  v2repo.ExpRepository
+	notiRepo gnurepo.NotiRepository
 }
 
 // NewExpHandler creates a new ExpHandler
 func NewExpHandler(expRepo v2repo.ExpRepository) *ExpHandler {
 	return &ExpHandler{expRepo: expRepo}
+}
+
+// SetNotiRepository sets the optional notification repository for level-up notifications
+func (h *ExpHandler) SetNotiRepository(repo gnurepo.NotiRepository) {
+	h.notiRepo = repo
+}
+
+// createLevelUpNotification inserts a level-up notification into g5_na_noti
+func (h *ExpHandler) createLevelUpNotification(mbID string, newLevel int) {
+	if h.notiRepo == nil {
+		return
+	}
+	noti := &gnurepo.Notification{
+		MbID:          mbID,
+		PhFromCase:    "levelup",
+		PhToCase:      "me",
+		BoTable:       "@system",
+		WrID:          0,
+		RelMbID:       "system",
+		RelMbNick:     "시스템",
+		RelMsg:        fmt.Sprintf("레벨 %d로 승급했습니다!", newLevel),
+		RelURL:        "/mypage/exp",
+		PhReaded:      "N",
+		ParentSubject: fmt.Sprintf("레벨 %d 달성", newLevel),
+	}
+	if err := h.notiRepo.Create(noti); err != nil {
+		log.Printf("[xp] levelup notification failed for %s: %v", mbID, err)
+	}
 }
 
 // GetExpSummary handles GET /api/v1/my/exp
@@ -185,15 +217,21 @@ func (h *ExpHandler) AdminGrantXP(c *gin.Context) {
 	today := time.Now().Format("2006-01-02")
 	relID := "admin-" + adminID + "-" + today
 
-	if err := h.expRepo.AddExp(mbID, req.Point, req.Content, "@admin", relID, "@admin-grant"); err != nil {
+	result, err := h.expRepo.AddExp(mbID, req.Point, req.Content, "@admin", relID, "@admin-grant")
+	if err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "경험치 지급에 실패했습니다", err)
 		return
 	}
 
+	if result.LevelUp {
+		go h.createLevelUpNotification(mbID, result.NewLevel)
+	}
+
 	common.V2Success(c, gin.H{
-		"message": "경험치가 지급되었습니다",
-		"mb_id":   mbID,
-		"point":   req.Point,
+		"message":  "경험치가 지급되었습니다",
+		"mb_id":    mbID,
+		"point":    req.Point,
+		"level_up": result.LevelUp,
 	})
 }
 
@@ -208,8 +246,14 @@ func (h *ExpHandler) AdminGetXPConfig(c *gin.Context) {
 }
 
 // adminUpdateXPConfigRequest represents the request body for updating XP config
+// Uses pointers for partial update (nil = keep existing value)
 type adminUpdateXPConfigRequest struct {
-	LoginXP int `json:"login_xp"`
+	LoginXP        *int  `json:"login_xp"`
+	WriteXP        *int  `json:"write_xp"`
+	CommentXP      *int  `json:"comment_xp"`
+	LoginEnabled   *bool `json:"login_enabled"`
+	WriteEnabled   *bool `json:"write_enabled"`
+	CommentEnabled *bool `json:"comment_enabled"`
 }
 
 // AdminUpdateXPConfig handles PUT /api/v2/admin/xp/config
@@ -220,19 +264,49 @@ func (h *ExpHandler) AdminUpdateXPConfig(c *gin.Context) {
 		return
 	}
 
-	if req.LoginXP < 0 {
-		common.V2ErrorResponse(c, http.StatusBadRequest, "로그인 경험치는 0 이상이어야 합니다", nil)
+	// Load existing config to merge
+	existing, err := h.expRepo.GetXPConfig()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 조회에 실패했습니다", err)
 		return
 	}
 
-	config := &v2repo.XPConfig{LoginXP: req.LoginXP}
-	if err := h.expRepo.UpdateXPConfig(config); err != nil {
+	// Partial update: only override non-nil fields
+	if req.LoginXP != nil {
+		if *req.LoginXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.LoginXP = *req.LoginXP
+	}
+	if req.WriteXP != nil {
+		if *req.WriteXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.WriteXP = *req.WriteXP
+	}
+	if req.CommentXP != nil {
+		if *req.CommentXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.CommentXP = *req.CommentXP
+	}
+	if req.LoginEnabled != nil {
+		existing.LoginEnabled = *req.LoginEnabled
+	}
+	if req.WriteEnabled != nil {
+		existing.WriteEnabled = *req.WriteEnabled
+	}
+	if req.CommentEnabled != nil {
+		existing.CommentEnabled = *req.CommentEnabled
+	}
+
+	if err := h.expRepo.UpdateXPConfig(existing); err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 저장에 실패했습니다", err)
 		return
 	}
 
-	common.V2Success(c, gin.H{
-		"message":  "설정이 저장되었습니다",
-		"login_xp": req.LoginXP,
-	})
+	common.V2Success(c, existing)
 }

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -1,10 +1,10 @@
 package v2
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"strconv"
-
-	"fmt"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -26,6 +26,7 @@ type V2Handler struct {
 	pointRepo    v2repo.PointRepository
 	revisionRepo v2repo.RevisionRepository
 	notiRepo     gnurepo.NotiRepository
+	expRepo      v2repo.ExpRepository
 	gnuDB        *gorm.DB // gnuboard g5_member 조회용
 }
 
@@ -64,6 +65,31 @@ func (h *V2Handler) SetNotiRepository(repo gnurepo.NotiRepository) {
 // SetGnuDB sets the gnuboard database connection for mb_id → mb_no lookup
 func (h *V2Handler) SetGnuDB(db *gorm.DB) {
 	h.gnuDB = db
+}
+
+// SetExpRepository sets the optional exp repository for XP operations
+func (h *V2Handler) SetExpRepository(repo v2repo.ExpRepository) {
+	h.expRepo = repo
+}
+
+// createLevelUpNoti inserts a level-up notification into g5_na_noti
+func (h *V2Handler) createLevelUpNoti(mbID string, newLevel int) {
+	noti := &gnurepo.Notification{
+		MbID:          mbID,
+		PhFromCase:    "levelup",
+		PhToCase:      "me",
+		BoTable:       "@system",
+		WrID:          0,
+		RelMbID:       "system",
+		RelMbNick:     "시스템",
+		RelMsg:        fmt.Sprintf("레벨 %d로 승급했습니다!", newLevel),
+		RelURL:        "/mypage/exp",
+		PhReaded:      "N",
+		ParentSubject: fmt.Sprintf("레벨 %d 달성", newLevel),
+	}
+	if err := h.notiRepo.Create(noti); err != nil {
+		log.Printf("[xp] levelup notification failed for %s: %v", mbID, err)
+	}
 }
 
 // resolveUserIDToMbNo converts gnuboard mb_id (string) to mb_no (uint64)
@@ -350,6 +376,32 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 	// 포인트 처리 (지급 또는 차감)
 	if board.WritePoint != 0 && h.pointRepo != nil {
 		_ = h.pointRepo.AddPoint(userID, board.WritePoint, "글쓰기", "v2_posts", post.ID) //nolint:errcheck
+	}
+
+	// 경험치 부여 (비동기, best-effort)
+	if h.expRepo != nil {
+		mbID := middleware.GetUserID(c)
+		tableName := fmt.Sprintf("v2_posts_%s", slug)
+		wrID := fmt.Sprintf("%d", post.ID)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[xp] write XP panic for %s: %v", mbID, r)
+				}
+			}()
+			xpConfig, err := h.expRepo.GetXPConfig()
+			if err != nil || xpConfig == nil || !xpConfig.WriteEnabled || xpConfig.WriteXP <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpConfig.WriteXP, "글쓰기", tableName, wrID, "@write")
+			if err != nil {
+				log.Printf("[xp] write XP grant failed for %s: %v", mbID, err)
+				return
+			}
+			if result.LevelUp && h.notiRepo != nil {
+				h.createLevelUpNoti(mbID, result.NewLevel)
+			}
+		}()
 	}
 
 	common.V2Created(c, post)
@@ -713,9 +765,19 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	// 포인트 처리 (지급 또는 차감)
+	// 30일 이전 글 체크 (포인트 + XP 모두 적용)
+	// postRepo.FindByID는 PK 조회이므로 빠름 (1회만 조회)
+	isOldPost := false
+	if parentPost, postErr := h.postRepo.FindByID(postID); postErr == nil {
+		isOldPost = time.Since(parentPost.CreatedAt) > 30*24*time.Hour
+	}
+
+	// 포인트 처리 (지급 또는 차감) — 30일 이전 글에는 지급 포인트 미부여
 	if board.CommentPoint != 0 && h.pointRepo != nil {
-		_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+		// 차감 포인트(음수)는 항상 적용, 지급 포인트(양수)는 30일 이내만
+		if board.CommentPoint < 0 || !isOldPost {
+			_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+		}
 	}
 
 	// 알림 생성 (비동기, 에러 무시)
@@ -726,6 +788,32 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 	}
 	if h.notiRepo != nil {
 		go h.createCommentNotification(slug, postID, comment, mbID, authorName)
+	}
+
+	// 경험치 부여 (비동기, best-effort)
+	// 30일 이전 글에 달린 댓글은 XP 미부여 (스팸 방지)
+	if h.expRepo != nil && !isOldPost {
+		tableName := fmt.Sprintf("v2_comments_%s", slug)
+		wrID := fmt.Sprintf("%d", comment.ID)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[xp] comment XP panic for %s: %v", mbID, r)
+				}
+			}()
+			xpConfig, err := h.expRepo.GetXPConfig()
+			if err != nil || xpConfig == nil || !xpConfig.CommentEnabled || xpConfig.CommentXP <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpConfig.CommentXP, "댓글 작성", tableName, wrID, "@comment")
+			if err != nil {
+				log.Printf("[xp] comment XP grant failed for %s: %v", mbID, err)
+				return
+			}
+			if result.LevelUp && h.notiRepo != nil {
+				h.createLevelUpNoti(mbID, result.NewLevel)
+			}
+		}()
 	}
 
 	// FreeComment 형태로 응답 (프론트엔드 호환)

--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -2,11 +2,21 @@ package v2
 
 import (
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
 )
+
+// xpConfigCache caches XPConfig to avoid hitting site_settings on every write/comment
+var (
+	xpConfigCacheMu    sync.RWMutex
+	xpConfigCacheVal   *XPConfig
+	xpConfigCacheExpAt time.Time
+)
+
+const xpConfigCacheTTL = 30 * time.Second
 
 // ExpSummary represents experience point summary statistics
 type ExpSummary struct {
@@ -20,12 +30,24 @@ type ExpSummary struct {
 
 // XPConfig represents configurable XP settings (stored in site_settings.settings_json)
 type XPConfig struct {
-	LoginXP int `json:"login_xp"` // XP granted per daily login (default: 500)
+	LoginXP        int  `json:"login_xp"`        // XP granted per daily login (default: 500)
+	WriteXP        int  `json:"write_xp"`         // XP granted per post (default: 100)
+	CommentXP      int  `json:"comment_xp"`       // XP granted per comment (default: 50)
+	LoginEnabled   bool `json:"login_enabled"`    // Enable login XP (default: true)
+	WriteEnabled   bool `json:"write_enabled"`    // Enable write XP (default: false)
+	CommentEnabled bool `json:"comment_enabled"`  // Enable comment XP (default: false)
 }
 
 // DefaultXPConfig returns the default XP configuration
 func DefaultXPConfig() *XPConfig {
-	return &XPConfig{LoginXP: 500}
+	return &XPConfig{
+		LoginXP:        500,
+		WriteXP:        100,
+		CommentXP:      50,
+		LoginEnabled:   true,
+		WriteEnabled:   false,
+		CommentEnabled: false,
+	}
 }
 
 // MemberXPInfo represents a member's XP summary for admin listing
@@ -37,14 +59,21 @@ type MemberXPInfo struct {
 	MbLevel int    `json:"mb_level"`
 }
 
+// AddExpResult contains the result of an AddExp operation
+type AddExpResult struct {
+	LevelUp  bool `json:"level_up"`
+	OldLevel int  `json:"old_level"`
+	NewLevel int  `json:"new_level"`
+}
+
 // ExpRepository handles experience point data access
 type ExpRepository interface {
 	// GetSummary returns exp summary for a user (by mb_id)
 	GetSummary(mbID string) (*ExpSummary, error)
 	// GetHistory returns exp history with pagination
 	GetHistory(mbID string, page, limit int) ([]gnuboard.ExpHistory, int64, error)
-	// AddExp adds experience points to a user
-	AddExp(mbID string, point int, content, relTable, relID, action string) error
+	// AddExp adds experience points to a user and returns level change info
+	AddExp(mbID string, point int, content, relTable, relID, action string) (*AddExpResult, error)
 	// HasTodayAction checks if the user already has a specific action logged today
 	HasTodayAction(mbID, action string) (bool, error)
 	// ListMembersWithXP returns paginated member list with XP info for admin
@@ -164,8 +193,25 @@ func (r *expRepository) GetHistory(mbID string, page, limit int) ([]gnuboard.Exp
 	return history, total, nil
 }
 
-func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID, action string) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+// maxXPLevel is the highest XP level; users at this level stop earning XP from actions
+var maxXPLevel = len(levelThresholds)
+
+func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID, action string) (*AddExpResult, error) {
+	result := &AddExpResult{}
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		// Get current level before update
+		var member gnuboard.G5Member
+		if err := tx.Select("as_exp, as_level").Where("mb_id = ?", mbID).First(&member).Error; err != nil {
+			return err
+		}
+		result.OldLevel = member.AsLevel
+		result.NewLevel = member.AsLevel
+
+		// 최대 레벨 도달 시 자동 적립(양수) 차단 — 관리자 수동 지급/차감은 허용
+		if member.AsLevel >= maxXPLevel && point > 0 && relTable != "@admin" {
+			return nil // 적립 없이 조용히 반환
+		}
+
 		// Update member exp
 		if err := tx.Model(&gnuboard.G5Member{}).
 			Where("mb_id = ?", mbID).
@@ -173,15 +219,12 @@ func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID,
 			return err
 		}
 
-		// Get updated exp to check level
-		var member gnuboard.G5Member
-		if err := tx.Select("as_exp, as_level").Where("mb_id = ?", mbID).First(&member).Error; err != nil {
-			return err
-		}
-
 		// Check if level up is needed
-		newLevel, _, _, _, _ := calculateLevelInfo(member.AsExp)
+		newExp := member.AsExp + point
+		newLevel, _, _, _, _ := calculateLevelInfo(newExp)
+		result.NewLevel = newLevel
 		if newLevel > member.AsLevel {
+			result.LevelUp = true
 			if err := tx.Model(&gnuboard.G5Member{}).
 				Where("mb_id = ?", mbID).
 				UpdateColumn("as_level", newLevel).Error; err != nil {
@@ -200,14 +243,22 @@ func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID,
 		}
 		return tx.Create(log).Error
 	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // HasTodayAction checks if the user already has a specific action logged today
+// Uses range query on xp_datetime to leverage idx_mb_action_date index
 func (r *expRepository) HasTodayAction(mbID, action string) (bool, error) {
-	today := time.Now().Format("2006-01-02")
+	now := time.Now()
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	tomorrowStart := todayStart.AddDate(0, 0, 1)
 	var count int64
 	err := r.db.Model(&gnuboard.G5NaXP{}).
-		Where("mb_id = ? AND xp_rel_action = ? AND DATE(xp_datetime) = ?", mbID, action, today).
+		Where("mb_id = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?",
+			mbID, action, todayStart, tomorrowStart).
 		Count(&count).Error
 	if err != nil {
 		return false, err
@@ -255,8 +306,34 @@ type settingsJSONWrapper struct {
 	Extra    map[string]interface{} `json:"-"`
 }
 
-// GetXPConfig reads XP configuration from site_settings.settings_json
+// GetXPConfig reads XP configuration from site_settings.settings_json (cached 30s)
 func (r *expRepository) GetXPConfig() (*XPConfig, error) {
+	// Check cache first
+	xpConfigCacheMu.RLock()
+	if xpConfigCacheVal != nil && time.Now().Before(xpConfigCacheExpAt) {
+		cached := *xpConfigCacheVal // copy
+		xpConfigCacheMu.RUnlock()
+		return &cached, nil
+	}
+	xpConfigCacheMu.RUnlock()
+
+	config, err := r.getXPConfigFromDB()
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cache
+	xpConfigCacheMu.Lock()
+	cp := *config
+	xpConfigCacheVal = &cp
+	xpConfigCacheExpAt = time.Now().Add(xpConfigCacheTTL)
+	xpConfigCacheMu.Unlock()
+
+	return config, nil
+}
+
+// getXPConfigFromDB fetches XPConfig directly from database
+func (r *expRepository) getXPConfigFromDB() (*XPConfig, error) {
 	var row siteSettingsJSON
 	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
 	if err != nil {
@@ -277,16 +354,30 @@ func (r *expRepository) GetXPConfig() (*XPConfig, error) {
 		return DefaultXPConfig(), nil
 	}
 
-	// Validate: if login_xp is 0, return default
+	// Fill defaults for zero values on legacy configs (only LoginXP had a value before)
 	if wrapper.XPConfig.LoginXP == 0 {
 		wrapper.XPConfig.LoginXP = 500
+	}
+	if wrapper.XPConfig.WriteXP == 0 {
+		wrapper.XPConfig.WriteXP = 100
+	}
+	if wrapper.XPConfig.CommentXP == 0 {
+		wrapper.XPConfig.CommentXP = 50
 	}
 
 	return wrapper.XPConfig, nil
 }
 
 // UpdateXPConfig writes XP configuration to site_settings.settings_json (preserving other fields)
+// Invalidates the XPConfig cache on success
 func (r *expRepository) UpdateXPConfig(config *XPConfig) error {
+	// Invalidate cache before update (will be repopulated on next read)
+	defer func() {
+		xpConfigCacheMu.Lock()
+		xpConfigCacheVal = nil
+		xpConfigCacheMu.Unlock()
+	}()
+
 	var row siteSettingsJSON
 	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
 

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -107,7 +107,7 @@ func (s *V2AuthService) grantLoginXP(username string) {
 		log.Printf("[v2-auth] XP config read failed for user %s: %v", username, cfgErr)
 		return
 	}
-	if xpConfig.LoginXP <= 0 {
+	if !xpConfig.LoginEnabled || xpConfig.LoginXP <= 0 {
 		return
 	}
 
@@ -121,7 +121,7 @@ func (s *V2AuthService) grantLoginXP(username string) {
 	}
 
 	today := time.Now().Format("2006-01-02")
-	if addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
+	if _, addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
 		log.Printf("[v2-auth] login XP grant failed for user %s: %v", username, addErr)
 	}
 }


### PR DESCRIPTION
## Summary
- XPConfig 확장: 글쓰기/댓글 XP + 개별 활성화 토글
- CreatePost/CreateComment에 XP goroutine 추가 (비동기 best-effort)
- 30일 이전 글 댓글 시 포인트/XP 미부여 (스팸 방지)
- 최대 레벨 도달 시 자동 적립 차단
- 레벨업 감지 → g5_na_noti 알림 삽입
- XPConfig 30초 메모리 캐시 (동접 1~2만 대응)
- HasTodayAction: DATE() → 범위 쿼리 (인덱스 활용)
- g5_na_xp 복합 인덱스 DDL 추가

## 성능
- 모든 쿼리 PK 또는 복합 인덱스 사용, N+1 없음
- XP 처리 goroutine → 응답 지연 0
- XPConfig 30초 캐시 → DB 히트 최소화

## Test plan
- [ ] `make build` 성공
- [ ] 글쓰기/댓글 XP 비활성 상태에서 미부여 확인
- [ ] 활성화 후 XP 부여 + 레벨업 시 알림 생성 확인
- [ ] 30일 이전 글 댓글 시 포인트/XP 미부여 확인
- [ ] 최대 레벨 도달 시 자동 적립 차단 확인