### PR TITLE
perf: Redis 캐시 레이어 + Cache-Control 헤더

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1236,6 +1236,7 @@ func main() {
 		v1Boards := router.Group("/api/v1/boards")
 		v1Boards.Use(middleware.OptionalJWTAuth(jwtManager))
 		v1Boards.Use(middleware.ArchiveBoardCheck())
+		v1Boards.Use(middleware.APICacheControl(10)) // 브라우저 캐시 10초
 
 		// Board extended settings repo & write restriction service (used by multiple handlers)
 		v2ExtendedSettingsRepo := v2repo.NewBoardExtendedSettingsRepository(db)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1465,11 +1465,29 @@ func main() {
 				return
 			}
 
-			// Get post from g5_write_{slug}
-			post, err := gnuWriteRepo.FindPostByIDIncludeDeleted(slug, id)
-			if err != nil {
-				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "Post not found"})
-				return
+			// Redis 캐시에서 게시글 조회 (raw post data)
+			var post *gnuboard.G5Write
+			ctx := c.Request.Context()
+			if cacheService != nil {
+				if cached, cacheErr := cacheService.GetPost(ctx, slug, id); cacheErr == nil {
+					var cachedPost gnuboard.G5Write
+					if json.Unmarshal(cached, &cachedPost) == nil {
+						post = &cachedPost
+					}
+				}
+			}
+
+			if post == nil {
+				// Cache miss: DB에서 조회
+				post, err = gnuWriteRepo.FindPostByIDIncludeDeleted(slug, id)
+				if err != nil {
+					c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "Post not found"})
+					return
+				}
+				// Redis에 캐시 저장
+				if cacheService != nil {
+					_ = cacheService.SetPost(ctx, slug, id, post)
+				}
 			}
 
 			// Increment view count async (skip for deleted posts)
@@ -1544,14 +1562,51 @@ func main() {
 				return
 			}
 
+			ctx := c.Request.Context()
+			isAdmin := middleware.GetUserLevel(c) >= 10
+
 			// Get comments from g5_write_{slug} where wr_parent = id and wr_is_comment = 1
 			var comments []*gnuboard.G5Write
