### PR TITLE
refactor: 중복 Dantry 조회 라우트 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/damoang/angple-backend
+  DISCORD_WEBHOOK_TOKEN_BACKEND: ${{ secrets.DISCORD_WEBHOOK_TOKEN_BACKEND }}
 
 concurrency:
   group: deploy-main-backend
@@ -145,7 +146,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Canary)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")
@@ -233,7 +234,7 @@ jobs:
           exit 1
 
       - name: Notify Discord (Production)
-        if: always() && secrets.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
+        if: always() && env.DISCORD_WEBHOOK_TOKEN_BACKEND != ''
         run: |
           STATUS="${{ job.status }}"
           COLOR=$([[ "$STATUS" == "success" ]] && echo "3066993" || echo "15158332")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/config"
 	"github.com/damoang/angple-backend/internal/cron"
-	"github.com/damoang/angple-backend/internal/dantry"
 	"github.com/damoang/angple-backend/internal/domain"
 	gnuboard "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
@@ -4120,35 +4119,6 @@ func main() {
 
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 		})
-
-		// Dantry (에러 리포트 - ClickHouse)
-		if chHost := os.Getenv("CLICKHOUSE_HOST"); chHost != "" {
-			chPort := 9000
-			if p, err := strconv.Atoi(os.Getenv("CLICKHOUSE_PORT")); err == nil {
-				chPort = p
-			}
-			chClient, chErr := dantry.NewClickHouseClient(dantry.ClientConfig{
-				Host:     chHost,
-				Port:     chPort,
-				Database: "error_logs",
-				User:     os.Getenv("CLICKHOUSE_USER"),
-				Password: os.Getenv("CLICKHOUSE_PASSWORD"),
-			})
-			if chErr != nil {
-				log.Printf("Dantry ClickHouse connection failed: %v (dantry disabled)", chErr)
-			} else {
-				dantryRepo := dantry.NewRepository(chClient)
-				dantryHandler := dantry.NewHandler(dantryRepo)
-				dantryGroup := router.Group("/api/v1/dantry", middleware.JWTAuth(jwtManager))
-				dantryGroup.GET("/errors", dantryHandler.ListErrors)
-				dantryGroup.GET("/errors/grouped", dantryHandler.ListGrouped)
-				dantryGroup.GET("/errors/members", dantryHandler.GetMembersByMessage)
-				dantryGroup.GET("/errors/:id", dantryHandler.GetByID)
-				dantryGroup.GET("/stats", dantryHandler.GetStats)
-				dantryGroup.GET("/timeseries", dantryHandler.GetTimeseries)
-				log.Println("Dantry error viewer initialized")
-			}
-		}
 
 		// Plugin System
 		installRepo := pluginstoreRepo.NewInstallationRepository(db)


### PR DESCRIPTION
## 요약
-  에 남아 있던 중복 Dantry 조회 라우트를 제거했습니다.
- 운영 Dantry 조회 owner는  로 단일화합니다.
-  는 이미  전체를  로 프록시하고 있어, 이 변경은 중복 owner 제거 목적입니다.

## 변경 내용
-  에서  초기화 및  라우트 등록 제거
- 직접 ClickHouse 연결 경로 제거

## 배경
-  와  가 동일한 Dantry 조회 API를 중복 제공하고 있었습니다.
- 중복 owner는 ClickHouse 책임 경계와 운영 최적화 경로를 흐리게 만듭니다.
- Dantry 조회는 운영/관리 기능이므로  로 단일화하는 것이 더 적절합니다.

## 기대 효과
- Dantry 조회 owner 단일화
-  의 direct ClickHouse 접근 제거
- 향후 Dantry 최적화/캐시/summary 적용 경로 단순화

## 테스트
- 
