### PR TITLE
fix: 글 삭제 시 댓글 cascade 삭제 버그 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2834,6 +2834,38 @@ func main() {
 			})
 		})
 
+		// POST /api/v1/boards/:slug/posts/:id/comments/:comment_id/restore - Restore soft deleted comment (admin only)
+		v1Boards.POST("/:slug/posts/:id/comments/:comment_id/restore", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+			slug := c.Param("slug")
+			commentID, err := strconv.Atoi(c.Param("comment_id"))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid comment ID"})
+				return
+			}
+
+			// 관리자 확인
+			userLevel := middleware.GetUserLevel(c)
+			if userLevel < 10 {
+				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "관리자만 복구할 수 있습니다"})
+				return
+			}
+
+			// 댓글 복구
+			if err := gnuWriteRepo.RestoreComment(slug, commentID); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 복구 실패"})
+				return
+			}
+
+			// 캐시 무효화
+			postID, _ := strconv.Atoi(c.Param("id"))
+			if cacheService != nil {
+				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
+				_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
+			}
+
+			c.JSON(http.StatusOK, gin.H{"success": true, "message": "댓글 복구 완료"})
+		})
+
 		// POST /api/v1/boards/:slug/posts/:id/cancel-delete - Cancel a scheduled delete
 		v1Boards.POST("/:slug/posts/:id/cancel-delete", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
 			slug := c.Param("slug")

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -467,36 +467,19 @@ func (r *writeRepository) SoftDeletePost(boardID string, wrID int, deletedBy str
 		}
 	}
 
-	// Soft delete the post
-	if err := r.db.Table(table).Where("wr_id = ?", wrID).Updates(map[string]interface{}{
-		"wr_deleted_at": now,
-		"wr_deleted_by": deletedBy,
-	}).Error; err != nil {
-		return err
-	}
-
-	// Soft delete all comments for this post
-	return r.db.Table(table).Where("wr_parent = ? AND wr_is_comment = 1", wrID).Updates(map[string]interface{}{
+	// Soft delete the post only (comments are preserved)
+	return r.db.Table(table).Where("wr_id = ?", wrID).Updates(map[string]interface{}{
 		"wr_deleted_at": now,
 		"wr_deleted_by": deletedBy,
 	}).Error
 }
 
-// RestorePost restores a soft deleted post and its comments
+// RestorePost restores a soft deleted post (comments are not affected)
 func (r *writeRepository) RestorePost(boardID string, wrID int) error {
 	InvalidatePostCount(boardID)
 	table := tableName(boardID)
 
-	// Restore the post
-	if err := r.db.Table(table).Where("wr_id = ?", wrID).Updates(map[string]interface{}{
-		"wr_deleted_at": nil,
-		"wr_deleted_by": nil,
-	}).Error; err != nil {
-		return err
-	}
-
-	// Restore all comments for this post
-	return r.db.Table(table).Where("wr_parent = ?", wrID).Updates(map[string]interface{}{
+	return r.db.Table(table).Where("wr_id = ?", wrID).Updates(map[string]interface{}{
 		"wr_deleted_at": nil,
 		"wr_deleted_by": nil,
 	}).Error


### PR DESCRIPTION
## Summary
- 글 삭제 시 다른 사용자의 댓글까지 함께 삭제되는 버그 수정
- SoftDeletePost()에서 댓글 cascade soft-delete 제거
- RestorePost()에서 댓글 무조건 복구 제거
- 댓글 복구 API 엔드포인트 추가 (POST /comments/:comment_id/restore, 관리자 전용)

## Test plan
- [ ] 글 삭제 시 댓글이 보존되는지 확인
- [ ] 관리자 댓글 복구 API 동작 확인