### PR TITLE
게시판 카테고리 필터 서버 사이드 지원

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1299,8 +1299,8 @@ func main() {
 			useCursor := cursorNumErr == nil && cursorWrReply != ""
 
 			// Search parameters
-			sfl := c.Query("sfl") // search field: title, content, title_content, author
-			stx := c.Query("stx") // search text
+			sfl := c.Query("sfl")           // search field: title, content, title_content, author
+			stx := c.Query("stx")           // search text
 			category := c.Query("category") // category filter (ca_name)
 			isSearching := sfl != "" && stx != ""
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1301,6 +1301,7 @@ func main() {
 			// Search parameters
 			sfl := c.Query("sfl") // search field: title, content, title_content, author
 			stx := c.Query("stx") // search text
+			category := c.Query("category") // category filter (ca_name)
 			isSearching := sfl != "" && stx != ""
 
 			// Get blocked user IDs (skip for admins)
@@ -1311,11 +1312,14 @@ func main() {
 
 			// --- 2-layer cache: in-memory → Redis → DB ---
 			memKey := fmt.Sprintf("posts:%s:%d:%d", slug, page, limit)
+			if category != "" {
+				memKey = fmt.Sprintf("posts:%s:%d:%d:cat:%s", slug, page, limit, category)
+			}
 			if useCursor {
 				memKey = fmt.Sprintf("posts:%s:cursor:%d:%s:%d", slug, cursorWrNum, cursorWrReply, limit)
 			}
 
-			if !isSearching && !useCursor {
+			if !isSearching && !useCursor && category == "" {
 				// Layer 1: In-memory cache (30s TTL)
 				if cached, ok := postMemCache.Load(memKey); ok {
 					mc := cached.(*memCachedPosts)
@@ -1380,6 +1384,8 @@ func main() {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
 			} else if useCursor {
 				posts, total, err = gnuWriteRepo.FindPostsAfter(slug, limit, cursorWrNum, cursorWrReply)
+			} else if category != "" {
+				posts, total, err = gnuWriteRepo.FindPostsByCategory(slug, category, page, limit)
 			} else {
 				posts, total, err = gnuWriteRepo.FindPosts(slug, page, limit)
 			}
@@ -1441,8 +1447,8 @@ func main() {
 				"meta":    meta,
 			}
 
-			// Store in both caches (only for non-search requests, unfiltered data)
-			if !isSearching && !useCursor {
+			// Store in both caches (only for non-search, non-category requests, unfiltered data)
+			if !isSearching && !useCursor && category == "" {
 				if cacheService != nil {
 					_ = cacheService.SetPosts(ctx, slug, page, limit, response)
 				}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -53,6 +53,7 @@ var coreColumns = []string{
 type WriteRepository interface {
 	// Posts
 	FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error)
+	FindPostsByCategory(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsFiltered(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
 	SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error)
@@ -185,6 +186,33 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	err := r.db.Table(table).
 		Select(coreColumns).
 		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
+		Order(orderClause).
+		Offset(offset).
+		Limit(limit).
+		Find(&posts).Error
+
+	return posts, total, err
+}
+
+// FindPostsByCategory retrieves posts filtered by ca_name (category) with pagination
+func (r *writeRepository) FindPostsByCategory(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
+	var posts []*gnuboard.G5Write
+	var total int64
+
+	offset := (page - 1) * limit
+	table := tableName(boardID)
+
+	baseWhere := "wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND ca_name = ?"
+
+	if err := r.db.Table(table).Where(baseWhere, category).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	orderClause := r.getSortField(boardID)
+
+	err := r.db.Table(table).
+		Select(coreColumns).
+		Where(baseWhere, category).
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).


### PR DESCRIPTION
## Summary
- `FindPostsByCategory` 메서드 추가 (ca_name 기준 필터 + 페이지네이션)
- `GET /api/v1/boards/:slug/posts?category=xxx` 파라미터 처리
- 카테고리 필터 시 캐시 분리 및 Redis bypass

## Test plan
- [ ] `curl "localhost:8090/api/v1/boards/economy/posts?category=네이버페이&limit=30"` → total=711, 30개 반환
- [ ] 카테고리 없이 호출 시 기존 동작 유지
- [ ] 페이지네이션 정상 동작 확인