### PR TITLE
free 목록에 커서 페이지네이션 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/damoang/angple-backend
+  DISCORD_WEBHOOK_TOKEN_BACKEND: ${{ secrets.DISCORD_WEBHOOK_TOKEN_BACKEND }}
 
 concurrency:
   group: deploy-main-backend
@@ -145,7 +146,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Canary)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")
@@ -233,7 +234,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Production)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1294,6 +1294,9 @@ func main() {
 			if err3 != nil || limit < 1 || limit > 100 {
 				limit = 20
 			}
+			cursorWrNum, cursorNumErr := strconv.Atoi(c.Query("cursor_wr_num"))
+			cursorWrReply := c.Query("cursor_wr_reply")
+			useCursor := cursorNumErr == nil && cursorWrReply != ""
 
 			// Search parameters
 			sfl := c.Query("sfl") // search field: title, content, title_content, author
@@ -1308,8 +1311,11 @@ func main() {
 
 			// --- 2-layer cache: in-memory → Redis → DB ---
 			memKey := fmt.Sprintf("posts:%s:%d:%d", slug, page, limit)
+			if useCursor {
+				memKey = fmt.Sprintf("posts:%s:cursor:%d:%s:%d", slug, cursorWrNum, cursorWrReply, limit)
+			}
 
-			if !isSearching {
+			if !isSearching && !useCursor {
 				// Layer 1: In-memory cache (30s TTL)
 				if cached, ok := postMemCache.Load(memKey); ok {
 					mc := cached.(*memCachedPosts)
@@ -1372,6 +1378,8 @@ func main() {
 			var total int64
 			if isSearching {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
+			} else if useCursor {
+				posts, total, err = gnuWriteRepo.FindPostsAfter(slug, limit, cursorWrNum, cursorWrReply)
 			} else {
 				posts, total, err = gnuWriteRepo.FindPosts(slug, page, limit)
 			}
@@ -1422,6 +1430,11 @@ func main() {
 			}
 
 			meta := gin.H{"board_id": slug, "page": page, "limit": limit, "total": total}
+			if useCursor && len(posts) > 0 {
+				last := posts[len(posts)-1]
+				meta["next_cursor_wr_num"] = last.WrNum
+				meta["next_cursor_wr_reply"] = last.WrReply
+			}
 			response := gin.H{
 				"success": true,
 				"data":    items,
@@ -1429,7 +1442,7 @@ func main() {
 			}
 
 			// Store in both caches (only for non-search requests, unfiltered data)
-			if !isSearching {
+			if !isSearching && !useCursor {
 				if cacheService != nil {
 					_ = cacheService.SetPosts(ctx, slug, page, limit, response)
 				}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -53,6 +53,7 @@ var coreColumns = []string{
 type WriteRepository interface {
 	// Posts
 	FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error)
+	FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsFiltered(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
 	SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	SearchPostsFiltered(boardID string, searchField, searchQuery string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
@@ -206,6 +207,49 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 		Offset(offset).
 		Limit(limit).
 		Find(&posts).Error
+
+	return posts, total, err
+}
+
+// FindPostsAfter retrieves posts using cursor pagination for the default gnuboard sort.
+// Cursor is the last seen (wr_num, wr_reply) pair from the previous page.
+func (r *writeRepository) FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error) {
+	var posts []*gnuboard.G5Write
+	var total int64
+
+	table := tableName(boardID)
+
+	total = r.getCachedPostCount(boardID)
+	if total == 0 {
+		countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')")
+		if err := countQuery.Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
+		r.setCachedPostCount(boardID, total)
+	}
+
+	orderClause := r.getSortField(boardID)
+	if orderClause != "wr_num, wr_reply" {
+		return r.FindPosts(boardID, 1, limit)
+	}
+
+	selectCols := strings.Join(coreColumns, ", ")
+	err := r.db.Raw(
+		fmt.Sprintf(
+			"SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?)) ORDER BY wr_num, wr_reply LIMIT ?",
+			selectCols,
+			table,
+		),
+		cursorWrNum, cursorWrNum, cursorWrReply, limit,
+	).Scan(&posts).Error
+	if err != nil && strings.Contains(err.Error(), "idx_list_page") {
+		err = r.db.Table(table).
+			Select(coreColumns).
+			Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?))", cursorWrNum, cursorWrNum, cursorWrReply).
+			Order(orderClause).
+			Limit(limit).
+			Find(&posts).Error
+	}
 
 	return posts, total, err
 }


### PR DESCRIPTION
요약
- /api/v1/boards/:slug/posts 에 cursor_wr_num, cursor_wr_reply 기반 커서 페이지네이션 추가
- 기본 정렬(wr_num, wr_reply)일 때 OFFSET 대신 커서 쿼리 사용
- 검색/커스텀 정렬은 기존 page/limit 유지

효과
- g5_write_free 큰 OFFSET 스캔 완화
- 깊은 페이지에서 수십만 행 버리는 비용 감소

테스트
- go test ./cmd/api ./internal/repository/gnuboard/...