### PR TITLE
게시글 본문 미디어 URL을 CDN 절대 경로로 정규화

### DIFF
--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -69,6 +69,25 @@ func normalizeMediaURL(raw string) string {
 	return raw
 }
 
+func normalizeMediaContent(raw string) string {
+	cdnURL := strings.TrimRight(os.Getenv("CDN_URL"), "/")
+	if raw == "" || cdnURL == "" {
+		return raw
+	}
+
+	replacer := strings.NewReplacer(
+		`src="/data/`, `src="`+cdnURL+`/data/`,
+		`src='/data/`, `src='`+cdnURL+`/data/`,
+		`src="data/`, `src="`+cdnURL+`/data/`,
+		`src='data/`, `src='`+cdnURL+`/data/`,
+		`href="/data/`, `href="`+cdnURL+`/data/`,
+		`href='/data/`, `href='`+cdnURL+`/data/`,
+		`href="data/`, `href="`+cdnURL+`/data/`,
+		`href='data/`, `href='`+cdnURL+`/data/`,
+	)
+	return replacer.Replace(raw)
+}
+
 // MaskIP masks the 2nd octet of an IPv4 address with ♡ (e.g. "1.2.3.4" → "1.♡.3.4")
 func MaskIP(ip string) string {
 	if ip == "" {
@@ -136,7 +155,7 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 // TransformToV1PostDetail converts G5Write to detailed v1 API response format
 func TransformToV1PostDetail(w *gnuboard.G5Write, isNotice bool) map[string]any {
 	result := TransformToV1Post(w, isNotice)
-	result["content"] = w.WrContent
+	result["content"] = normalizeMediaContent(w.WrContent)
 	if w.Wr9 != "" {
 		result["extra_9"] = w.Wr9
 	}


### PR DESCRIPTION
## 배경
- /data/* 비용 누수의 남은 큰 축은 게시글 상세 본문(content) 안에 박혀 있는 /data/editor/* 링크입니다.
- 목록 썸네일은 이미 CDN 절대 URL로 바꿨지만, 상세 본문이 여전히 /data/... 를 내리면 브라우저가 origin 경로를 계속 탑니다.

## 변경
- v1 상세 응답의 content 필드에서 src/href 의 /data/... 및 data/... 경로를 CDN_URL 기준 절대 경로로 정규화

## 기대 효과
- 상세 페이지 본문 이미지/첨부 링크도 처음부터 S3/CDN 경로 사용
- /data/editor/* ALB 트래픽 추가 감소 기대