### PR TITLE
차단 회원 필터링 + 알림 버그 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -394,6 +394,7 @@ func main() {
 		v2Handler.SetNotiRepository(gnurepo.NewNotiRepository(db))
 		v2Handler.SetNotiPreferenceRepository(gnurepo.NewNotiPreferenceRepository(db))
 		v2Handler.SetGnuDB(db)
+		v2Handler.SetBlockRepository(v2repo.NewBlockRepository(db))
 
 		// XP: DI into V2Handler (set after expRepo is created below)
 

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -32,6 +32,7 @@ type V2Handler struct {
 	gnuDB             *gorm.DB // gnuboard g5_member 조회용
 	gnuPointWriteRepo v2repo.GnuboardPointWriteRepository
 	pointConfigRepo   v2repo.PointConfigRepository
+	blockRepo         v2repo.BlockRepository
 }
 
 // NewV2Handler creates a new V2Handler
@@ -89,6 +90,27 @@ func (h *V2Handler) SetGnuboardPointWriteRepository(repo v2repo.GnuboardPointWri
 // SetPointConfigRepository sets the point config repository for point expiry settings
 func (h *V2Handler) SetPointConfigRepository(repo v2repo.PointConfigRepository) {
 	h.pointConfigRepo = repo
+}
+
+// SetBlockRepository sets the block repository for filtering blocked users
+func (h *V2Handler) SetBlockRepository(repo v2repo.BlockRepository) {
+	h.blockRepo = repo
+}
+
+// getBlockedUserIDs returns blocked user IDs (as uint64) for the given mb_id
+func (h *V2Handler) getBlockedUserIDs(mbID string) []uint64 {
+	if h.blockRepo == nil || mbID == "" || h.gnuDB == nil {
+		return nil
+	}
+	blockedMbIDs, err := h.blockRepo.GetBlockedUserIDs(mbID)
+	if err != nil || len(blockedMbIDs) == 0 {
+		return nil
+	}
+	var userIDs []uint64
+	if err := h.gnuDB.Table("g5_member").Select("mb_no").Where("mb_id IN ?", blockedMbIDs).Pluck("mb_no", &userIDs).Error; err != nil || len(userIDs) == 0 {
+		return nil
+	}
+	return userIDs
 }
 
 // createLevelUpNoti inserts a level-up notification into g5_na_noti
@@ -287,13 +309,16 @@ func (h *V2Handler) ListPosts(c *gin.Context) {
 	searchField := c.Query("sfl")
 	searchQuery := c.Query("stx")
 
+	// 차단 사용자 필터링
+	blockedUserIDs := h.getBlockedUserIDs(middleware.GetUserID(c))
+
 	var posts []*v2domain.V2Post
 	var total int64
 
 	if searchField != "" && searchQuery != "" {
-		posts, total, err = h.postRepo.SearchByBoard(board.ID, searchField, searchQuery, page, perPage)
+		posts, total, err = h.postRepo.SearchByBoardFiltered(board.ID, searchField, searchQuery, page, perPage, blockedUserIDs)
 	} else {
-		posts, total, err = h.postRepo.FindByBoard(board.ID, page, perPage)
+		posts, total, err = h.postRepo.FindByBoardFiltered(board.ID, page, perPage, blockedUserIDs)
 	}
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 목록 조회 실패", err)
@@ -719,7 +744,8 @@ func (h *V2Handler) ListComments(c *gin.Context) {
 	}
 
 	page, perPage := parsePagination(c)
-	comments, total, err := h.commentRepo.FindByPost(postID, page, perPage)
+	blockedUserIDs := h.getBlockedUserIDs(middleware.GetUserID(c))
+	comments, total, err := h.commentRepo.FindByPostFiltered(postID, page, perPage, blockedUserIDs)
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 목록 조회 실패", err)
 		return
@@ -1024,22 +1050,25 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 					}
 				}
 				if sendReply {
-					noti := &gnurepo.Notification{
-						PhToCase:      "comment_reply",
-						PhFromCase:    "comment",
-						BoTable:       boardSlug,
-						WrID:          safeUint64ToInt(comment.ID),
-						MbID:          parentAuthorMbID,
-						RelMbID:       commenterMbID,
-						RelMbNick:     commenterNick,
-						RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", commenterNick),
-						RelURL:        fmt.Sprintf("/%s/%d#comment_%d", boardSlug, postID, comment.ID),
-						PhReaded:      "N",
-						PhDatetime:    time.Now(),
-						ParentSubject: post.Title,
-						WrParent:      safeUint64ToInt(postID),
+					wrID := safeUint64ToInt(postID)
+					if exists, _ := h.notiRepo.Exists(parentAuthorMbID, boardSlug, wrID, "comment", commenterMbID); !exists {
+						noti := &gnurepo.Notification{
+							PhToCase:      "comment_reply",
+							PhFromCase:    "comment",
+							BoTable:       boardSlug,
+							WrID:          wrID,
+							MbID:          parentAuthorMbID,
+							RelMbID:       commenterMbID,
+							RelMbNick:     commenterNick,
+							RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", commenterNick),
+							RelURL:        fmt.Sprintf("/%s/%d#comment_%d", boardSlug, postID, comment.ID),
+							PhReaded:      "N",
+							PhDatetime:    time.Now(),
+							ParentSubject: post.Title,
+							WrParent:      wrID,
+						}
+						_ = h.notiRepo.Create(noti)
 					}
-					_ = h.notiRepo.Create(noti)
 				}
 			}
 		}
