### PR TITLE
fix: BanCheck에 YYYY-MM-DD 포맷 파싱 추가

### DIFF
--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	interceptDateFormat      = "2006-01-02 15:04:05"
+	interceptDateDashFormat  = "2006-01-02"
 	interceptDateShortFormat = "20060102"
 	claimBoardSlug           = "claim"
 	claimWindowDays          = 15
@@ -132,6 +133,10 @@ func ArchiveBoardCheck() gin.HandlerFunc {
 func parseInterceptDate(s string) (time.Time, error) {
 	if t, err := time.ParseInLocation(interceptDateFormat, s, time.Local); err == nil {
 		return t, nil
+	}
+	if t, err := time.ParseInLocation(interceptDateDashFormat, s, time.Local); err == nil {
+		// YYYY-MM-DD format (no time component) — treat as end of day
+		return t.Add(24*time.Hour - time.Second), nil
 	}
 	if t, err := time.ParseInLocation(interceptDateShortFormat, s, time.Local); err == nil {
 		// Short format has no time component — treat as end of day


### PR DESCRIPTION
## Summary
- `parseInterceptDate`에 `YYYY-MM-DD` 포맷 파싱 지원 추가
- `mb_intercept_date` varchar(8) 컬럼에 10글자(`2026-03-09`)가 저장되면 `2026-03-`로 잘려 파싱 실패 → 정지 중 글쓰기 가능한 버그 방어

## Test plan
- [ ] 정지 회원 글쓰기 차단 확인