### PR TITLE
ci: 백엔드 카나리 배포 단계 추가

### DIFF
--- a/.github/workflows/ghcr-deploy.yml
+++ b/.github/workflows/ghcr-deploy.yml
@@ -98,31 +98,87 @@ jobs:
           echo "- ECR: \`${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.sha_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   # ──────────────────────────────────────────────
-  # 2단계: 빌드 완료 알림 + 승인 대기 (자동)
+  # 2단계: 카나리 배포 + 스모크 테스트 (자동)
   # ──────────────────────────────────────────────
-  notify:
-    name: Notify & Wait for Approval
+  deploy-canary:
+    name: Canary Deploy & Smoke Test
     needs: build
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy canary via SSM
+        env:
+          IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
+        run: |
+          echo "Deploying backend canary with tag: $IMAGE_TAG"
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "i-038a1d1f00798d94b" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[
+              \"/home/angple/k8s/prod/deploy.sh backend $IMAGE_TAG --canary-only\"
+            ]" \
+            --timeout-seconds 300 \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command: $COMMAND_ID"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            if [ "$STATUS" = "Success" ]; then
+              echo "Canary deploy + smoke test passed!"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text
+              exit 0
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+              echo "Canary failed: $STATUS"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text
+              exit 1
+            fi
+
+            sleep 10
+          done
+          echo "Timed out"
+          exit 1
 
       - name: Notify Telegram (승인 요청)
+        if: success()
         env:
           IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         run: |
           COMMIT_MSG=$(echo "${{ github.event.head_commit.message }}" | head -1)
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          MSG="✅ 백엔드 빌드+테스트 통과 — 승인 대기 중
+          MSG="✅ 백엔드 카나리 배포 통과 — 승인 대기 중
 
           ${COMMIT_MSG}
           Tag: ${IMAGE_TAG}
 
-          👉 승인하기: ${RUN_URL}"
+          👉 canary.damoang.net 에서 확인 후 승인: ${RUN_URL}"
 
           MSG=$(echo "$MSG" | sed 's/^          //')
 
@@ -130,18 +186,18 @@ jobs:
             --data-urlencode "chat_id=${{ secrets.TELEGRAM_CHAT_ID }}" \
             --data-urlencode "text=${MSG}" >/dev/null 2>&1 || true
 
-      - name: Notify summary
+      - name: Canary summary
         run: |
-          echo "### Notify Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Canary Passed" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: \`${{ needs.build.outputs.image-tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- 텔레그램 알림 전송 → 프로덕션 승인 대기 중" >> "$GITHUB_STEP_SUMMARY"
+          echo "- 스모크 테스트 통과 → canary.damoang.net 확인 후 본배포 승인" >> "$GITHUB_STEP_SUMMARY"
 
   # ──────────────────────────────────────────────
   # 3단계: 프로덕션 배포 (승인 후)
   # ──────────────────────────────────────────────
   deploy-production:
     name: Production Deploy
-    needs: [build, notify]
+    needs: [build, deploy-canary]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: production
@@ -156,7 +212,7 @@ jobs:
           role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Deploy via SSM
+      - name: Deploy to production via SSM
         env:
           IMAGE_TAG: ${{ needs.build.outputs.image-tag }}
         run: |
@@ -166,7 +222,7 @@ jobs:
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
             --parameters "commands=[
-              \"/home/angple/k8s/prod/deploy.sh backend $IMAGE_TAG\"
+              \"/home/angple/k8s/prod/deploy.sh backend $IMAGE_TAG --skip-canary\"
             ]" \
             --timeout-seconds 300 \
             --query "Command.CommandId" \


### PR DESCRIPTION
## Summary
- 빌드 후 canary.damoang.net에 카나리 자동 배포 (1 pod, NodePort 30083)
- 카나리 스모크 테스트 통과 후 텔레그램 승인 요청
- production gate 승인 시 --skip-canary로 본배포 (카나리 중복 방지)
- angple(프론트)와 동일한 3단계 파이프라인: 빌드 → 카나리 → 승인 → 운영

## Test plan
- [ ] main 머지 후 카나리 배포 자동 실행 확인
- [ ] canary.damoang.net에서 API v2 동작 확인
- [ ] production gate 승인 후 운영 배포 확인