### PR TITLE
feat: 포인트 유효기간(Point Expiry) 시스템

### DIFF
--- a/.docker/mysql/init/14-xp-indexes.sql
+++ b/.docker/mysql/init/14-xp-indexes.sql
@@ -1,0 +1,8 @@
+-- g5_na_xp 인덱스 추가
+-- HasTodayAction 쿼리: WHERE mb_id = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?
+-- DATE() 함수 대신 범위 쿼리 사용으로 인덱스 활용 가능
+CREATE INDEX IF NOT EXISTS idx_mb_action_date ON g5_na_xp (mb_id, xp_rel_action, xp_datetime);
+
+-- GetHistory 쿼리: WHERE mb_id = ? ORDER BY xp_datetime DESC
+-- 기존 mb_id 단일 인덱스 대신 복합 인덱스로 filesort 방지
+CREATE INDEX IF NOT EXISTS idx_mb_datetime ON g5_na_xp (mb_id, xp_datetime DESC);

--- a/.docker/mysql/init/15-point-expiry-indexes.sql
+++ b/.docker/mysql/init/15-point-expiry-indexes.sql
@@ -1,0 +1,16 @@
+-- Point expiry indexes for FIFO consumption and batch expiry processing
+
+-- FIFO consumption: find active credit entries ordered by expire date
+-- Used in GnuboardPointWriteRepository.AddPoint (negative points)
+CREATE INDEX idx_g5_point_fifo ON g5_point (po_mb_id, po_expired, po_point, po_expire_date, po_id);
+
+-- Batch expiry: find entries past their expiry date
+-- Used in GnuboardPointWriteRepository.ExpireBatch (cron)
+CREATE INDEX idx_g5_point_expiry ON g5_point (po_expired, po_point, po_expire_date);
+
+-- Normalize existing data: set empty/null expire dates to permanent (9999-12-31)
+UPDATE g5_point SET po_expire_date = '9999-12-31'
+WHERE po_expire_date IS NULL OR po_expire_date = '' OR po_expire_date = '0000-00-00';
+
+-- Normalize existing data: set NULL po_expired to 0
+UPDATE g5_point SET po_expired = 0 WHERE po_expired IS NULL;

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -390,9 +390,7 @@ func main() {
 		v2Handler.SetNotiRepository(gnurepo.NewNotiRepository(db))
 		v2Handler.SetGnuDB(db)
 
-		// TODO: 경험치 서비스 구현 후 활성화
-		// expSvc := v2svc.NewExpService(v2UserRepo)
-		// v2Handler.SetExpService(expSvc)
+		// XP: DI into V2Handler (set after expRepo is created below)
 
 		v2routes.Setup(router, v2Handler, jwtManager, permChecker, db)
 		v2routes.SetupAdminPosts(router, v2Handler, jwtManager)
@@ -402,6 +400,10 @@ func main() {
 		gnuPointRepo := v2repo.NewGnuboardPointRepository(db)
 		pointHandler := v2handler.NewPointHandler(gnuPointRepo)
 		expHandler := v2handler.NewExpHandler(v2ExpRepo)
+		expHandler.SetNotiRepository(gnurepo.NewNotiRepository(db))
+
+		// Inject expRepo into V2Handler for write/comment XP
+		v2Handler.SetExpRepository(v2ExpRepo)
 		myPageRepo := gnurepo.NewMyPageRepository(db, gnuBoardRepo)
 		myPageHandler := handler.NewMyPageHandler(myPageRepo)
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -402,14 +402,22 @@ func main() {
 		expHandler := v2handler.NewExpHandler(v2ExpRepo)
 		expHandler.SetNotiRepository(gnurepo.NewNotiRepository(db))
 
+		// Point config + write repos
+		pointConfigRepo := v2repo.NewPointConfigRepository(db)
+		gnuPointWriteRepo := v2repo.NewGnuboardPointWriteRepository(db)
+		expHandler.SetPointConfigRepository(pointConfigRepo)
+		v2Handler.SetGnuboardPointWriteRepository(gnuPointWriteRepo)
+		v2Handler.SetPointConfigRepository(pointConfigRepo)
+
 		// Inject expRepo into V2Handler for write/comment XP
 		v2Handler.SetExpRepository(v2ExpRepo)
 		myPageRepo := gnurepo.NewMyPageRepository(db, gnuBoardRepo)
 		myPageHandler := handler.NewMyPageHandler(myPageRepo)
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)
 
-		// Admin XP management routes
+		// Admin XP + Point config management routes
 		v2routes.SetupAdminXP(router, expHandler, jwtManager)
+		v2routes.SetupAdminPoint(router, expHandler, jwtManager)
 
 		// DisciplineLog routes (uses gnuboard g5_write_disciplinelog table)
 		disciplineLogHandler := v2handler.NewDisciplineLogHandler(gnuWriteRepo, db)
@@ -1805,19 +1813,16 @@ func main() {
 				return
 			}
 
-			// 포인트 차감 게시판인 경우 잔액 확인
+			// 포인트 차감 게시판인 경우 잔액 확인 (g5_member.mb_point 기반)
 			if board.BoWritePoint < 0 {
-				var mbNo uint64
-				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
-					canAfford, err := v2PointRepo.CanAfford(mbNo, board.BoWritePoint)
-					if err != nil {
-						c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
-						return
-					}
-					if !canAfford {
-						c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoWritePoint) + "포인트가 필요합니다."})
-						return
-					}
+				canAfford, err := gnuPointWriteRepo.CanAfford(mbID, board.BoWritePoint)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
+					return
+				}
+				if !canAfford {
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoWritePoint) + "포인트가 필요합니다."})
+					return
 				}
 			}
 
@@ -1911,12 +1916,13 @@ func main() {
 				db.Table(tableName).Where("wr_id = ?", post.WrID).Updates(extras)
 			}
 
-			// 포인트 처리
+			// 포인트 처리 (g5_point 기반 FIFO 소비)
 			if board.BoWritePoint != 0 {
-				var mbNo uint64
-				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
-					_ = v2PointRepo.AddPoint(mbNo, board.BoWritePoint, "글쓰기", tableName, uint64(post.WrID)) //nolint:gosec // WrID is always positive
+				var pc *v2repo.PointConfig
+				if pointConfigRepo != nil {
+					pc, _ = pointConfigRepo.GetPointConfig()
 				}
+				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoWritePoint, "글쓰기", tableName, fmt.Sprintf("%d", post.WrID), "@write", pc) //nolint:errcheck
 			}
 
 			// 게시글 목록 캐시 무효화 (새 글이 목록에 즉시 반영되도록)
@@ -2032,19 +2038,16 @@ func main() {
 				return
 			}
 
-			// 포인트 차감 게시판인 경우 잔액 확인
+			// 포인트 차감 게시판인 경우 잔액 확인 (g5_member.mb_point 기반)
 			if board.BoCommentPoint < 0 {
-				var mbNo uint64
-				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
-					canAfford, err := v2PointRepo.CanAfford(mbNo, board.BoCommentPoint)
-					if err != nil {
-						c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
-						return
-					}
-					if !canAfford {
-						c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoCommentPoint) + "포인트가 필요합니다."})
-						return
-					}
+				canAfford, err := gnuPointWriteRepo.CanAfford(mbID, board.BoCommentPoint)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
+					return
+				}
+				if !canAfford {
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "포인트가 부족합니다. " + strconv.Itoa(-board.BoCommentPoint) + "포인트가 필요합니다."})
+					return
 				}
 			}
 
@@ -2159,12 +2162,13 @@ func main() {
 			}
 			comment := createdComment
 