-			if middleware.GetUserLevel(c) >= 10 {
-				// 관리자: 삭제된 댓글 포함 전체 조회
+
+			if isAdmin {
+				// 관리자: 삭제된 댓글 포함 — 캐시 사용하지 않음 (데이터 다름)
 				comments, err = gnuWriteRepo.FindCommentsIncludeDeleted(slug, id)
 			} else {
-				blockedIDs := getBlockedIDs(c.Request.Context(), middleware.GetUserID(c))
-				comments, err = gnuWriteRepo.FindCommentsFiltered(slug, id, blockedIDs)
+				// 일반 사용자: Redis 캐시에서 전체 댓글 조회 후 차단 필터링
+				var cacheHit bool
+				if cacheService != nil {
+					if cached, cacheErr := cacheService.GetComments(ctx, slug, id); cacheErr == nil {
+						var cachedComments []*gnuboard.G5Write
+						if json.Unmarshal(cached, &cachedComments) == nil {
+							comments = cachedComments
+							cacheHit = true
+						}
+					}
+				}
+
+				if !cacheHit {
+					// Cache miss: DB에서 조회 (차단 필터 없이 전체)
+					comments, err = gnuWriteRepo.FindCommentsFiltered(slug, id, nil)
+					if err == nil && cacheService != nil {
+						_ = cacheService.SetComments(ctx, slug, id, comments)
+					}
+				}
+
+				// 차단 사용자 필터링 (캐시 후 인메모리)
+				blockedIDs := getBlockedIDs(ctx, middleware.GetUserID(c))
+				if len(blockedIDs) > 0 {
+					blockedSet := make(map[string]struct{}, len(blockedIDs))
+					for _, bid := range blockedIDs {
+						blockedSet[bid] = struct{}{}
+					}
+					filtered := make([]*gnuboard.G5Write, 0, len(comments))
+					for _, comment := range comments {
+						if _, blocked := blockedSet[comment.MbID]; !blocked {
+							filtered = append(filtered, comment)
+						}
+					}
+					comments = filtered
+				}
 			}
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{"success": true, "data": []any{}})
@@ -1560,8 +1615,8 @@ func main() {
 
 			// 댓글별 수정 횟수 배치 조회
 			commentIDs := make([]int, len(comments))
-			for i, c := range comments {
-				commentIDs[i] = c.WrID
+			for i, cm := range comments {
+				commentIDs[i] = cm.WrID
 			}
 			editCountMap := map[int]int{}
 			if len(commentIDs) > 0 {
@@ -1582,7 +1637,7 @@ func main() {
 
 			transformed := v1handler.TransformToV1Comments(comments)
 			// Admin sees full (unmasked) IP
-			if middleware.GetUserLevel(c) >= 10 {
+			if isAdmin {
 				v1handler.OverrideIPForAdmin(transformed, comments)
 			}
 			for i, comment := range comments {
@@ -2171,8 +2226,9 @@ func main() {
 				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoCommentPoint, "댓글작성", fmt.Sprintf("g5_write_%s", slug), fmt.Sprintf("%d", comment.WrID), "@comment", pc) //nolint:errcheck
 			}
 
-			// 게시글 목록 캐시 무효화 (댓글 수 변경 반영)
+			// 캐시 무효화: 댓글 목록 + 게시글 목록 (댓글 수 변경 반영)
 			if cacheService != nil {
+				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
 				_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 			}
 			postMemCache.Range(func(key, value interface{}) bool {
@@ -2369,6 +2425,18 @@ func main() {
 				}
 			}
 
+			// 캐시 무효화: 게시글 상세 + 목록
+			if cacheService != nil {
+				_ = cacheService.InvalidatePost(c.Request.Context(), slug, postID)
+				_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
+			}
+			postMemCache.Range(func(key, value interface{}) bool {
+				if strings.HasPrefix(key.(string), "posts:"+slug+":") {
+					postMemCache.Delete(key)
+				}
+				return true
+			})
+
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "수정 완료"})
 		})
 
@@ -2422,6 +2490,12 @@ func main() {
 			}).Error; err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 수정 실패"})
 				return
+			}
+
+			// 캐시 무효화: 댓글 목록
+			if cacheService != nil {
+				postID, _ := strconv.Atoi(c.Param("id"))
+				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
 			}
 
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "수정 완료"})
@@ -2523,6 +2597,17 @@ func main() {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
 					return
 				}
+				// 캐시 무효화: 게시글 상세 + 목록
+				if cacheService != nil {
+					_ = cacheService.InvalidatePost(c.Request.Context(), slug, postID)
+					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
+				}
+				postMemCache.Range(func(key, value interface{}) bool {
+					if strings.HasPrefix(key.(string), "posts:"+slug+":") {
+						postMemCache.Delete(key)
+					}
+					return true
+				})
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
 			}
@@ -2667,17 +2752,22 @@ func main() {
 			}
 
 			// 관리자(level >= 10)는 즉시 삭제
+			postID, _ := strconv.Atoi(c.Param("id"))
 			if userLevel >= 10 {
 				if err := gnuWriteRepo.SoftDeleteComment(slug, commentID, userID); err != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 삭제 실패"})
 					return
+				}
+				// 캐시 무효화: 댓글 + 게시글 목록 (댓글 수 변경)
+				if cacheService != nil {
+					_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
+					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
 			}
 
 			// 일반 사용자: 답글 수에 따라 지연 삭제 적용
