### PR TITLE
영구 이용제한 회원 쓰기 차단 보정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/damoang/angple-backend
+  DISCORD_WEBHOOK_TOKEN_BACKEND: ${{ secrets.DISCORD_WEBHOOK_TOKEN_BACKEND }}
 
 concurrency:
   group: deploy-main-backend
@@ -145,7 +146,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Canary)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")
@@ -233,7 +234,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Production)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -38,10 +38,16 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			// mb_intercept_date가 비어있어도 g5_da_member_discipline에 활성 제재가 있으면 차단
 			var penaltyEndDate string
 			fallbackErr := gnuDB.Raw(
-				`SELECT DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y%m%d')
+				`SELECT CASE
+						WHEN penalty_period = -1 THEN '99991231'
+						ELSE DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y%m%d')
+					END
 				 FROM g5_da_member_discipline
-				 WHERE penalty_mb_id = ? AND penalty_period > 0
-				   AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW()
+				 WHERE penalty_mb_id = ?
+				   AND (
+						penalty_period = -1
+						OR (penalty_period > 0 AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW())
+				   )
 				 ORDER BY id DESC LIMIT 1`, mbID,
 			).Row().Scan(&penaltyEndDate)
 			if fallbackErr != nil || penaltyEndDate == "" {

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -84,7 +84,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 		// Block the request
 		banEndStr := banEnd.Format("2006-01-02 15:04:05")
 		if banEnd.Year() >= 9999 {
-			banEndStr = "영구 제재"
+			banEndStr = "영구 이용제한"
 		}
 		common.ErrorResponse(c, http.StatusForbidden,
 			"이용제한 기간 중에는 해당 기능을 사용할 수 없습니다. (해제일: "+banEndStr+")", nil)


### PR DESCRIPTION
## 요약
- 영구 이용제한(-1) 징계를 쓰기 차단에 반영합니다.
- mb_intercept_date가 비어 있어도 discipline 이력을 보고 차단합니다.

## 테스트
- go test ./internal/middleware/... ./internal/routes/v2/... ./internal/handler/...