### PR TITLE
feat: mb_level 2→3 자동등업 크론 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4262,6 +4262,7 @@ func main() {
 		cronGroup.POST("/discipline-release", cronHandler.DisciplineRelease)
 		cronGroup.POST("/point-expiry", cronHandler.PointExpiry)
 		cronGroup.POST("/point-expiry-notify", cronHandler.PointExpiryNotify)
+		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(gnuWriteRepo, scheduledDeleteRepo)

--- a/internal/cron/auto_promote.go
+++ b/internal/cron/auto_promote.go
@@ -1,0 +1,83 @@
+package cron
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	"gorm.io/gorm"
+)
+
+// AutoPromoteResult contains the result of auto-promotion cron
+type AutoPromoteResult struct {
+	PromotedCount int      `json:"promoted_count"`
+	PromotedIDs   []string `json:"promoted_ids"`
+	ExecutedAt    string   `json:"executed_at"`
+}
+
+// runAutoPromote promotes members from mb_level 2 to 3
+// Conditions: mb_login_days >= 7 AND as_exp >= 3000
+func runAutoPromote(db *gorm.DB, notiRepo gnurepo.NotiRepository) (*AutoPromoteResult, error) {
+	now := time.Now()
+
+	// 조건 충족 회원 조회: mb_level=2, 로그인 7일 이상, 경험치 3000 이상
+	type candidate struct {
+		MbID string `gorm:"column:mb_id"`
+	}
+	var candidates []candidate
+	if err := db.Table("g5_member").
+		Select("mb_id").
+		Where("mb_level = 2 AND mb_login_days >= 7 AND as_exp >= 3000").
+		Where("mb_leave_date = '' AND mb_intercept_date = ''").
+		Find(&candidates).Error; err != nil {
+		return nil, fmt.Errorf("후보 조회 실패: %w", err)
+	}
+
+	result := &AutoPromoteResult{
+		ExecutedAt: now.Format("2006-01-02 15:04:05"),
+	}
+
+	if len(candidates) == 0 {
+		return result, nil
+	}
+
+	// 일괄 업데이트
+	mbIDs := make([]string, len(candidates))
+	for i, c := range candidates {
+		mbIDs[i] = c.MbID
+	}
+
+	if err := db.Table("g5_member").
+		Where("mb_id IN ?", mbIDs).
+		Update("mb_level", 3).Error; err != nil {
+		return nil, fmt.Errorf("등급 업데이트 실패: %w", err)
+	}
+
+	result.PromotedCount = len(mbIDs)
+	result.PromotedIDs = mbIDs
+
+	// 알림 발송 (best-effort)
+	if notiRepo != nil {
+		for _, mbID := range mbIDs {
+			noti := &gnurepo.Notification{
+				MbID:          mbID,
+				PhFromCase:    "promote",
+				PhToCase:      "me",
+				BoTable:       "@system",
+				WrID:          0,
+				RelMbID:       "system",
+				RelMbNick:     "시스템",
+				RelMsg:        "활동 조건을 충족하여 등급이 3으로 승급되었습니다",
+				RelURL:        "/my",
+				PhReaded:      "N",
+				ParentSubject: "등급 승급 안내",
+			}
+			if err := notiRepo.Create(noti); err != nil {
+				log.Printf("[Cron:auto-promote] notification failed for %s: %v", mbID, err)
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -136,3 +136,21 @@ func (h *Handler) UpdateReportPattern(c *gin.Context) {
 	log.Printf("[Cron:update-report-pattern] report generated: %s", result.Subject)
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
 }
+
+// AutoPromote handles POST /api/internal/cron/auto-promote
+// Promotes members from mb_level 2 to 3 when conditions are met
+func (h *Handler) AutoPromote(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runAutoPromote(h.db, h.notiRepo)
+	if err != nil {
+		log.Printf("[Cron:auto-promote] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:auto-promote] promoted %d members: %v", result.PromotedCount, result.PromotedIDs)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}

--- a/internal/domain/gnuboard/member.go
+++ b/internal/domain/gnuboard/member.go
@@ -64,6 +64,8 @@ type G5Member struct {
 	// 경험치/레벨 필드 (nariya 애드온)
 	AsExp   int `gorm:"column:as_exp" json:"as_exp"`
 	AsLevel int `gorm:"column:as_level" json:"as_level"`
+	// 서로 다른 날 로그인 횟수 (자동등업 조건용)
+	MbLoginDays int `gorm:"column:mb_login_days" json:"mb_login_days"`
 }
 
 // TableName returns the table name for GORM

--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -82,6 +82,8 @@ type ExpRepository interface {
 	GetXPConfig() (*XPConfig, error)
 	// UpdateXPConfig updates the XP configuration
 	UpdateXPConfig(config *XPConfig) error
+	// IncrementLoginDays increments mb_login_days by 1
+	IncrementLoginDays(mbID string) error
 }
 
 type expRepository struct {
@@ -287,6 +289,13 @@ func (r *expRepository) ListMembersWithXP(search string, page, limit int) ([]Mem
 	}
 
 	return members, total, nil
+}
+
+// IncrementLoginDays increments mb_login_days by 1
+func (r *expRepository) IncrementLoginDays(mbID string) error {
+	return r.db.Model(&gnuboard.G5Member{}).
+		Where("mb_id = ?", mbID).
+		UpdateColumn("mb_login_days", gorm.Expr("mb_login_days + 1")).Error
 }
 
 const defaultSiteID = "default"

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -123,6 +123,11 @@ func (s *V2AuthService) grantLoginXP(username string) {
 	if _, addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
 		log.Printf("[v2-auth] login XP grant failed for user %s: %v", username, addErr)
 	}
+
+	// 서로 다른 날 로그인 횟수 증가 (자동등업 조건)
+	if err := s.expRepo.IncrementLoginDays(username); err != nil {
+		log.Printf("[v2-auth] login days increment failed for user %s: %v", username, err)
+	}
 }
 
 // RefreshToken validates a refresh token and issues new token pair


### PR DESCRIPTION
## Summary
- G5Member에 `mb_login_days` 필드 추가 (서로 다른 날 로그인 횟수 누적)
- 로그인 시 `mb_login_days` 자동 증가 (기존 하루 1회 dedup 활용)
- 자동등업 크론 엔드포인트: `POST /api/internal/cron/auto-promote`
- 승급 조건: `mb_level=2 AND mb_login_days>=7 AND as_exp>=3000` → mb_level 3
- 승급 시 g5_na_noti 알림 발송

## 배포 전 DB 마이그레이션
```sql
ALTER TABLE g5_member ADD COLUMN mb_login_days INT DEFAULT 0;

UPDATE g5_member SET mb_login_days = (
  SELECT COUNT(DISTINCT DATE(xp_datetime))
  FROM g5_na_xp
  WHERE g5_na_xp.mb_id = g5_member.mb_id AND xp_rel_action = '@login'
);
```

## Test plan
- [ ] DB 마이그레이션 실행
- [ ] 로그인 시 mb_login_days 증가 확인
- [ ] `curl -X POST "http://localhost:8090/api/internal/cron/auto-promote?secret=..."` 실행
- [ ] 조건 충족 회원 mb_level 2→3 변경 확인
- [ ] 알림 발송 확인