### PR TITLE
백엔드 배포 중복 실행 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/damoang/angple-backend
 
+concurrency:
+  group: deploy-main-backend
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-24.04-arm
@@ -20,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -38,7 +42,7 @@ jobs:
 
       - name: Build and push API
         id: build_api
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: deployments/docker/api.Dockerfile
@@ -51,7 +55,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=api
 
       - name: Build and push Gateway
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: deployments/docker/gateway.Dockerfile

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -222,8 +222,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 	table := tableName(boardID)
 
 	// Reuse cached total count (same as FindPosts — avoids expensive COUNT on large tables)
-	var total int64
-	total = r.getCachedPostCount(boardID)
+	total := r.getCachedPostCount(boardID)
 	if total == 0 {
 		if err := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").Count(&total).Error; err != nil {
 			return nil, 0, err


### PR DESCRIPTION
## 변경 내용
- main deploy workflow에 concurrency 추가
- checkout/build-push action 버전 정리

## 기대 효과
- 같은 브랜치에서 연속 push 시 오래된 배포 런 자동 취소
- 최신 커밋 기준 배포만 유지
