### PR TITLE
fix: 로그인 XP 중복 적립 버그 수정

### DIFF
--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -110,7 +110,9 @@ func (s *V2AuthService) grantLoginXP(username string) {
 		return
 	}
 
-	already, err := s.expRepo.HasTodayAction(username, "@login")
+	today := time.Now().Format("2006-01-02")
+
+	already, err := s.expRepo.HasTodayAction(username, today)
 	if err != nil {
 		log.Printf("[v2-auth] login XP check failed for user %s: %v", username, err)
 		return
@@ -118,8 +120,6 @@ func (s *V2AuthService) grantLoginXP(username string) {
 	if already {
 		return
 	}
-
-	today := time.Now().Format("2006-01-02")
 	if _, addErr := s.expRepo.AddExp(username, xpConfig.LoginXP, today+" 로그인", "@login", username, today); addErr != nil {
 		log.Printf("[v2-auth] login XP grant failed for user %s: %v", username, addErr)
 	}


### PR DESCRIPTION
## Summary
- `HasTodayAction(username, "@login")` → `HasTodayAction(username, today)`로 수정
- 실제 `xp_rel_action`에는 날짜(2026-03-15)가 저장되는데 `@login`으로 조회해서 dedup이 동작하지 않던 버그

## Test plan
- [ ] 로그인 후 g5_na_xp에 같은 날짜 중복 레코드 생성 안 되는지 확인