### PR TITLE
레거시 /data 미디어 URL을 CDN 절대 경로로 정규화

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -429,8 +429,9 @@ func main() {
 		disciplineLogHandler := v2handler.NewDisciplineLogHandler(gnuWriteRepo, db)
 		v2routes.SetupDisciplineLog(router, disciplineLogHandler, jwtManager)
 
-		// v2 Auth (with ExpRepo for daily login XP)
+		// v2 Auth (with ExpRepo for daily login XP + auto-promotion on login)
 		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager, v2ExpRepo)
+		v2AuthSvc.SetPromotionDeps(db, gnurepo.NewNotiRepository(db))
 		v2AuthHandler := v2handler.NewV2AuthHandler(v2AuthSvc)
 		v2routes.SetupAuth(router, v2AuthHandler, jwtManager)
 
@@ -1424,11 +1425,16 @@ func main() {
 			}
 			if len(needFileIDs) > 0 {
 				if fileImages, err := gnuFileRepo.GetFirstImagesByPostIDs(slug, needFileIDs); err == nil && len(fileImages) > 0 {
+					cdnURL := strings.TrimRight(cfg.Storage.CDNURL, "/")
 					for i, item := range items {
 						if _, ok := item["thumbnail"]; !ok {
 							if id, ok := item["id"].(int); ok {
 								if fname, ok := fileImages[id]; ok {
-									items[i]["thumbnail"] = "data/file/" + slug + "/" + fname
+									if cdnURL != "" {
+										items[i]["thumbnail"] = cdnURL + "/data/file/" + slug + "/" + fname
+									} else {
+										items[i]["thumbnail"] = "data/file/" + slug + "/" + fname
+									}
 								}
 							}
 						}

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -1,6 +1,7 @@
 package v1handler
 
 import (
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -37,9 +38,35 @@ func parseWrLast(wrLast string, createdAt time.Time) any {
 func extractFirstImageURL(html string) string {
 	m := imgSrcRegex.FindStringSubmatch(html)
 	if len(m) >= 2 {
-		return m[1]
+		return normalizeMediaURL(m[1])
 	}
 	return ""
+}
+
+func normalizeMediaURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return raw
+	}
+
+	cdnURL := strings.TrimRight(os.Getenv("CDN_URL"), "/")
+	if cdnURL == "" {
+		return raw
+	}
+
+	if strings.HasPrefix(raw, "./") {
+		raw = strings.TrimPrefix(raw, "./")
+	}
+	if strings.HasPrefix(raw, "data/") {
+		return cdnURL + "/" + raw
+	}
+	if strings.HasPrefix(raw, "/data/") {
+		return cdnURL + raw
+	}
+
+	return raw
 }
 
 // MaskIP masks the 2nd octet of an IPv4 address with ♡ (e.g. "1.2.3.4" → "1.♡.3.4")
@@ -97,8 +124,8 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 
 	// Add thumbnail: priority is wr_10 > first <img> in content
 	if w.Wr10 != "" {
-		result["thumbnail"] = w.Wr10
-		result["extra_10"] = w.Wr10
+		result["thumbnail"] = normalizeMediaURL(w.Wr10)
+		result["extra_10"] = normalizeMediaURL(w.Wr10)
 	} else if img := extractFirstImageURL(w.WrContent); img != "" {
 		result["thumbnail"] = img
 	}


### PR DESCRIPTION
## 배경
- /data/* 비용 누수의 원인은 저장 위치보다 레거시 URL 발급에 가깝습니다.
- 파일은 이미 S3에 있지만, 일부 응답이 여전히 data/file/... 또는 /data/... 를 내려 브라우저가 damoang.net/data/... 를 먼저 타고 있습니다.

## 변경
- 게시글 목록 썸네일 fallback을 CDN_URL + /data/file/... 형태로 반환
- wr_10 및 본문 첫 이미지가 /data/... 또는 data/... 여도 응답 시 CDN 절대 URL로 정규화

## 기대 효과
- 브라우저가 처음부터 s3.damoang.net 경로를 보게 되어 /data/* origin 경유를 줄입니다.
- /data/* 관련 ALB 바이트와 요청 수 감소를 기대할 수 있습니다.

## 비고
- 저장소 이전 작업이 아니라 레거시 URL 발급 정리입니다.
- 배포 후 ALB access log 기준으로 /data/* 감소폭을 다시 확인할 예정입니다.