@@ -1053,20 +1082,23 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 	}
 
 	// 게시글 작성자에게 알림
-	noti := &gnurepo.Notification{
-		PhToCase:      "comment",
-		PhFromCase:    "comment",
-		BoTable:       boardSlug,
-		WrID:          safeUint64ToInt(comment.ID),
-		MbID:          postAuthorMbID,
-		RelMbID:       commenterMbID,
-		RelMbNick:     commenterNick,
-		RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", commenterNick),
-		RelURL:        fmt.Sprintf("/%s/%d#comment_%d", boardSlug, postID, comment.ID),
-		PhReaded:      "N",
-		PhDatetime:    time.Now(),
-		ParentSubject: post.Title,
-		WrParent:      safeUint64ToInt(postID),
+	wrID := safeUint64ToInt(postID)
+	if exists, _ := h.notiRepo.Exists(postAuthorMbID, boardSlug, wrID, "comment", commenterMbID); !exists {
+		noti := &gnurepo.Notification{
+			PhToCase:      "comment",
+			PhFromCase:    "comment",
+			BoTable:       boardSlug,
+			WrID:          wrID,
+			MbID:          postAuthorMbID,
+			RelMbID:       commenterMbID,
+			RelMbNick:     commenterNick,
+			RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", commenterNick),
+			RelURL:        fmt.Sprintf("/%s/%d#comment_%d", boardSlug, postID, comment.ID),
+			PhReaded:      "N",
+			PhDatetime:    time.Now(),
+			ParentSubject: post.Title,
+			WrParent:      wrID,
+		}
+		_ = h.notiRepo.Create(noti)
 	}
-	_ = h.notiRepo.Create(noti)
 }

