### PR TITLE
fix: 삭제 시스템 버그 수정 (cascade + 필터링 + 댓글 필드)

### DIFF
--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -126,7 +126,7 @@ func TransformToV1Posts(posts []*gnuboard.G5Write, noticeIDs map[int]bool) []map
 // TransformToV1Comment converts G5Write (comment) to v1 API response format
 func TransformToV1Comment(w *gnuboard.G5Write) map[string]any {
 	depth := len(w.WrCommentReply)
-	return map[string]any{
+	result := map[string]any{
 		"id":         w.WrID,
 		"post_id":    w.WrParent,
 		"content":    w.WrContent,
@@ -140,6 +140,13 @@ func TransformToV1Comment(w *gnuboard.G5Write) map[string]any {
 		"updated_at": parseWrLast(w.WrLast, w.WrDatetime),
 		"is_secret":  strings.Contains(w.WrOption, "secret"),
 	}
+	if w.WrDeletedAt != nil {
+		result["deleted_at"] = w.WrDeletedAt.Format(time.RFC3339)
+	}
+	if w.WrDeletedBy != nil {
+		result["deleted_by"] = *w.WrDeletedBy
+	}
+	return result
 }
 
 // TransformToV1Comments converts a slice of G5Write comments to v1 API response format


### PR DESCRIPTION
## Summary
- 글 삭제 시 다른 사용자의 댓글까지 삭제되는 cascade 버그 수정
- 게시판 목록, 검색, 마이페이지에서 삭제된 글 필터링
- TransformToV1Comment에 deleted_at, deleted_by 필드 추가 (관리자 삭제 댓글 상세 표시)

## Test plan
- [ ] 글 삭제 시 본인 댓글만 삭제되는지 확인
- [ ] 게시판 목록/검색에서 삭제된 글 미노출 확인
- [ ] 관리자로 삭제된 댓글 조회 시 삭제 시간/원문/복구 버튼 표시 확인