-			postID, _ := strconv.Atoi(c.Param("id"))
 			replyCount, err := gnuWriteRepo.CountCommentReplies(slug, postID, commentID)
 			if err != nil {
 				// 카운트 실패 시 즉시 삭제로 fallback
@@ -2691,6 +2781,11 @@ func main() {
 				if err := gnuWriteRepo.SoftDeleteComment(slug, commentID, userID); err != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 삭제 실패"})
 					return
+				}
+				// 캐시 무효화: 댓글 + 게시글 목록 (댓글 수 변경)
+				if cacheService != nil {
+					_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
+					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return

--- a/internal/middleware/cache.go
+++ b/internal/middleware/cache.go
@@ -121,6 +121,30 @@ func InvalidateCacheByPath(redisClient *redis.Client, path string) {
 	redisClient.Del(context.Background(), key)
 }
 
+// APICacheControl sets Cache-Control headers on GET JSON responses.
+// Authenticated requests get "private", anonymous get "public".
+// This allows browsers to cache responses and reduce redundant requests.
+func APICacheControl(maxAge int) gin.HandlerFunc {
+	privateVal := fmt.Sprintf("private, max-age=%d", maxAge)
+	publicVal := fmt.Sprintf("public, max-age=%d", maxAge)
+	return func(c *gin.Context) {
+		if c.Request.Method != http.MethodGet {
+			c.Next()
+			return
+		}
+		c.Next()
+
+		// Only set on successful JSON responses
+		if c.Writer.Status() >= 200 && c.Writer.Status() < 300 {
+			if c.GetString("userID") != "" {
+				c.Header("Cache-Control", privateVal)
+			} else {
+				c.Header("Cache-Control", publicVal)
+			}
+		}
+	}
+}
+
 func cacheKey(path, query string) string {
 	raw := path
 	if query != "" {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -11,24 +11,27 @@ import (
 
 // TTL 상수 정의
 const (
-	TTLBoard   = 10 * time.Minute // 게시판 설정 (변경 빈도 낮음)
-	TTLPopular = 5 * time.Minute  // 인기 게시글
-	TTLSession = 30 * time.Minute // 세션
-	TTLShort   = 1 * time.Minute  // 짧은 캐시 (실시간성 필요)
-	TTLDefault = 5 * time.Minute  // 기본값
-	TTLPosts   = 30 * time.Second // 게시글 목록 (자주 갱신)
-	TTLNotices = 2 * time.Minute  // 공지사항
+	TTLBoard    = 10 * time.Minute // 게시판 설정 (변경 빈도 낮음)
+	TTLPopular  = 5 * time.Minute  // 인기 게시글
+	TTLSession  = 30 * time.Minute // 세션
+	TTLShort    = 1 * time.Minute  // 짧은 캐시 (실시간성 필요)
+	TTLDefault  = 5 * time.Minute  // 기본값
+	TTLPosts    = 30 * time.Second // 게시글 목록 (자주 갱신)
+	TTLNotices  = 2 * time.Minute  // 공지사항
+	TTLPost     = 30 * time.Second // 게시글 상세 (자주 갱신)
+	TTLComments = 30 * time.Second // 댓글 목록 (자주 갱신)
 )
 
 // 캐시 키 접두사
 const (
-	PrefixBoard   = "board:"
-	PrefixPopular = "popular:"
-	PrefixSession = "session:"
-	PrefixUser    = "user:"
-	PrefixPost    = "post:"
-	PrefixPosts   = "posts:"
-	PrefixNotices = "notices:"
+	PrefixBoard    = "board:"
+	PrefixPopular  = "popular:"
+	PrefixSession  = "session:"
+	PrefixUser     = "user:"
+	PrefixPost     = "post:"
+	PrefixPosts    = "posts:"
+	PrefixNotices  = "notices:"
+	PrefixComments = "comments:"
 )
 
 // Service Redis 캐시 서비스 인터페이스
@@ -65,6 +68,16 @@ type Service interface {
 	GetPosts(ctx context.Context, boardID string, page, limit int) ([]byte, error)
 	SetPosts(ctx context.Context, boardID string, page, limit int, data interface{}) error
 	InvalidatePosts(ctx context.Context, boardID string) error
+
+	// 게시글 상세 캐시
+	GetPost(ctx context.Context, boardID string, postID int) ([]byte, error)
+	SetPost(ctx context.Context, boardID string, postID int, data interface{}) error
+	InvalidatePost(ctx context.Context, boardID string, postID int) error
+
+	// 댓글 캐시
+	GetComments(ctx context.Context, boardID string, postID int) ([]byte, error)
+	SetComments(ctx context.Context, boardID string, postID int, data interface{}) error
+	InvalidateComments(ctx context.Context, boardID string, postID int) error
 
 	// 공지사항 캐시
 	GetNotices(ctx context.Context, boardID string) ([]byte, error)
@@ -338,6 +351,72 @@ func (c *redisCache) InvalidatePosts(ctx context.Context, boardID string) error 
 		return nil
 	}
 	return c.deleteByPattern(ctx, PrefixPosts+boardID+":*")
+}
+
+// ========================================
+// 게시글 상세 캐시
+// ========================================
+
+func (c *redisCache) postKey(boardID string, postID int) string {
+	return fmt.Sprintf("%s%s:%d", PrefixPost, boardID, postID)
+}
+
+func (c *redisCache) GetPost(ctx context.Context, boardID string, postID int) ([]byte, error) {
+	if c.client == nil {
+		return nil, fmt.Errorf("redis not available")
+	}
+	return c.client.Get(ctx, c.postKey(boardID, postID)).Bytes()
+}
+
+func (c *redisCache) SetPost(ctx context.Context, boardID string, postID int, data interface{}) error {
+	if c.client == nil {
+		return nil
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return c.client.Set(ctx, c.postKey(boardID, postID), jsonData, TTLPost).Err()
+}
+
+func (c *redisCache) InvalidatePost(ctx context.Context, boardID string, postID int) error {
+	if c.client == nil {
+		return nil
+	}
+	return c.client.Del(ctx, c.postKey(boardID, postID)).Err()
+}
+
+// ========================================
+// 댓글 캐시
+// ========================================
+
+func (c *redisCache) commentsKey(boardID string, postID int) string {
+	return fmt.Sprintf("%s%s:%d", PrefixComments, boardID, postID)
+}
+
+func (c *redisCache) GetComments(ctx context.Context, boardID string, postID int) ([]byte, error) {
+	if c.client == nil {
+		return nil, fmt.Errorf("redis not available")
+	}
+	return c.client.Get(ctx, c.commentsKey(boardID, postID)).Bytes()
+}
+
+func (c *redisCache) SetComments(ctx context.Context, boardID string, postID int, data interface{}) error {
+	if c.client == nil {
+		return nil
+	}
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return c.client.Set(ctx, c.commentsKey(boardID, postID), jsonData, TTLComments).Err()
+}
+
+func (c *redisCache) InvalidateComments(ctx context.Context, boardID string, postID int) error {
+	if c.client == nil {
+		return nil
+	}
+	return c.client.Del(ctx, c.commentsKey(boardID, postID)).Err()
 }
 
 // ========================================


### PR DESCRIPTION
## Summary
- 게시글 상세 + 댓글 API에 Redis 캐시 레이어 추가 (TTL 30초)
- 게시글/댓글 CUD 시 자동 캐시 무효화
- API GET 응답에 Cache-Control 헤더 추가 (10초, 인증 시 private / 비인증 시 public)

## Test plan
- [ ] 게시글 상세 조회 시 Redis 캐시 HIT 확인
- [ ] 댓글 목록 조회 시 Redis 캐시 HIT 확인
- [ ] 게시글 수정/삭제 후 캐시 무효화 확인
- [ ] 댓글 작성/수정/삭제 후 캐시 무효화 확인
- [ ] Cache-Control 헤더 응답 확인