-			// 포인트 처리
+			// 포인트 처리 (g5_point 기반 FIFO 소비)
 			if board.BoCommentPoint != 0 {
-				var mbNo uint64
-				if err := db.Table("g5_member").Select("mb_no").Where("mb_id = ?", mbID).Scan(&mbNo).Error; err == nil {
-					_ = v2PointRepo.AddPoint(mbNo, board.BoCommentPoint, "댓글작성", fmt.Sprintf("g5_write_%s", slug), uint64(comment.WrID)) //nolint:gosec // WrID is always positive
+				var pc *v2repo.PointConfig
+				if pointConfigRepo != nil {
+					pc, _ = pointConfigRepo.GetPointConfig()
 				}
+				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoCommentPoint, "댓글작성", fmt.Sprintf("g5_write_%s", slug), fmt.Sprintf("%d", comment.WrID), "@comment", pc) //nolint:errcheck
 			}
 
 			// 게시글 목록 캐시 무효화 (댓글 수 변경 반영)
@@ -4120,12 +4124,15 @@ func main() {
 
 		// Internal cron endpoints (curl-based cron jobs)
 		cronHandler := cron.NewHandler(db)
+		cronHandler.SetPointExpiryDeps(pointConfigRepo, gnuPointWriteRepo, gnurepo.NewNotiRepository(db))
 		cronGroup := router.Group("/api/internal/cron")
 		cronGroup.POST("/member-lock-release", cronHandler.MemberLockRelease)
 		cronGroup.POST("/update-member-levels", cronHandler.UpdateMemberLevels)
 		cronGroup.POST("/process-approved-reports", cronHandler.ProcessApprovedReports)
 		cronGroup.POST("/update-report-pattern", cronHandler.UpdateReportPattern)
 		cronGroup.POST("/discipline-release", cronHandler.DisciplineRelease)
+		cronGroup.POST("/point-expiry", cronHandler.PointExpiry)
+		cronGroup.POST("/point-expiry-notify", cronHandler.PointExpiryNotify)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(gnuWriteRepo, scheduledDeleteRepo)

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -5,14 +5,19 @@ import (
 	"net/http"
 	"os"
 
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
 // Handler handles internal cron job endpoints
 type Handler struct {
-	db     *gorm.DB
-	secret string
+	db                 *gorm.DB
+	secret             string
+	pointConfigRepo    v2repo.PointConfigRepository
+	gnuPointWriteRepo  v2repo.GnuboardPointWriteRepository
+	notiRepo           gnurepo.NotiRepository
 }
 
 // NewHandler creates a new cron Handler
@@ -22,6 +27,17 @@ func NewHandler(db *gorm.DB) *Handler {
 		secret = "angple_cron_2024"
 	}
 	return &Handler{db: db, secret: secret}
+}
+
+// SetPointExpiryDeps sets dependencies for point expiry cron jobs
+func (h *Handler) SetPointExpiryDeps(
+	pointConfigRepo v2repo.PointConfigRepository,
+	gnuPointWriteRepo v2repo.GnuboardPointWriteRepository,
+	notiRepo gnurepo.NotiRepository,
+) {
+	h.pointConfigRepo = pointConfigRepo
+	h.gnuPointWriteRepo = gnuPointWriteRepo
+	h.notiRepo = notiRepo
 }
 
 // verifySecret checks the secret query parameter

--- a/internal/cron/point_expiry.go
+++ b/internal/cron/point_expiry.go
@@ -1,0 +1,146 @@
+package cron
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	"github.com/gin-gonic/gin"
+)
+
+// PointExpiryResult contains the result of a point expiry batch run
+type PointExpiryResult struct {
+	ExpiredCount int    `json:"expired_count"`
+	ExecutedAt   string `json:"executed_at"`
+}
+
+// PointExpiryNotifyResult contains the result of a point expiry notification run
+type PointExpiryNotifyResult struct {
+	NotifiedCount int    `json:"notified_count"`
+	ExecutedAt    string `json:"executed_at"`
+}
+
+// PointExpiry handles POST /api/internal/cron/point-expiry
+func (h *Handler) PointExpiry(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	if h.pointConfigRepo == nil || h.gnuPointWriteRepo == nil {
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": PointExpiryResult{
+			ExpiredCount: 0,
+			ExecutedAt:   time.Now().Format(time.RFC3339),
+		}, "message": "point expiry not configured"})
+		return
+	}
+
+	// Check if expiry is enabled
+	config, err := h.pointConfigRepo.GetPointConfig()
+	if err != nil {
+		log.Printf("[Cron:point-expiry] config error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	if !config.ExpiryEnabled {
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": PointExpiryResult{
+			ExpiredCount: 0,
+			ExecutedAt:   time.Now().Format(time.RFC3339),
+		}, "message": "expiry disabled"})
+		return
+	}
+
+	expired, err := h.gnuPointWriteRepo.ExpireBatch(1000)
+	if err != nil {
+		log.Printf("[Cron:point-expiry] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	result := PointExpiryResult{
+		ExpiredCount: expired,
+		ExecutedAt:   time.Now().Format(time.RFC3339),
+	}
+	log.Printf("[Cron:point-expiry] expired %d point entries", expired)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}
+
+// PointExpiryNotify handles POST /api/internal/cron/point-expiry-notify
+func (h *Handler) PointExpiryNotify(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	if h.pointConfigRepo == nil || h.gnuPointWriteRepo == nil || h.notiRepo == nil {
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": PointExpiryNotifyResult{
+			NotifiedCount: 0,
+			ExecutedAt:    time.Now().Format(time.RFC3339),
+		}, "message": "point expiry notify not configured"})
+		return
+	}
+
+	config, err := h.pointConfigRepo.GetPointConfig()
+	if err != nil {
+		log.Printf("[Cron:point-expiry-notify] config error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	if !config.ExpiryEnabled {
+		c.JSON(http.StatusOK, gin.H{"success": true, "data": PointExpiryNotifyResult{
+			NotifiedCount: 0,
+			ExecutedAt:    time.Now().Format(time.RFC3339),
+		}, "message": "expiry disabled"})
+		return
+	}
+
+	// Get members with points expiring within 7 days
+	expiringMembers, err := h.gnuPointWriteRepo.GetExpiringPoints(7, 500)
+	if err != nil {
+		log.Printf("[Cron:point-expiry-notify] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	notified := 0
+	today := time.Now().Format("2006-01-02")
+	for _, m := range expiringMembers {
+		// Check for duplicate notification today
+		relID := fmt.Sprintf("point_expiry_%s", today)
+		var count int64
+		h.db.Table("g5_na_noti").
+			Where("mb_id = ? AND ph_from_case = ? AND rel_url = ?", m.MbID, "point_expiry", relID).
+			Count(&count)
+		if count > 0 {
+			continue
+		}
+
+		noti := &gnurepo.Notification{
+			MbID:          m.MbID,
+			PhFromCase:    "point_expiry",
+			PhToCase:      "me",
+			BoTable:       "@system",
+			WrID:          0,
+			RelMbID:       "system",
+			RelMbNick:     "시스템",
+			RelMsg:        fmt.Sprintf("7일 내 %dP가 만료됩니다", m.ExpiringAmount),
+			RelURL:        relID,
+			PhReaded:      "N",
+			ParentSubject: "포인트 만료 예정",
+		}
+		if err := h.notiRepo.Create(noti); err != nil {
+			log.Printf("[Cron:point-expiry-notify] notification failed for %s: %v", m.MbID, err)
+			continue
+		}
+		notified++
+	}
+
+	result := PointExpiryNotifyResult{
+		NotifiedCount: notified,
+		ExecutedAt:    time.Now().Format(time.RFC3339),
+	}
+	log.Printf("[Cron:point-expiry-notify] notified %d members", notified)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}

--- a/internal/handler/v2/exp_handler.go
+++ b/internal/handler/v2/exp_handler.go
@@ -1,24 +1,56 @@
 package v2
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/middleware"
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/gin-gonic/gin"
 )
 
 // ExpHandler handles experience point-related endpoints
 type ExpHandler struct {
-	expRepo v2repo.ExpRepository
+	expRepo  v2repo.ExpRepository
+	notiRepo gnurepo.NotiRepository
 }
 
 // NewExpHandler creates a new ExpHandler
 func NewExpHandler(expRepo v2repo.ExpRepository) *ExpHandler {
 	return &ExpHandler{expRepo: expRepo}
+}
+
+// SetNotiRepository sets the optional notification repository for level-up notifications
+func (h *ExpHandler) SetNotiRepository(repo gnurepo.NotiRepository) {
+	h.notiRepo = repo
+}
+
+// createLevelUpNotification inserts a level-up notification into g5_na_noti
+func (h *ExpHandler) createLevelUpNotification(mbID string, newLevel int) {
+	if h.notiRepo == nil {
+		return
+	}
+	noti := &gnurepo.Notification{
+		MbID:          mbID,
+		PhFromCase:    "levelup",
+		PhToCase:      "me",
+		BoTable:       "@system",
+		WrID:          0,
+		RelMbID:       "system",
+		RelMbNick:     "시스템",
+		RelMsg:        fmt.Sprintf("레벨 %d로 승급했습니다!", newLevel),
+		RelURL:        "/mypage/exp",
+		PhReaded:      "N",
+		ParentSubject: fmt.Sprintf("레벨 %d 달성", newLevel),
+	}
+	if err := h.notiRepo.Create(noti); err != nil {
+		log.Printf("[xp] levelup notification failed for %s: %v", mbID, err)
+	}
 }
 
 // GetExpSummary handles GET /api/v1/my/exp
@@ -185,15 +217,21 @@ func (h *ExpHandler) AdminGrantXP(c *gin.Context) {
 	today := time.Now().Format("2006-01-02")
 	relID := "admin-" + adminID + "-" + today
 
-	if err := h.expRepo.AddExp(mbID, req.Point, req.Content, "@admin", relID, "@admin-grant"); err != nil {
+	result, err := h.expRepo.AddExp(mbID, req.Point, req.Content, "@admin", relID, "@admin-grant")
+	if err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "경험치 지급에 실패했습니다", err)
 		return
 	}
 
+	if result.LevelUp {
+		go h.createLevelUpNotification(mbID, result.NewLevel)
+	}
+
 	common.V2Success(c, gin.H{
-		"message": "경험치가 지급되었습니다",
-		"mb_id":   mbID,
-		"point":   req.Point,
+		"message":  "경험치가 지급되었습니다",
+		"mb_id":    mbID,
+		"point":    req.Point,
+		"level_up": result.LevelUp,
 	})
 }
 
