### PR TITLE
feat: report 뷰 extra_9 (wr_9) API 응답 추가

### DIFF
--- a/internal/domain/gnuboard/write.go
+++ b/internal/domain/gnuboard/write.go
@@ -37,7 +37,8 @@ type G5Write struct {
 	WrFile         int       `gorm:"column:wr_file" json:"wr_file"`
 	WrLast         string    `gorm:"column:wr_last" json:"wr_last"`
 	WrIP           string    `gorm:"column:wr_ip" json:"wr_ip"`
-	// Extended columns for thumbnail/image support
+	// Extended columns
+	Wr9  string `gorm:"column:wr_9" json:"wr_9"`   // 리포트 통계 JSON 등
 	Wr10 string `gorm:"column:wr_10" json:"wr_10"` // 이미지 URL (갤러리/메시지 썸네일)
 	// Soft delete columns
 	WrDeletedAt *time.Time `gorm:"column:wr_deleted_at" json:"deleted_at,omitempty"`

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -110,6 +110,9 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 func TransformToV1PostDetail(w *gnuboard.G5Write, isNotice bool) map[string]any {
 	result := TransformToV1Post(w, isNotice)
 	result["content"] = w.WrContent
+	if w.Wr9 != "" {
+		result["extra_9"] = w.Wr9
+	}
 	return result
 }
 

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -45,6 +45,7 @@ var coreColumns = []string{
 	"wr_link1_hit", "wr_link2_hit", "wr_hit", "wr_good", "wr_nogood",
 	"mb_id", "wr_password", "wr_name", "wr_email", "wr_homepage",
 	"wr_datetime", "wr_file", "wr_last", "wr_ip",
+	"wr_9",                           // 리포트 통계 JSON 등
 	"wr_10",                          // 이미지 URL (갤러리/메시지 썸네일)
 	"wr_deleted_at", "wr_deleted_by", // Soft delete columns (마이그레이션된 테이블만)
 }


### PR DESCRIPTION
## Summary
- G5Write 구조체에 Wr9 필드 추가 (wr_9 컬럼 매핑)
- coreColumns에 wr_9 포함하여 DB 조회 시 SELECT에 포함
- TransformToV1PostDetail에서 extra_9 키로 API 응답에 포함

## Test plan
- [ ] /report/270 상세 API 응답에 extra_9 필드 포함 확인