### PR TITLE
fix: 삭제된 글이 목록/검색에 노출되는 문제 수정

### DIFF
--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -186,7 +186,7 @@ func (r *myPageRepository) FindLikedPostsByMember(mbID string, page, limit int) 
 		table := fmt.Sprintf("g5_write_%s", boardID)
 		var posts []gnuboard.MyPost
 		if err := r.db.Raw(
-			fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE wr_id IN ? AND wr_is_comment = 0", boardID, table),
+			fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE wr_id IN ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", boardID, table),
 			wrIDs,
 		).Scan(&posts).Error; err != nil {
 			continue // skip boards with errors

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -140,7 +140,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 		}
 	}
 	if total == 0 {
-		countQuery := r.db.Table(table).Where("wr_is_comment = 0")
+		countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')")
 		if err := countQuery.Count(&total).Error; err != nil {
 			return nil, 0, err
 		}
@@ -174,14 +174,14 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	if orderClause == "wr_num, wr_reply" {
 		selectCols := strings.Join(coreColumns, ", ")
 		err := r.db.Raw(
-			fmt.Sprintf("SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?", selectCols, table),
+			fmt.Sprintf("SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?", selectCols, table),
 			limit, offset,
 		).Scan(&posts).Error
 		// Fallback if idx_list_page doesn't exist on this table
 		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
 			err = r.db.Table(table).
 				Select(coreColumns).
-				Where("wr_is_comment = 0").
+				Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
 				Order(orderClause).
 				Offset(offset).
 				Limit(limit).
@@ -192,7 +192,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 
 	err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_is_comment = 0").
+		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).
@@ -221,7 +221,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 		}
 	}
 	if total == 0 {
-		if err := r.db.Table(table).Where("wr_is_comment = 0").Count(&total).Error; err != nil {
+		if err := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").Count(&total).Error; err != nil {
 			return nil, 0, err
 		}
 		postCountCache.Store(cacheKey, &cachedCount{total: total, expiresAt: time.Now().Add(countCacheTTL)})
@@ -233,13 +233,13 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 	if orderClause == "wr_num, wr_reply" {
 		selectCols := strings.Join(coreColumns, ", ")
 		err := r.db.Raw(
-			fmt.Sprintf("SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND mb_id NOT IN ? ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?", selectCols, table),
+			fmt.Sprintf("SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ? ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?", selectCols, table),
 			excludeMbIDs, limit, offset,
 		).Scan(&posts).Error
 		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
 			err = r.db.Table(table).
 				Select(coreColumns).
-				Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
+				Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ?", excludeMbIDs).
 				Order(orderClause).
 				Offset(offset).
 				Limit(limit).
@@ -250,7 +250,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 
 	err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
+		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ?", excludeMbIDs).
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).
@@ -289,7 +289,7 @@ func (r *writeRepository) SearchPostsFiltered(boardID string, searchField, searc
 	table := tableName(boardID)
 	if err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_id IN ? AND mb_id NOT IN ?", result.IDs, excludeMbIDs).
+		Where("wr_id IN ? AND mb_id NOT IN ? AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", result.IDs, excludeMbIDs).
 		Find(&posts).Error; err != nil {
 		return nil, 0, err
 	}
@@ -338,7 +338,7 @@ func (r *writeRepository) SearchPosts(boardID string, searchField, searchQuery s
 	table := tableName(boardID)
 	if err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_id IN ?", result.IDs).
+		Where("wr_id IN ? AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", result.IDs).
 		Find(&posts).Error; err != nil {
 		return nil, 0, err
 	}

--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -153,7 +153,7 @@ func (s *BoardWriteRestrictionService) countTodayPosts(boardSlug, memberID strin
 
 	var count int64
 	err := s.db.Table(tableName).
-		Where("mb_id = ? AND DATE(wr_datetime) = ? AND wr_is_comment = 0", memberID, today).
+		Where("mb_id = ? AND DATE(wr_datetime) = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", memberID, today).
 		Count(&count).Error
 	if err != nil {
 		return 0, err

--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -343,7 +343,7 @@ func (s *SearchService) BulkIndexPosts(ctx context.Context, boardID string, limi
 	}
 
 	err := s.db.Table(tableName).
-		Where("wr_is_comment = 0").
+		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
 		Order("wr_id DESC").
 		Limit(limit).
 		Find(&rows).Error


### PR DESCRIPTION
## Summary
- 모든 게시글 조회 쿼리에 wr_deleted_at 필터 추가
- 삭제된 글이 목록, 검색, 마이페이지, 글쓰기 제한 카운트에서 제외됨

## Test plan
- [ ] 삭제된 글이 게시판 목록에 미노출 확인
- [ ] 검색 결과에서 삭제된 글 제외 확인