### PR TITLE
feat: 로그인 시 자동 등업 체크 (2→3 앙님)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -429,8 +429,9 @@ func main() {
 		disciplineLogHandler := v2handler.NewDisciplineLogHandler(gnuWriteRepo, db)
 		v2routes.SetupDisciplineLog(router, disciplineLogHandler, jwtManager)
 
-		// v2 Auth (with ExpRepo for daily login XP)
+		// v2 Auth (with ExpRepo for daily login XP + auto-promotion on login)
 		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager, v2ExpRepo)
+		v2AuthSvc.SetPromotionDeps(db, gnurepo.NewNotiRepository(db))
 		v2AuthHandler := v2handler.NewV2AuthHandler(v2AuthSvc)
 		v2routes.SetupAuth(router, v2AuthHandler, jwtManager)
 
@@ -1424,11 +1425,16 @@ func main() {
 			}
 			if len(needFileIDs) > 0 {
 				if fileImages, err := gnuFileRepo.GetFirstImagesByPostIDs(slug, needFileIDs); err == nil && len(fileImages) > 0 {
+					cdnURL := strings.TrimRight(cfg.Storage.CDNURL, "/")
 					for i, item := range items {
 						if _, ok := item["thumbnail"]; !ok {
 							if id, ok := item["id"].(int); ok {
 								if fname, ok := fileImages[id]; ok {
-									items[i]["thumbnail"] = "data/file/" + slug + "/" + fname
+									if cdnURL != "" {
+										items[i]["thumbnail"] = cdnURL + "/data/file/" + slug + "/" + fname
+									} else {
+										items[i]["thumbnail"] = "data/file/" + slug + "/" + fname
+									}
 								}
 							}
 						}

--- a/internal/cron/auto_promote.go
+++ b/internal/cron/auto_promote.go
@@ -67,11 +67,11 @@ func runAutoPromote(db *gorm.DB, notiRepo gnurepo.NotiRepository) (*AutoPromoteR
 				BoTable:       "@system",
 				WrID:          0,
 				RelMbID:       "system",
-				RelMbNick:     "시스템",
-				RelMsg:        "활동 조건을 충족하여 등급이 3으로 승급되었습니다",
+				RelMbNick:     "다모앙",
+				RelMsg:        "💛 앙님(💛)으로 되었습니다. 앞으로도 다모앙에서 즐거운 시간 보내세요!",
 				RelURL:        "/my",
 				PhReaded:      "N",
-				ParentSubject: "등급 승급 안내",
+				ParentSubject: "축하합니다.",
 			}
 			if err := notiRepo.Create(noti); err != nil {
 				log.Printf("[Cron:auto-promote] notification failed for %s: %v", mbID, err)

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -1,6 +1,7 @@
 package v1handler
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -37,9 +38,35 @@ func parseWrLast(wrLast string, createdAt time.Time) any {
 func extractFirstImageURL(html string) string {
 	m := imgSrcRegex.FindStringSubmatch(html)
 	if len(m) >= 2 {
-		return m[1]
+		return normalizeMediaURL(m[1])
 	}
 	return ""
+}
+
+func normalizeMediaURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+
+	cdnURL := strings.TrimRight(os.Getenv("CDN_URL"), "/")
+	if cdnURL == "" {
+		return raw
+	}
+
+	if strings.HasPrefix(raw, "./") {
+		raw = strings.TrimPrefix(raw, "./")
+	}
+	if strings.HasPrefix(raw, "data/") {
+		return cdnURL + "/" + raw
+	}
+	if strings.HasPrefix(raw, "/data/") {
+		return cdnURL + raw
+	}
+
+	return raw
 }
 
 // MaskIP masks the 2nd octet of an IPv4 address with ♡ (e.g. "1.2.3.4" → "1.♡.3.4")
@@ -97,8 +124,8 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 
 	// Add thumbnail: priority is wr_10 > first <img> in content
 	if w.Wr10 != "" {
-		result["thumbnail"] = w.Wr10
-		result["extra_10"] = w.Wr10
+		result["thumbnail"] = normalizeMediaURL(w.Wr10)
+		result["extra_10"] = normalizeMediaURL(w.Wr10)
 	} else if img := extractFirstImageURL(w.WrContent); img != "" {
 		result["thumbnail"] = img
 	}

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/damoang/angple-backend/internal/common"
 	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 	"github.com/damoang/angple-backend/pkg/jwt"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 // V2AuthService handles v2 authentication with bcrypt + legacy password support
@@ -21,6 +23,8 @@ type V2AuthService struct {
 	userRepo   v2repo.UserRepository
 	jwtManager *jwt.Manager
 	expRepo    v2repo.ExpRepository
+	notiRepo   gnurepo.NotiRepository
+	db         *gorm.DB
 }
 
 // NewV2AuthService creates a new V2AuthService
@@ -30,6 +34,12 @@ func NewV2AuthService(userRepo v2repo.UserRepository, jwtManager *jwt.Manager, e
 		jwtManager: jwtManager,
 		expRepo:    expRepo,
 	}
+}
+
+// SetPromotionDeps sets dependencies needed for auto-promotion on login
+func (s *V2AuthService) SetPromotionDeps(db *gorm.DB, notiRepo gnurepo.NotiRepository) {
+	s.db = db
+	s.notiRepo = notiRepo
 }
 
 // V2LoginResponse represents v2 login response
@@ -70,20 +80,29 @@ func (s *V2AuthService) Login(username, password string) (*V2LoginResponse, erro
 		}
 	}
 
+	// Grant daily login XP synchronously (mb_login_days must be updated before promotion check)
+	if s.expRepo != nil {
+		s.grantLoginXP(username)
+	}
+
+	// Check auto-promotion (2→3) and update level if promoted
+	level := int(user.Level)
+	if promoted, newLevel := s.checkAndPromote(user.Username); promoted {
+		level = newLevel
+		user.Level = uint8(newLevel)
+		// Update v2_users level (best-effort)
+		_ = s.userRepo.Update(user)
+	}
+
 	// Generate JWT tokens
 	userIDStr := strconv.FormatUint(user.ID, 10)
-	accessToken, err := s.jwtManager.GenerateAccessToken(userIDStr, user.Username, user.Nickname, int(user.Level))
+	accessToken, err := s.jwtManager.GenerateAccessToken(userIDStr, user.Username, user.Nickname, level)
 	if err != nil {
 		return nil, fmt.Errorf("generate access token: %w", err)
 	}
 	refreshToken, err := s.jwtManager.GenerateRefreshToken(userIDStr)
 	if err != nil {
 		return nil, fmt.Errorf("generate refresh token: %w", err)
-	}
-
-	// Grant daily login XP (best-effort, errors don't affect login)
-	if s.expRepo != nil {
-		go s.grantLoginXP(username)
 	}
 
 	return &V2LoginResponse{
@@ -180,4 +199,70 @@ func verifyPassword(plain, hashed string) bool {
 // isBcryptHash checks if the hash is bcrypt format ($2a$, $2b$, $2y$)
 func isBcryptHash(hash string) bool {
 	return len(hash) == 60 && (hash[:4] == "$2a$" || hash[:4] == "$2b$" || hash[:4] == "$2y$")
+}
+
+// checkAndPromote checks if the user meets auto-promotion criteria and promotes them.
+// Currently supports 2→3 (앙님) promotion.
+func (s *V2AuthService) checkAndPromote(mbID string) (bool, int) {
+	if s.db == nil {
+		return false, 0
+	}
+
+	var member struct {
+		MbLevel   int `gorm:"column:mb_level"`
+		LoginDays int `gorm:"column:mb_login_days"`
+		Exp       int `gorm:"column:as_exp"`
+	}
+	if err := s.db.Table("g5_member").
+		Select("mb_level, mb_login_days, as_exp").
+		Where("mb_id = ?", mbID).
+		First(&member).Error; err != nil {
+		log.Printf("[v2-auth] checkAndPromote: member query failed for %s: %v", mbID, err)
+		return false, 0
+	}
+
+	// 2→3 (앙님) 조건: 로그인 7일 이상 + 경험치 3000 이상
+	if member.MbLevel == 2 && member.LoginDays >= 7 && member.Exp >= 3000 {
+		if err := s.db.Table("g5_member").
+			Where("mb_id = ?", mbID).
+			Update("mb_level", 3).Error; err != nil {
+			log.Printf("[v2-auth] checkAndPromote: level update failed for %s: %v", mbID, err)
+			return false, member.MbLevel
+		}
+		log.Printf("[v2-auth] auto-promoted %s from level 2 to 3", mbID)
+		go s.sendPromotionNotification(mbID, 3)
+		return true, 3
+	}
+
+	return false, member.MbLevel
+}
+
+// sendPromotionNotification sends a promotion notification (best-effort)
+func (s *V2AuthService) sendPromotionNotification(mbID string, newLevel int) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[v2-auth] promotion notification panic for %s: %v", mbID, r)
+		}
+	}()
+
+	if s.notiRepo == nil {
+		return
+	}
+
+	noti := &gnurepo.Notification{
+		MbID:          mbID,
+		PhFromCase:    "promote",
+		PhToCase:      "me",
+		BoTable:       "@system",
+		WrID:          0,
+		RelMbID:       "system",
+		RelMbNick:     "다모앙",
+		RelMsg:        "💛 앙님(💛)으로 되었습니다. 앞으로도 다모앙에서 즐거운 시간 보내세요!",
+		RelURL:        "/my",
+		PhReaded:      "N",
+		ParentSubject: "축하합니다.",
+	}
+	if err := s.notiRepo.Create(noti); err != nil {
+		log.Printf("[v2-auth] promotion notification failed for %s: %v", mbID, err)
+	}
 }

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -89,7 +89,7 @@ func (s *V2AuthService) Login(username, password string) (*V2LoginResponse, erro
 	level := int(user.Level)
 	if promoted, newLevel := s.checkAndPromote(user.Username); promoted {
 		level = newLevel
-		user.Level = uint8(newLevel)
+		user.Level = uint8(min(newLevel, 255)) //nolint:gosec // level values are small (2-10)
 		// Update v2_users level (best-effort)
 		_ = s.userRepo.Update(user)
 	}
@@ -230,7 +230,7 @@ func (s *V2AuthService) checkAndPromote(mbID string) (bool, int) {
 			return false, member.MbLevel
 		}
 		log.Printf("[v2-auth] auto-promoted %s from level 2 to 3", mbID)
-		go s.sendPromotionNotification(mbID, 3)
+		go s.sendPromotionNotification(mbID)
 		return true, 3
 	}
 
@@ -238,7 +238,7 @@ func (s *V2AuthService) checkAndPromote(mbID string) (bool, int) {
 }
 
 // sendPromotionNotification sends a promotion notification (best-effort)
-func (s *V2AuthService) sendPromotionNotification(mbID string, newLevel int) {
+func (s *V2AuthService) sendPromotionNotification(mbID string) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[v2-auth] promotion notification panic for %s: %v", mbID, r)


### PR DESCRIPTION
## Summary
- 로그인 시 grantLoginXP를 동기 실행 후 checkAndPromote()로 자동 등업 조건 체크
- 조건: mb_level=2, mb_login_days >= 7, as_exp >= 3000 → 레벨 3 승급
- 승급 시 g5_member + v2_users 레벨 업데이트, JWT에 새 레벨 즉시 반영
- 알림 발송 (goroutine, best-effort)
- 기존 크론 엔드포인트는 폴백용으로 유지

## Test plan
- [ ] dev에서 레벨 2 테스트 계정 로그인 → 레벨 3 승급 확인
- [ ] JWT 토큰에 새 레벨 반영 확인
- [ ] 알림(g5_na_noti) 생성 확인
- [ ] 조건 미충족 유저 로그인 시 레벨 변경 없음 확인