--- a/internal/repository/gnuboard/noti_repo.go
+++ b/internal/repository/gnuboard/noti_repo.go
@@ -61,6 +61,7 @@ type NotiRepository interface {
 	Delete(mbID string, phID int) error
 	DeleteGroup(mbID, boTable string, wrID int, fromCase string) error
 	Create(noti *Notification) error
+	Exists(mbID, boTable string, wrID int, fromCase, relMbID string) (bool, error)
 }
 
 type notiRepository struct {
@@ -122,6 +123,15 @@ func (r *notiRepository) Delete(mbID string, phID int) error {
 // Create inserts a new notification
 func (r *notiRepository) Create(noti *Notification) error {
 	return r.db.Create(noti).Error
+}
+
+// Exists checks if a duplicate notification already exists
+func (r *notiRepository) Exists(mbID, boTable string, wrID int, fromCase, relMbID string) (bool, error) {
+	var count int64
+	err := r.db.Model(&Notification{}).
+		Where("mb_id = ? AND bo_table = ? AND wr_id = ? AND ph_from_case = ? AND rel_mb_id = ?", mbID, boTable, wrID, fromCase, relMbID).
+		Count(&count).Error
+	return count > 0, err
 }
 
 // GetGroupedNotifications returns notifications grouped by (bo_table, wr_id, ph_from_case)

--- a/internal/repository/v2/comment_repo.go
+++ b/internal/repository/v2/comment_repo.go
@@ -11,6 +11,7 @@ import (
 type CommentRepository interface {
 	FindByID(id uint64) (*v2.V2Comment, error)
 	FindByPost(postID uint64, page, limit int) ([]*v2.V2Comment, int64, error)
+	FindByPostFiltered(postID uint64, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Comment, int64, error)
 	Create(comment *v2.V2Comment) error
 	Update(comment *v2.V2Comment) error
 	Delete(id uint64) error
@@ -39,6 +40,24 @@ func (r *commentRepository) FindByPost(postID uint64, page, limit int) ([]*v2.V2
 	var total int64
 
 	query := r.db.Model(&v2.V2Comment{}).Where("post_id = ? AND status = 'active'", postID)
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("id ASC").Offset(offset).Limit(limit).Find(&comments).Error; err != nil {
+		return nil, 0, err
+	}
+	return comments, total, nil
+}
+
+// FindByPostFiltered retrieves comments excluding specified user IDs. Delegates to FindByPost if excludeUserIDs is empty.
+func (r *commentRepository) FindByPostFiltered(postID uint64, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Comment, int64, error) {
+	if len(excludeUserIDs) == 0 {
+		return r.FindByPost(postID, page, limit)
+	}
+	var comments []*v2.V2Comment
+	var total int64
+	query := r.db.Model(&v2.V2Comment{}).Where("post_id = ? AND status = 'active' AND user_id NOT IN ?", postID, excludeUserIDs)
 	if err := query.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}

--- a/internal/repository/v2/post_repo.go
+++ b/internal/repository/v2/post_repo.go
@@ -12,7 +12,9 @@ type PostRepository interface {
 	FindByID(id uint64) (*v2.V2Post, error)
 	FindByIDIncludeDeleted(id uint64) (*v2.V2Post, error)
 	FindByBoard(boardID uint64, page, limit int) ([]*v2.V2Post, int64, error)
+	FindByBoardFiltered(boardID uint64, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Post, int64, error)
 	SearchByBoard(boardID uint64, field, query string, page, limit int) ([]*v2.V2Post, int64, error)
+	SearchByBoardFiltered(boardID uint64, field, query string, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Post, int64, error)
 	FindDeleted(page, limit int) ([]*v2.V2Post, int64, error)
 	Create(post *v2.V2Post) error
 	Update(post *v2.V2Post) error
@@ -91,6 +93,55 @@ func (r *postRepository) FindByBoard(boardID uint64, page, limit int) ([]*v2.V2P
 	}
 	offset := (page - 1) * limit
 	if err := query.Order("is_notice DESC, id DESC").Offset(offset).Limit(limit).Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+	return posts, total, nil
+}
+
+// FindByBoardFiltered retrieves posts excluding specified user IDs. Delegates to FindByBoard if excludeUserIDs is empty.
+func (r *postRepository) FindByBoardFiltered(boardID uint64, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Post, int64, error) {
+	if len(excludeUserIDs) == 0 {
+		return r.FindByBoard(boardID, page, limit)
+	}
+	var posts []*v2.V2Post
+	var total int64
+	query := r.db.Model(&v2.V2Post{}).Where("board_id = ? AND status = 'published' AND user_id NOT IN ?", boardID, excludeUserIDs)
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("is_notice DESC, id DESC").Offset(offset).Limit(limit).Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+	return posts, total, nil
+}
+
+// SearchByBoardFiltered searches posts by field excluding specified user IDs. Delegates to SearchByBoard if excludeUserIDs is empty.
+func (r *postRepository) SearchByBoardFiltered(boardID uint64, field, keyword string, page, limit int, excludeUserIDs []uint64) ([]*v2.V2Post, int64, error) {
+	if len(excludeUserIDs) == 0 {
+		return r.SearchByBoard(boardID, field, keyword, page, limit)
+	}
+	var posts []*v2.V2Post
+	var total int64
+	query := r.db.Model(&v2.V2Post{}).Where("board_id = ? AND status = 'published' AND user_id NOT IN ?", boardID, excludeUserIDs)
+	like := "%" + keyword + "%"
+	switch field {
+	case "title":
+		query = query.Where("title LIKE ?", like)
+	case "content":
+		query = query.Where("content LIKE ?", like)
+	case "title_content":
+		query = query.Where("(title LIKE ? OR content LIKE ?)", like, like)
+	case "author":
+		query = query.Where("author_name LIKE ?", like)
+	default:
+		query = query.Where("(title LIKE ? OR content LIKE ?)", like, like)
+	}
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	offset := (page - 1) * limit
+	if err := query.Order("id DESC").Offset(offset).Limit(limit).Find(&posts).Error; err != nil {
 		return nil, 0, err
 	}
 	return posts, total, nil


### PR DESCRIPTION
## Summary
- V2 게시글/댓글 목록에서 차단 회원 글 제외 (P0)
- 알림 WrID를 comment.ID에서 postID로 수정하여 그룹핑 정상화 (P1)
- 알림 생성 전 중복 체크 추가 (P1)

## 변경 파일
- post_repo.go: FindByBoardFiltered, SearchByBoardFiltered 추가
- comment_repo.go: FindByPostFiltered 추가
- noti_repo.go: Exists() 중복 체크
- handler.go: 차단 필터 + WrID 수정 + 중복 체크
- main.go: blockRepo DI 연결

## Test plan
- [ ] 차단 회원 게시글/댓글 미표시 확인
- [ ] 알림 클릭 시 올바른 게시글로 이동
- [ ] 동일 댓글 중복 알림 미생성 확인