@@ -208,8 +246,14 @@ func (h *ExpHandler) AdminGetXPConfig(c *gin.Context) {
 }
 
 // adminUpdateXPConfigRequest represents the request body for updating XP config
+// Uses pointers for partial update (nil = keep existing value)
 type adminUpdateXPConfigRequest struct {
-	LoginXP int `json:"login_xp"`
+	LoginXP        *int  `json:"login_xp"`
+	WriteXP        *int  `json:"write_xp"`
+	CommentXP      *int  `json:"comment_xp"`
+	LoginEnabled   *bool `json:"login_enabled"`
+	WriteEnabled   *bool `json:"write_enabled"`
+	CommentEnabled *bool `json:"comment_enabled"`
 }
 
 // AdminUpdateXPConfig handles PUT /api/v2/admin/xp/config
@@ -220,19 +264,49 @@ func (h *ExpHandler) AdminUpdateXPConfig(c *gin.Context) {
 		return
 	}
 
-	if req.LoginXP < 0 {
-		common.V2ErrorResponse(c, http.StatusBadRequest, "로그인 경험치는 0 이상이어야 합니다", nil)
+	// Load existing config to merge
+	existing, err := h.expRepo.GetXPConfig()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 조회에 실패했습니다", err)
 		return
 	}
 
-	config := &v2repo.XPConfig{LoginXP: req.LoginXP}
-	if err := h.expRepo.UpdateXPConfig(config); err != nil {
+	// Partial update: only override non-nil fields
+	if req.LoginXP != nil {
+		if *req.LoginXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.LoginXP = *req.LoginXP
+	}
+	if req.WriteXP != nil {
+		if *req.WriteXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.WriteXP = *req.WriteXP
+	}
+	if req.CommentXP != nil {
+		if *req.CommentXP < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "경험치는 0 이상이어야 합니다", nil)
+			return
+		}
+		existing.CommentXP = *req.CommentXP
+	}
+	if req.LoginEnabled != nil {
+		existing.LoginEnabled = *req.LoginEnabled
+	}
+	if req.WriteEnabled != nil {
+		existing.WriteEnabled = *req.WriteEnabled
+	}
+	if req.CommentEnabled != nil {
+		existing.CommentEnabled = *req.CommentEnabled
+	}
+
+	if err := h.expRepo.UpdateXPConfig(existing); err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 저장에 실패했습니다", err)
 		return
 	}
 
-	common.V2Success(c, gin.H{
-		"message":  "설정이 저장되었습니다",
-		"login_xp": req.LoginXP,
-	})
+	common.V2Success(c, existing)
 }

--- a/internal/handler/v2/exp_handler.go
+++ b/internal/handler/v2/exp_handler.go
@@ -16,8 +16,9 @@ import (
 
 // ExpHandler handles experience point-related endpoints
 type ExpHandler struct {
-	expRepo  v2repo.ExpRepository
-	notiRepo gnurepo.NotiRepository
+	expRepo         v2repo.ExpRepository
+	notiRepo        gnurepo.NotiRepository
+	pointConfigRepo v2repo.PointConfigRepository
 }
 
 // NewExpHandler creates a new ExpHandler
@@ -28,6 +29,11 @@ func NewExpHandler(expRepo v2repo.ExpRepository) *ExpHandler {
 // SetNotiRepository sets the optional notification repository for level-up notifications
 func (h *ExpHandler) SetNotiRepository(repo gnurepo.NotiRepository) {
 	h.notiRepo = repo
+}
+
+// SetPointConfigRepository sets the point config repository for point expiry settings
+func (h *ExpHandler) SetPointConfigRepository(repo v2repo.PointConfigRepository) {
+	h.pointConfigRepo = repo
 }
 
 // createLevelUpNotification inserts a level-up notification into g5_na_noti
@@ -304,6 +310,69 @@ func (h *ExpHandler) AdminUpdateXPConfig(c *gin.Context) {
 	}
 
 	if err := h.expRepo.UpdateXPConfig(existing); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 저장에 실패했습니다", err)
+		return
+	}
+
+	common.V2Success(c, existing)
+}
+
+// ========================================
+// Admin Point Config Handlers
+// ========================================
+
+// AdminGetPointConfig handles GET /api/v2/admin/point/config
+func (h *ExpHandler) AdminGetPointConfig(c *gin.Context) {
+	if h.pointConfigRepo == nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 설정 기능이 비활성화되어 있습니다", nil)
+		return
+	}
+
+	config, err := h.pointConfigRepo.GetPointConfig()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 조회에 실패했습니다", err)
+		return
+	}
+	common.V2Success(c, config)
+}
+
+// adminUpdatePointConfigRequest represents the request body for updating point config
+type adminUpdatePointConfigRequest struct {
+	ExpiryEnabled *bool `json:"expiry_enabled"`
+	ExpiryDays    *int  `json:"expiry_days"`
+}
+
+// AdminUpdatePointConfig handles PUT /api/v2/admin/point/config
+func (h *ExpHandler) AdminUpdatePointConfig(c *gin.Context) {
+	if h.pointConfigRepo == nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 설정 기능이 비활성화되어 있습니다", nil)
+		return
+	}
+
+	var req adminUpdatePointConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청입니다", err)
+		return
+	}
+
+	existing, err := h.pointConfigRepo.GetPointConfig()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 조회에 실패했습니다", err)
+		return
+	}
+
+	if req.ExpiryEnabled != nil {
+		existing.ExpiryEnabled = *req.ExpiryEnabled
+	}
+	if req.ExpiryDays != nil {
+		if *req.ExpiryDays < 1 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "유효기간은 1일 이상이어야 합니다", nil)
+			return
+		}
+		existing.ExpiryDays = *req.ExpiryDays
+	}
+
+	if err := h.pointConfigRepo.UpdatePointConfig(existing); err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "설정 저장에 실패했습니다", err)
 		return
 	}

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -1,10 +1,10 @@
 package v2
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"strconv"
-
-	"fmt"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -26,6 +26,7 @@ type V2Handler struct {
 	pointRepo    v2repo.PointRepository
 	revisionRepo v2repo.RevisionRepository
 	notiRepo     gnurepo.NotiRepository
+	expRepo      v2repo.ExpRepository
 	gnuDB        *gorm.DB // gnuboard g5_member 조회용
 }
 
