### PR TITLE
알림 설정 저장 시 값이 되돌아가는 버그 수정

### DIFF
--- a/internal/repository/gnuboard/noti_preference.go
+++ b/internal/repository/gnuboard/noti_preference.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 // NotiPreference represents a row in g5_noti_preference table
@@ -60,11 +59,16 @@ func (r *notiPreferenceRepository) Get(mbID string) (*NotiPreference, error) {
 
 // Upsert inserts or updates a user's notification preferences
 func (r *notiPreferenceRepository) Upsert(pref *NotiPreference) error {
-	return r.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "mb_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{
-			"noti_comment", "noti_reply", "noti_mention",
-			"noti_like", "noti_follow", "like_threshold",
-		}),
-	}).Create(pref).Error
+	result := r.db.Where("mb_id = ?", pref.MbID).First(&NotiPreference{})
+	if result.Error == gorm.ErrRecordNotFound {
+		return r.db.Create(pref).Error
+	}
+	return r.db.Model(&NotiPreference{}).Where("mb_id = ?", pref.MbID).Updates(map[string]interface{}{
+		"noti_comment":   pref.NotiComment,
+		"noti_reply":     pref.NotiReply,
+		"noti_mention":   pref.NotiMention,
+		"noti_like":      pref.NotiLike,
+		"noti_follow":    pref.NotiFollow,
+		"like_threshold": pref.LikeThreshold,
+	}).Error
 }


### PR DESCRIPTION
## Summary
- GORM `clause.OnConflict` + `AssignmentColumns`가 Go zero value(bool `false`, int `0`)를 무시하여 알림 설정이 저장되지 않던 버그 수정
- 명시적 check-then-update 방식 + `map[string]interface{}`로 변경하여 zero value 정상 반영

## Test plan
- [ ] dev.damoang.net에서 알림 설정 페이지 진입
- [ ] 댓글 알림 OFF → 저장 → 새로고침 → OFF 유지 확인
- [ ] 모든 항목 OFF → 저장 → 새로고침 → 모두 OFF 유지 확인
- [ ] 모든 항목 ON → 저장 → 새로고침 → 모두 ON 유지 확인