@@ -64,6 +65,31 @@ func (h *V2Handler) SetNotiRepository(repo gnurepo.NotiRepository) {
 // SetGnuDB sets the gnuboard database connection for mb_id → mb_no lookup
 func (h *V2Handler) SetGnuDB(db *gorm.DB) {
 	h.gnuDB = db
+}
+
+// SetExpRepository sets the optional exp repository for XP operations
+func (h *V2Handler) SetExpRepository(repo v2repo.ExpRepository) {
+	h.expRepo = repo
+}
+
+// createLevelUpNoti inserts a level-up notification into g5_na_noti
+func (h *V2Handler) createLevelUpNoti(mbID string, newLevel int) {
+	noti := &gnurepo.Notification{
+		MbID:          mbID,
+		PhFromCase:    "levelup",
+		PhToCase:      "me",
+		BoTable:       "@system",
+		WrID:          0,
+		RelMbID:       "system",
+		RelMbNick:     "시스템",
+		RelMsg:        fmt.Sprintf("레벨 %d로 승급했습니다!", newLevel),
+		RelURL:        "/mypage/exp",
+		PhReaded:      "N",
+		ParentSubject: fmt.Sprintf("레벨 %d 달성", newLevel),
+	}
+	if err := h.notiRepo.Create(noti); err != nil {
+		log.Printf("[xp] levelup notification failed for %s: %v", mbID, err)
+	}
 }
 
 // resolveUserIDToMbNo converts gnuboard mb_id (string) to mb_no (uint64)
@@ -350,6 +376,32 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 	// 포인트 처리 (지급 또는 차감)
 	if board.WritePoint != 0 && h.pointRepo != nil {
 		_ = h.pointRepo.AddPoint(userID, board.WritePoint, "글쓰기", "v2_posts", post.ID) //nolint:errcheck
+	}
+
+	// 경험치 부여 (비동기, best-effort)
+	if h.expRepo != nil {
+		mbID := middleware.GetUserID(c)
+		tableName := fmt.Sprintf("v2_posts_%s", slug)
+		wrID := fmt.Sprintf("%d", post.ID)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[xp] write XP panic for %s: %v", mbID, r)
+				}
+			}()
+			xpConfig, err := h.expRepo.GetXPConfig()
+			if err != nil || xpConfig == nil || !xpConfig.WriteEnabled || xpConfig.WriteXP <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpConfig.WriteXP, "글쓰기", tableName, wrID, "@write")
+			if err != nil {
+				log.Printf("[xp] write XP grant failed for %s: %v", mbID, err)
+				return
+			}
+			if result.LevelUp && h.notiRepo != nil {
+				h.createLevelUpNoti(mbID, result.NewLevel)
+			}
+		}()
 	}
 
 	common.V2Created(c, post)
@@ -713,9 +765,19 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	// 포인트 처리 (지급 또는 차감)
+	// 30일 이전 글 체크 (포인트 + XP 모두 적용)
+	// postRepo.FindByID는 PK 조회이므로 빠름 (1회만 조회)
+	isOldPost := false
+	if parentPost, postErr := h.postRepo.FindByID(postID); postErr == nil {
+		isOldPost = time.Since(parentPost.CreatedAt) > 30*24*time.Hour
+	}
+
+	// 포인트 처리 (지급 또는 차감) — 30일 이전 글에는 지급 포인트 미부여
 	if board.CommentPoint != 0 && h.pointRepo != nil {
-		_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+		// 차감 포인트(음수)는 항상 적용, 지급 포인트(양수)는 30일 이내만
+		if board.CommentPoint < 0 || !isOldPost {
+			_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+		}
 	}
 
 	// 알림 생성 (비동기, 에러 무시)
@@ -726,6 +788,32 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 	}
 	if h.notiRepo != nil {
 		go h.createCommentNotification(slug, postID, comment, mbID, authorName)
+	}
+
+	// 경험치 부여 (비동기, best-effort)
+	// 30일 이전 글에 달린 댓글은 XP 미부여 (스팸 방지)
+	if h.expRepo != nil && !isOldPost {
+		tableName := fmt.Sprintf("v2_comments_%s", slug)
+		wrID := fmt.Sprintf("%d", comment.ID)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[xp] comment XP panic for %s: %v", mbID, r)
+				}
+			}()
+			xpConfig, err := h.expRepo.GetXPConfig()
+			if err != nil || xpConfig == nil || !xpConfig.CommentEnabled || xpConfig.CommentXP <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpConfig.CommentXP, "댓글 작성", tableName, wrID, "@comment")
+			if err != nil {
+				log.Printf("[xp] comment XP grant failed for %s: %v", mbID, err)
+				return
+			}
+			if result.LevelUp && h.notiRepo != nil {
+				h.createLevelUpNoti(mbID, result.NewLevel)
+			}
+		}()
 	}
 
 	// FreeComment 형태로 응답 (프론트엔드 호환)

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -18,16 +18,18 @@ import (
 
 // V2Handler handles all v2 API endpoints
 type V2Handler struct {
-	userRepo     v2repo.UserRepository
-	postRepo     v2repo.PostRepository
-	commentRepo  v2repo.CommentRepository
-	boardRepo    v2repo.BoardRepository
-	permChecker  middleware.BoardPermissionChecker
-	pointRepo    v2repo.PointRepository
-	revisionRepo v2repo.RevisionRepository
-	notiRepo     gnurepo.NotiRepository
-	expRepo      v2repo.ExpRepository
-	gnuDB        *gorm.DB // gnuboard g5_member 조회용
+	userRepo           v2repo.UserRepository
+	postRepo           v2repo.PostRepository
+	commentRepo        v2repo.CommentRepository
+	boardRepo          v2repo.BoardRepository
+	permChecker        middleware.BoardPermissionChecker
+	pointRepo          v2repo.PointRepository
+	revisionRepo       v2repo.RevisionRepository
+	notiRepo           gnurepo.NotiRepository
+	expRepo            v2repo.ExpRepository
+	gnuDB              *gorm.DB // gnuboard g5_member 조회용
+	gnuPointWriteRepo  v2repo.GnuboardPointWriteRepository
+	pointConfigRepo    v2repo.PointConfigRepository
 }
 
 // NewV2Handler creates a new V2Handler
@@ -70,6 +72,16 @@ func (h *V2Handler) SetGnuDB(db *gorm.DB) {
 // SetExpRepository sets the optional exp repository for XP operations
 func (h *V2Handler) SetExpRepository(repo v2repo.ExpRepository) {
 	h.expRepo = repo
+}
+
+// SetGnuboardPointWriteRepository sets the gnuboard point write repository for g5_point operations
+func (h *V2Handler) SetGnuboardPointWriteRepository(repo v2repo.GnuboardPointWriteRepository) {
+	h.gnuPointWriteRepo = repo
+}
+
+// SetPointConfigRepository sets the point config repository for point expiry settings
+func (h *V2Handler) SetPointConfigRepository(repo v2repo.PointConfigRepository) {
+	h.pointConfigRepo = repo
 }
 
 // createLevelUpNoti inserts a level-up notification into g5_na_noti
@@ -347,16 +359,30 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 	}
 
 	// 포인트 차감 게시판인 경우 잔액 확인
-	if board.WritePoint < 0 && h.pointRepo != nil {
-		canAfford, err := h.pointRepo.CanAfford(userID, board.WritePoint)
-		if err != nil {
-			common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
-			return
-		}
-		if !canAfford {
-			common.V2ErrorResponse(c, http.StatusForbidden,
-				"포인트가 부족합니다. "+strconv.Itoa(-board.WritePoint)+"포인트가 필요합니다.", nil)
-			return
+	if board.WritePoint < 0 {
+		mbIDForCheck := middleware.GetUserID(c)
+		if h.gnuPointWriteRepo != nil {
+			canAfford, err := h.gnuPointWriteRepo.CanAfford(mbIDForCheck, board.WritePoint)
+			if err != nil {
+				common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
+				return
+			}
+			if !canAfford {
+				common.V2ErrorResponse(c, http.StatusForbidden,
+					"포인트가 부족합니다. "+strconv.Itoa(-board.WritePoint)+"포인트가 필요합니다.", nil)
+				return
+			}
+		} else if h.pointRepo != nil {
+			canAfford, err := h.pointRepo.CanAfford(userID, board.WritePoint)
+			if err != nil {
+				common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
+				return
+			}
+			if !canAfford {
+				common.V2ErrorResponse(c, http.StatusForbidden,
+					"포인트가 부족합니다. "+strconv.Itoa(-board.WritePoint)+"포인트가 필요합니다.", nil)
+				return
+			}
 		}
 	}
 
@@ -373,9 +399,18 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 		return
 	}
 
-	// 포인트 처리 (지급 또는 차감)
-	if board.WritePoint != 0 && h.pointRepo != nil {
-		_ = h.pointRepo.AddPoint(userID, board.WritePoint, "글쓰기", "v2_posts", post.ID) //nolint:errcheck
+	// 포인트 처리 (지급 또는 차감) — g5_point 기반 FIFO 소비
+	if board.WritePoint != 0 {
+		mbID := middleware.GetUserID(c)
+		if h.gnuPointWriteRepo != nil {
+			var pc *v2repo.PointConfig
+			if h.pointConfigRepo != nil {
+				pc, _ = h.pointConfigRepo.GetPointConfig()
+			}
+			_ = h.gnuPointWriteRepo.AddPoint(mbID, board.WritePoint, "글쓰기", "v2_posts", fmt.Sprintf("%d", post.ID), "@write", pc) //nolint:errcheck
+		} else if h.pointRepo != nil {
+			_ = h.pointRepo.AddPoint(userID, board.WritePoint, "글쓰기", "v2_posts", post.ID) //nolint:errcheck
+		}
 	}
 
 	// 경험치 부여 (비동기, best-effort)
@@ -736,16 +771,30 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 	}
 
 	// 포인트 차감 게시판인 경우 잔액 확인
-	if board.CommentPoint < 0 && h.pointRepo != nil {
-		canAfford, err := h.pointRepo.CanAfford(userID, board.CommentPoint)
-		if err != nil {
-			common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
-			return
-		}
-		if !canAfford {
-			common.V2ErrorResponse(c, http.StatusForbidden,
-				"포인트가 부족합니다. "+strconv.Itoa(-board.CommentPoint)+"포인트가 필요합니다.", nil)
-			return
+	if board.CommentPoint < 0 {
+		mbIDForCheck := middleware.GetUserID(c)
+		if h.gnuPointWriteRepo != nil {
+			canAfford, err := h.gnuPointWriteRepo.CanAfford(mbIDForCheck, board.CommentPoint)
+			if err != nil {
+				common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
+				return
+			}
+			if !canAfford {
+				common.V2ErrorResponse(c, http.StatusForbidden,
+					"포인트가 부족합니다. "+strconv.Itoa(-board.CommentPoint)+"포인트가 필요합니다.", nil)
+				return
+			}
+		} else if h.pointRepo != nil {
+			canAfford, err := h.pointRepo.CanAfford(userID, board.CommentPoint)
+			if err != nil {
+				common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 확인 실패", err)
+				return
+			}
+			if !canAfford {
+				common.V2ErrorResponse(c, http.StatusForbidden,
+					"포인트가 부족합니다. "+strconv.Itoa(-board.CommentPoint)+"포인트가 필요합니다.", nil)
+				return
+			}
 		}
 	}
 
@@ -772,16 +821,26 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		isOldPost = time.Since(parentPost.CreatedAt) > 30*24*time.Hour
 	}
 
+	// 알림 + 포인트 + XP에서 사용할 mb_id
+	mbID := middleware.GetUserID(c)
+
 	// 포인트 처리 (지급 또는 차감) — 30일 이전 글에는 지급 포인트 미부여
-	if board.CommentPoint != 0 && h.pointRepo != nil {
+	if board.CommentPoint != 0 {
 		// 차감 포인트(음수)는 항상 적용, 지급 포인트(양수)는 30일 이내만
 		if board.CommentPoint < 0 || !isOldPost {
-			_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+			if h.gnuPointWriteRepo != nil {
+				var pc *v2repo.PointConfig
+				if h.pointConfigRepo != nil {
+					pc, _ = h.pointConfigRepo.GetPointConfig()
+				}
+				_ = h.gnuPointWriteRepo.AddPoint(mbID, board.CommentPoint, "댓글작성", fmt.Sprintf("v2_comments_%s", slug), fmt.Sprintf("%d", comment.ID), "@comment", pc) //nolint:errcheck
+			} else if h.pointRepo != nil {
+				_ = h.pointRepo.AddPoint(userID, board.CommentPoint, "댓글작성", "v2_comments", comment.ID) //nolint:errcheck
+			}
 		}
 	}
 
 	// 알림 생성 (비동기, 에러 무시)
-	mbID := middleware.GetUserID(c)
 	authorName := middleware.GetNickname(c)
 	if authorName == "" && h.gnuDB != nil {
 		h.gnuDB.Table("g5_member").Select("mb_nick").Where("mb_id = ?", mbID).Scan(&authorName)

--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -2,11 +2,21 @@ package v2
 
 import (
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
 )
+
+// xpConfigCache caches XPConfig to avoid hitting site_settings on every write/comment
+var (
+	xpConfigCacheMu    sync.RWMutex
+	xpConfigCacheVal   *XPConfig
+	xpConfigCacheExpAt time.Time
+)
+
+const xpConfigCacheTTL = 30 * time.Second
 
 // ExpSummary represents experience point summary statistics
 type ExpSummary struct {
@@ -20,12 +30,24 @@ type ExpSummary struct {
 
 // XPConfig represents configurable XP settings (stored in site_settings.settings_json)
 type XPConfig struct {
-	LoginXP int `json:"login_xp"` // XP granted per daily login (default: 500)
+	LoginXP        int  `json:"login_xp"`        // XP granted per daily login (default: 500)
+	WriteXP        int  `json:"write_xp"`         // XP granted per post (default: 100)
+	CommentXP      int  `json:"comment_xp"`       // XP granted per comment (default: 50)
+	LoginEnabled   bool `json:"login_enabled"`    // Enable login XP (default: true)
+	WriteEnabled   bool `json:"write_enabled"`    // Enable write XP (default: false)
+	CommentEnabled bool `json:"comment_enabled"`  // Enable comment XP (default: false)
 }
 
 // DefaultXPConfig returns the default XP configuration
 func DefaultXPConfig() *XPConfig {
-	return &XPConfig{LoginXP: 500}
+	return &XPConfig{
+		LoginXP:        500,
+		WriteXP:        100,
+		CommentXP:      50,
+		LoginEnabled:   true,
+		WriteEnabled:   false,
+		CommentEnabled: false,
+	}
 }
 
 // MemberXPInfo represents a member's XP summary for admin listing
@@ -37,14 +59,21 @@ type MemberXPInfo struct {
 	MbLevel int    `json:"mb_level"`
 }
 
+// AddExpResult contains the result of an AddExp operation
+type AddExpResult struct {
+	LevelUp  bool `json:"level_up"`
+	OldLevel int  `json:"old_level"`
+	NewLevel int  `json:"new_level"`
+}
+
 // ExpRepository handles experience point data access
 type ExpRepository interface {
 	// GetSummary returns exp summary for a user (by mb_id)
 	GetSummary(mbID string) (*ExpSummary, error)
 	// GetHistory returns exp history with pagination
 	GetHistory(mbID string, page, limit int) ([]gnuboard.ExpHistory, int64, error)
-	// AddExp adds experience points to a user
-	AddExp(mbID string, point int, content, relTable, relID, action string) error
+	// AddExp adds experience points to a user and returns level change info
+	AddExp(mbID string, point int, content, relTable, relID, action string) (*AddExpResult, error)
 	// HasTodayAction checks if the user already has a specific action logged today
 	HasTodayAction(mbID, action string) (bool, error)
 	// ListMembersWithXP returns paginated member list with XP info for admin
@@ -164,8 +193,25 @@ func (r *expRepository) GetHistory(mbID string, page, limit int) ([]gnuboard.Exp
 	return history, total, nil
 }
 
-func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID, action string) error {
-	return r.db.Transaction(func(tx *gorm.DB) error {
+// maxXPLevel is the highest XP level; users at this level stop earning XP from actions
+var maxXPLevel = len(levelThresholds)
+
+func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID, action string) (*AddExpResult, error) {
+	result := &AddExpResult{}
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		// Get current level before update
+		var member gnuboard.G5Member
+		if err := tx.Select("as_exp, as_level").Where("mb_id = ?", mbID).First(&member).Error; err != nil {
+			return err
+		}
+		result.OldLevel = member.AsLevel
+		result.NewLevel = member.AsLevel
+
+		// 최대 레벨 도달 시 자동 적립(양수) 차단 — 관리자 수동 지급/차감은 허용
+		if member.AsLevel >= maxXPLevel && point > 0 && relTable != "@admin" {
+			return nil // 적립 없이 조용히 반환
+		}
+
 		// Update member exp
 		if err := tx.Model(&gnuboard.G5Member{}).
 			Where("mb_id = ?", mbID).
@@ -173,15 +219,12 @@ func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID,
 			return err
 		}
 
-		// Get updated exp to check level
-		var member gnuboard.G5Member
-		if err := tx.Select("as_exp, as_level").Where("mb_id = ?", mbID).First(&member).Error; err != nil {
-			return err
-		}
-
 		// Check if level up is needed
-		newLevel, _, _, _, _ := calculateLevelInfo(member.AsExp)
+		newExp := member.AsExp + point
+		newLevel, _, _, _, _ := calculateLevelInfo(newExp)
+		result.NewLevel = newLevel
 		if newLevel > member.AsLevel {
+			result.LevelUp = true
 			if err := tx.Model(&gnuboard.G5Member{}).
 				Where("mb_id = ?", mbID).
 				UpdateColumn("as_level", newLevel).Error; err != nil {
@@ -200,14 +243,22 @@ func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID,
 		}
 		return tx.Create(log).Error
 	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // HasTodayAction checks if the user already has a specific action logged today
+// Uses range query on xp_datetime to leverage idx_mb_action_date index
 func (r *expRepository) HasTodayAction(mbID, action string) (bool, error) {
-	today := time.Now().Format("2006-01-02")
+	now := time.Now()
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	tomorrowStart := todayStart.AddDate(0, 0, 1)
 	var count int64
 	err := r.db.Model(&gnuboard.G5NaXP{}).
-		Where("mb_id = ? AND xp_rel_action = ? AND DATE(xp_datetime) = ?", mbID, action, today).
+		Where("mb_id = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?",
+			mbID, action, todayStart, tomorrowStart).
 		Count(&count).Error
 	if err != nil {
 		return false, err
@@ -255,8 +306,34 @@ type settingsJSONWrapper struct {
 	Extra    map[string]interface{} `json:"-"`
 }
 
-// GetXPConfig reads XP configuration from site_settings.settings_json
+// GetXPConfig reads XP configuration from site_settings.settings_json (cached 30s)
 func (r *expRepository) GetXPConfig() (*XPConfig, error) {
+	// Check cache first
+	xpConfigCacheMu.RLock()
+	if xpConfigCacheVal != nil && time.Now().Before(xpConfigCacheExpAt) {
+		cached := *xpConfigCacheVal // copy
+		xpConfigCacheMu.RUnlock()
+		return &cached, nil
+	}
+	xpConfigCacheMu.RUnlock()
+
+	config, err := r.getXPConfigFromDB()
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cache
+	xpConfigCacheMu.Lock()
+	cp := *config
+	xpConfigCacheVal = &cp
+	xpConfigCacheExpAt = time.Now().Add(xpConfigCacheTTL)
+	xpConfigCacheMu.Unlock()
+
+	return config, nil
+}
+
+// getXPConfigFromDB fetches XPConfig directly from database
+func (r *expRepository) getXPConfigFromDB() (*XPConfig, error) {
 	var row siteSettingsJSON
 	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
 	if err != nil {
@@ -277,16 +354,30 @@ func (r *expRepository) GetXPConfig() (*XPConfig, error) {
 		return DefaultXPConfig(), nil
 	}
 
-	// Validate: if login_xp is 0, return default
+	// Fill defaults for zero values on legacy configs (only LoginXP had a value before)
 	if wrapper.XPConfig.LoginXP == 0 {
 		wrapper.XPConfig.LoginXP = 500
+	}
+	if wrapper.XPConfig.WriteXP == 0 {
+		wrapper.XPConfig.WriteXP = 100
+	}
+	if wrapper.XPConfig.CommentXP == 0 {
+		wrapper.XPConfig.CommentXP = 50
 	}
 
 	return wrapper.XPConfig, nil
 }
 
 // UpdateXPConfig writes XP configuration to site_settings.settings_json (preserving other fields)
+// Invalidates the XPConfig cache on success
 func (r *expRepository) UpdateXPConfig(config *XPConfig) error {
+	// Invalidate cache before update (will be repopulated on next read)
+	defer func() {
+		xpConfigCacheMu.Lock()
+		xpConfigCacheVal = nil
+		xpConfigCacheMu.Unlock()
+	}()
+
 	var row siteSettingsJSON
 	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
 

--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -300,10 +300,25 @@ func (siteSettingsJSON) TableName() string {
 	return "site_settings"
 }
 
+// PointConfig represents configurable point expiry settings (stored in site_settings.settings_json)
+type PointConfig struct {
+	ExpiryEnabled bool `json:"expiry_enabled"` // Enable point expiry (default: false)
+	ExpiryDays    int  `json:"expiry_days"`    // Days until points expire (default: 180)
+}
+
+// DefaultPointConfig returns the default point configuration
+func DefaultPointConfig() *PointConfig {
+	return &PointConfig{
+		ExpiryEnabled: false,
+		ExpiryDays:    180,
+	}
+}
+
 // settingsJSONWrapper wraps the full settings_json content (preserves unknown fields)
 type settingsJSONWrapper struct {
-	XPConfig *XPConfig              `json:"xp_config,omitempty"`
-	Extra    map[string]interface{} `json:"-"`
+	XPConfig    *XPConfig    `json:"xp_config,omitempty"`
+	PointConfig *PointConfig `json:"point_config,omitempty"`
+	Extra       map[string]interface{} `json:"-"`
 }
 
 // GetXPConfig reads XP configuration from site_settings.settings_json (cached 30s)

--- a/internal/repository/v2/gnuboard_point_write_repo.go
+++ b/internal/repository/v2/gnuboard_point_write_repo.go
@@ -1,0 +1,259 @@
+package v2
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+)
+
+// ExpiringPointInfo represents a member with points expiring soon
+type ExpiringPointInfo struct {
+	MbID           string `json:"mb_id"`
+	ExpiringAmount int    `json:"expiring_amount"`
+}
+
+// GnuboardPointWriteRepository handles g5_point writes + g5_member.mb_point balance management
+type GnuboardPointWriteRepository interface {
+	// AddPoint grants or deducts points with FIFO consumption
+	AddPoint(mbID string, point int, content, relTable, relID, relAction string, pointConfig *PointConfig) error
+	// CanAfford checks if the member has enough points
+	CanAfford(mbID string, cost int) (bool, error)
+	// ExpireBatch expires points past their expiry date (cron). Returns number of expired rows.
+	ExpireBatch(batchSize int) (int, error)
+	// GetExpiringPoints returns members with points expiring within N days
+	GetExpiringPoints(withinDays int, limit int) ([]ExpiringPointInfo, error)
+}
+
+type gnuboardPointWriteRepository struct {
+	db *gorm.DB
+}
+
+// NewGnuboardPointWriteRepository creates a new GnuboardPointWriteRepository
+func NewGnuboardPointWriteRepository(db *gorm.DB) GnuboardPointWriteRepository {
+	return &gnuboardPointWriteRepository{db: db}
+}
+
+// AddPoint grants or deducts points with FIFO consumption for deductions
+func (r *gnuboardPointWriteRepository) AddPoint(mbID string, point int, content, relTable, relID, relAction string, pointConfig *PointConfig) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if point > 0 {
+			return r.addPositivePoint(tx, mbID, point, content, relTable, relID, relAction, pointConfig)
+		}
+		return r.addNegativePoint(tx, mbID, point, content, relTable, relID, relAction)
+	})
+}
+
+// addPositivePoint inserts a credit entry and updates member balance
+func (r *gnuboardPointWriteRepository) addPositivePoint(tx *gorm.DB, mbID string, point int, content, relTable, relID, relAction string, pointConfig *PointConfig) error {
+	// Determine expire date
+	expireDate := "9999-12-31"
+	if pointConfig != nil && pointConfig.ExpiryEnabled && pointConfig.ExpiryDays > 0 {
+		expireDate = time.Now().AddDate(0, 0, pointConfig.ExpiryDays).Format("2006-01-02")
+	}
+
+	// Update member balance
+	if err := tx.Table("g5_member").
+		Where("mb_id = ?", mbID).
+		UpdateColumn("mb_point", gorm.Expr("mb_point + ?", point)).Error; err != nil {
+		return err
+	}
+
+	// Get updated balance for snapshot
+	var mbPoint int
+	if err := tx.Table("g5_member").Select("mb_point").Where("mb_id = ?", mbID).Scan(&mbPoint).Error; err != nil {
+		return err
+	}
+
+	// Insert credit log
+	entry := &gnuboard.G5Point{
+		MbID:         mbID,
+		PoDatetime:   time.Now(),
+		PoContent:    content,
+		PoPoint:      point,
+		PoUsePoint:   0,
+		PoExpired:    0,
+		PoExpireDate: expireDate,
+		PoRelTable:   relTable,
+		PoRelID:      relID,
+		PoRelAction:  relAction,
+		MbPoint:      mbPoint,
+	}
+	return tx.Create(entry).Error
+}
+
+// addNegativePoint deducts points using FIFO consumption and updates member balance
+func (r *gnuboardPointWriteRepository) addNegativePoint(tx *gorm.DB, mbID string, point int, content, relTable, relID, relAction string) error {
+	absAmount := -point // positive value to consume
+
+	// FIFO: find active credit entries ordered by expire date, then ID
+	var credits []gnuboard.G5Point
+	if err := tx.Raw(`
+		SELECT po_id, po_point, po_use_point
+		FROM g5_point
+		WHERE po_mb_id = ? AND po_expired = 0 AND po_point > 0
+		  AND (po_point - po_use_point) > 0
+		ORDER BY po_expire_date ASC, po_id ASC
+		FOR UPDATE
+	`, mbID).Scan(&credits).Error; err != nil {
+		return err
+	}
+
+	remaining := absAmount
+	for _, credit := range credits {
+		if remaining <= 0 {
+			break
+		}
+		available := credit.PoPoint - credit.PoUsePoint
+		consume := available
+		if consume > remaining {
+			consume = remaining
+		}
+
+		newUsePoint := credit.PoUsePoint + consume
+		updates := map[string]interface{}{"po_use_point": newUsePoint}
+		// If fully consumed, mark as expired (100 = consumed)
+		if newUsePoint >= credit.PoPoint {
+			updates["po_expired"] = 100
+		}
+		if err := tx.Table("g5_point").Where("po_id = ?", credit.PoID).Updates(updates).Error; err != nil {
+			return err
+		}
+		remaining -= consume
+	}
+
+	// Update member balance
+	if err := tx.Table("g5_member").
+		Where("mb_id = ?", mbID).
+		UpdateColumn("mb_point", gorm.Expr("mb_point + ?", point)).Error; err != nil {
+		return err
+	}
+
+	// Get updated balance for snapshot
+	var mbPoint int
+	if err := tx.Table("g5_member").Select("mb_point").Where("mb_id = ?", mbID).Scan(&mbPoint).Error; err != nil {
+		return err
+	}
+
+	// Insert deduction log
+	entry := &gnuboard.G5Point{
+		MbID:         mbID,
+		PoDatetime:   time.Now(),
+		PoContent:    content,
+		PoPoint:      point,
+		PoUsePoint:   0,
+		PoExpired:    0,
+		PoExpireDate: "9999-12-31",
+		PoRelTable:   relTable,
+		PoRelID:      relID,
+		PoRelAction:  relAction,
+		MbPoint:      mbPoint,
+	}
+	return tx.Create(entry).Error
+}
+
+// CanAfford checks if the member has enough points for a deduction
+func (r *gnuboardPointWriteRepository) CanAfford(mbID string, cost int) (bool, error) {
+	var mbPoint int
+	if err := r.db.Table("g5_member").Select("mb_point").Where("mb_id = ?", mbID).Scan(&mbPoint).Error; err != nil {
+		return false, err
+	}
+	// cost is negative for deductions
+	return mbPoint+cost >= 0, nil
+}
+
+// ExpireBatch expires points past their expiry date in batches. Returns number of expired rows.
+func (r *gnuboardPointWriteRepository) ExpireBatch(batchSize int) (int, error) {
+	totalExpired := 0
+	today := time.Now().Format("2006-01-02")
+
+	for {
+		var expired []struct {
+			PoID       int    `gorm:"column:po_id"`
+			MbID       string `gorm:"column:po_mb_id"`
+			PoPoint    int    `gorm:"column:po_point"`
+			PoUsePoint int    `gorm:"column:po_use_point"`
+		}
+
+		err := r.db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Raw(`
+				SELECT po_id, po_mb_id, po_point, po_use_point
+				FROM g5_point
+				WHERE po_expired = 0 AND po_point > 0
+				  AND po_expire_date < ?
+				  AND po_expire_date != '9999-12-31'
+				ORDER BY po_id ASC
+				LIMIT ?
+				FOR UPDATE
+			`, today, batchSize).Scan(&expired).Error; err != nil {
+				return err
+			}
+
+			if len(expired) == 0 {
+				return nil
+			}
+
+			// Group by member for balance deduction
+			memberDeductions := make(map[string]int)
+			poIDs := make([]int, len(expired))
+			for i, row := range expired {
+				remaining := row.PoPoint - row.PoUsePoint
+				if remaining > 0 {
+					memberDeductions[row.MbID] += remaining
+				}
+				poIDs[i] = row.PoID
+			}
+
+			// Mark as expired (1 = time-expired)
+			if err := tx.Table("g5_point").Where("po_id IN ?", poIDs).Update("po_expired", 1).Error; err != nil {
+				return err
+			}
+
+			// Deduct remaining balance from each member
+			for mbID, deduction := range memberDeductions {
+				if err := tx.Table("g5_member").
+					Where("mb_id = ?", mbID).
+					UpdateColumn("mb_point", gorm.Expr("GREATEST(mb_point - ?, 0)", deduction)).Error; err != nil {
+					return fmt.Errorf("deduct balance for %s: %w", mbID, err)
+				}
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return totalExpired, err
+		}
+
+		totalExpired += len(expired)
+
+		// No more rows to process
+		if len(expired) < batchSize {
+			break
+		}
+	}
+
+	return totalExpired, nil
+}
+
+// GetExpiringPoints returns members with points expiring within N days
+func (r *gnuboardPointWriteRepository) GetExpiringPoints(withinDays int, limit int) ([]ExpiringPointInfo, error) {
+	today := time.Now().Format("2006-01-02")
+	futureDate := time.Now().AddDate(0, 0, withinDays).Format("2006-01-02")
+
+	var results []ExpiringPointInfo
+	err := r.db.Raw(`
+		SELECT po_mb_id AS mb_id, SUM(po_point - po_use_point) AS expiring_amount
+		FROM g5_point
+		WHERE po_expired = 0 AND po_point > 0
+		  AND po_expire_date BETWEEN ? AND ?
+		  AND po_expire_date != '9999-12-31'
+		  AND (po_point - po_use_point) > 0
+		GROUP BY po_mb_id
+		HAVING expiring_amount > 0
+		LIMIT ?
+	`, today, futureDate, limit).Scan(&results).Error
+
+	return results, err
+}

--- a/internal/repository/v2/point_config_repo.go
+++ b/internal/repository/v2/point_config_repo.go
@@ -1,0 +1,131 @@
+package v2
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// pointConfigCache caches PointConfig to avoid hitting site_settings on every point operation
+var (
+	pointConfigCacheMu    sync.RWMutex
+	pointConfigCacheVal   *PointConfig
+	pointConfigCacheExpAt time.Time
+)
+
+const pointConfigCacheTTL = 30 * time.Second
+
+// PointConfigRepository handles point configuration data access
+type PointConfigRepository interface {
+	// GetPointConfig returns the current point configuration (cached 30s)
+	GetPointConfig() (*PointConfig, error)
+	// UpdatePointConfig updates the point configuration
+	UpdatePointConfig(config *PointConfig) error
+}
+
+type pointConfigRepository struct {
+	db *gorm.DB
+}
+
+// NewPointConfigRepository creates a new PointConfigRepository
+func NewPointConfigRepository(db *gorm.DB) PointConfigRepository {
+	return &pointConfigRepository{db: db}
+}
+
+// GetPointConfig reads point configuration from site_settings.settings_json (cached 30s)
+func (r *pointConfigRepository) GetPointConfig() (*PointConfig, error) {
+	// Check cache first
+	pointConfigCacheMu.RLock()
+	if pointConfigCacheVal != nil && time.Now().Before(pointConfigCacheExpAt) {
+		cached := *pointConfigCacheVal
+		pointConfigCacheMu.RUnlock()
+		return &cached, nil
+	}
+	pointConfigCacheMu.RUnlock()
+
+	config, err := r.getPointConfigFromDB()
+	if err != nil {
+		return nil, err
+	}
+
+	// Update cache
+	pointConfigCacheMu.Lock()
+	cp := *config
+	pointConfigCacheVal = &cp
+	pointConfigCacheExpAt = time.Now().Add(pointConfigCacheTTL)
+	pointConfigCacheMu.Unlock()
+
+	return config, nil
+}
+
+// getPointConfigFromDB fetches PointConfig directly from database
+func (r *pointConfigRepository) getPointConfigFromDB() (*PointConfig, error) {
+	var row siteSettingsJSON
+	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
+	if err != nil {
+		return DefaultPointConfig(), nil
+	}
+
+	if row.SettingsJSON == nil || *row.SettingsJSON == "" || *row.SettingsJSON == "null" {
+		return DefaultPointConfig(), nil
+	}
+
+	var wrapper settingsJSONWrapper
+	if err := json.Unmarshal([]byte(*row.SettingsJSON), &wrapper); err != nil {
+		return DefaultPointConfig(), nil
+	}
+
+	if wrapper.PointConfig == nil {
+		return DefaultPointConfig(), nil
+	}
+
+	// Fill defaults for zero values
+	if wrapper.PointConfig.ExpiryDays == 0 {
+		wrapper.PointConfig.ExpiryDays = 180
+	}
+
+	return wrapper.PointConfig, nil
+}
+
+// UpdatePointConfig writes point configuration to site_settings.settings_json (preserving other fields)
+func (r *pointConfigRepository) UpdatePointConfig(config *PointConfig) error {
+	// Invalidate cache
+	defer func() {
+		pointConfigCacheMu.Lock()
+		pointConfigCacheVal = nil
+		pointConfigCacheMu.Unlock()
+	}()
+
+	var row siteSettingsJSON
+	err := r.db.Select("settings_json").Where("site_id = ?", defaultSiteID).First(&row).Error
+
+	// Parse existing JSON to preserve other fields
+	existing := make(map[string]interface{})
+	if err == nil && row.SettingsJSON != nil && *row.SettingsJSON != "" && *row.SettingsJSON != "null" {
+		if unmarshalErr := json.Unmarshal([]byte(*row.SettingsJSON), &existing); unmarshalErr != nil {
+			existing = make(map[string]interface{})
+		}
+	}
+
+	existing["point_config"] = config
+	jsonBytes, marshalErr := json.Marshal(existing)
+	if marshalErr != nil {
+		return marshalErr
+	}
+	jsonStr := string(jsonBytes)
+
+	if err != nil {
+		// Row doesn't exist — create it
+		return r.db.Exec(
+			"INSERT INTO site_settings (site_id, settings_json, active_theme) VALUES (?, ?, 'damoang-official')",
+			defaultSiteID, jsonStr,
+		).Error
+	}
+
+	// Update existing row
+	return r.db.Table("site_settings").
+		Where("site_id = ?", defaultSiteID).
+		UpdateColumn("settings_json", jsonStr).Error
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -113,6 +113,15 @@ func SetupAdminXP(router *gin.Engine, h *v2handler.ExpHandler, jwtManager *jwt.M
 	adminMembers.POST("/:mbId/grant", h.AdminGrantXP)
 }
 
+// SetupAdminPoint configures admin point configuration routes
+func SetupAdminPoint(router *gin.Engine, h *v2handler.ExpHandler, jwtManager *jwt.Manager) {
+	admin := router.Group("/api/v2/admin/point")
+	admin.Use(middleware.JWTAuth(jwtManager), middleware.RequireAdmin())
+
+	admin.GET("/config", h.AdminGetPointConfig)
+	admin.PUT("/config", h.AdminUpdatePointConfig)
+}
+
 // SetupScrap configures v2 scrap routes
 func SetupScrap(router *gin.Engine, h *v2handler.ScrapHandler, jwtManager *jwt.Manager) {
 	auth := middleware.JWTAuth(jwtManager)

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -107,7 +107,7 @@ func (s *V2AuthService) grantLoginXP(username string) {
 		log.Printf("[v2-auth] XP config read failed for user %s: %v", username, cfgErr)
 		return
 	}
-	if xpConfig.LoginXP <= 0 {
+	if !xpConfig.LoginEnabled || xpConfig.LoginXP <= 0 {
 		return
 	}
 
@@ -121,7 +121,7 @@ func (s *V2AuthService) grantLoginXP(username string) {
 	}
 
 	today := time.Now().Format("2006-01-02")
-	if addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
+	if _, addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
 		log.Printf("[v2-auth] login XP grant failed for user %s: %v", username, addErr)
 	}
 }


### PR DESCRIPTION
## Summary

- **PointConfig**: settings_json에 포인트 유효기간 설정 저장 (30초 캐시)
- **FIFO 소비**: g5_point 기반 포인트 차감 시 만료일 빠른 순서대로 소비
- **포인트 쓰기 전환**: v2_points + v2_users.point → g5_point + g5_member.mb_point
- **만료 크론**: `/api/internal/cron/point-expiry` (배치 1000건씩, `po_expired=1`)
- **만료 예정 알림**: `/api/internal/cron/point-expiry-notify` (7일 전 알림)
- **관리자 API**: `GET/PUT /api/v2/admin/point/config`
- **인덱스**: idx_g5_point_fifo, idx_g5_point_expiry

## Test plan

- [ ] 포인트 유효기간 활성화/비활성화 저장 확인
- [ ] 포인트 지급 시 `po_expire_date`가 올바르게 설정되는지 확인
- [ ] 포인트 소비 시 FIFO 순서로 `po_use_point` 차감 확인
- [ ] `curl -X POST localhost:8090/api/internal/cron/point-expiry?secret=...` 테스트
- [ ] `curl -X POST localhost:8090/api/internal/cron/point-expiry-notify?secret=...` 테스트
- [ ] `make build` 성공 확인