### PR TITLE
운영용 /data CDN 점검 도구 추가

### DIFF
--- a/cmd/rewrite-media-urls/main.go
+++ b/cmd/rewrite-media-urls/main.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/config"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+type rewritePlan struct {
+	boardID         string
+	tableName       string
+	contentMatches  int64
+	wr10Matches     int64
+	contentExamples []int
+	wr10Examples    []int
+}
+
+func main() {
+	configPath := flag.String("config", "configs/config.prod.yaml", "config file path")
+	apply := flag.Bool("apply", false, "apply database updates")
+	board := flag.String("board", "", "single board id to process")
+	limit := flag.Int("limit", 5, "example row limit per board")
+	sampleOnly := flag.Bool("sample-only", false, "skip full count scans and only fetch example row ids")
+	verbose := flag.Bool("verbose", false, "verbose SQL logging")
+	flag.Parse()
+
+	loaded := config.LoadDotEnv()
+	if len(loaded) > 0 {
+		log.Printf("Loaded env files: %v", loaded)
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	cdnURL := strings.TrimRight(cfg.Storage.CDNURL, "/")
+	if cdnURL == "" {
+		log.Fatal("CDN_URL is empty; refusing to continue")
+	}
+
+	logLevel := gormlogger.Warn
+	if *verbose {
+		logLevel = gormlogger.Info
+	}
+
+	db, err := gorm.Open(mysql.Open(cfg.Database.GetDSN()), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(logLevel),
+	})
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("failed to get underlying DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	boardIDs, err := getBoardIDs(db)
+	if err != nil {
+		log.Fatalf("failed to load board ids: %v", err)
+	}
+
+	if *board != "" {
+		boardIDs = []string{*board}
+	}
+
+	var totalContent int64
+	var totalWr10 int64
+	var changedTables int
+
+	for _, boardID := range boardIDs {
+		tableName := fmt.Sprintf("g5_write_%s", boardID)
+		if !tableExists(db, tableName) {
+			continue
+		}
+
+		plan, err := buildPlan(db, boardID, tableName, *limit, *sampleOnly)
+		if err != nil {
+			log.Printf("[audit] %s failed: %v", tableName, err)
+			continue
+		}
+
+		if plan.contentMatches == 0 && plan.wr10Matches == 0 {
+			continue
+		}
+
+		changedTables++
+		totalContent += plan.contentMatches
+		totalWr10 += plan.wr10Matches
+
+		log.Printf("[audit] %s content=%d wr10=%d content_examples=%v wr10_examples=%v",
+			tableName, plan.contentMatches, plan.wr10Matches, plan.contentExamples, plan.wr10Examples)
+
+		if !*apply {
+			continue
+		}
+
+		if err := applyRewrites(db, tableName, cdnURL); err != nil {
+			log.Printf("[apply] %s failed: %v", tableName, err)
+			continue
+		}
+		log.Printf("[apply] %s updated", tableName)
+	}
+
+	log.Printf("[summary] tables=%d content_matches=%d wr10_matches=%d apply=%v",
+		changedTables, totalContent, totalWr10, *apply)
+}
+
+func buildPlan(db *gorm.DB, boardID, tableName string, limit int, sampleOnly bool) (*rewritePlan, error) {
+	plan := &rewritePlan{
+		boardID:   boardID,
+		tableName: tableName,
+	}
+
+	contentWhere := mediaContentWhereClause()
+	wr10Where := mediaWr10WhereClause()
+
+	if !sampleOnly {
+		if err := db.Table(tableName).Where(contentWhere).Count(&plan.contentMatches).Error; err != nil {
+			return nil, err
+		}
+		if err := db.Table(tableName).Where(wr10Where).Count(&plan.wr10Matches).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	if err := db.Table(tableName).
+		Select("wr_id").
+		Where(contentWhere).
+		Order("wr_id DESC").
+		Limit(limit).
+		Scan(&plan.contentExamples).Error; err != nil {
+		return nil, err
+	}
+	if err := db.Table(tableName).
+		Select("wr_id").
+		Where(wr10Where).
+		Order("wr_id DESC").
+		Limit(limit).
+		Scan(&plan.wr10Examples).Error; err != nil {
+		return nil, err
+	}
+
+	if sampleOnly {
+		plan.contentMatches = int64(len(plan.contentExamples))
+		plan.wr10Matches = int64(len(plan.wr10Examples))
+	}
+
+	return plan, nil
+}
+
+func applyRewrites(db *gorm.DB, tableName, cdnURL string) error {
+	contentExpr := normalizeContentSQL("wr_content", cdnURL)
+	wr10Expr := normalizeWr10SQL("wr_10", cdnURL)
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec(
+			fmt.Sprintf("UPDATE `%s` SET wr_content = %s WHERE %s", tableName, contentExpr, mediaContentWhereClause()),
+		).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Exec(
+			fmt.Sprintf("UPDATE `%s` SET wr_10 = %s WHERE %s", tableName, wr10Expr, mediaWr10WhereClause()),
+		).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func normalizeContentSQL(column, cdnURL string) string {
+	replacements := [][2]string{
+		{`src="/data/`, `src="` + cdnURL + `/data/`},
+		{`src='/data/`, `src='` + cdnURL + `/data/`},
+		{`src="data/`, `src="` + cdnURL + `/data/`},
+		{`src='data/`, `src='` + cdnURL + `/data/`},
+		{`href="/data/`, `href="` + cdnURL + `/data/`},
+		{`href='/data/`, `href='` + cdnURL + `/data/`},
+		{`href="data/`, `href="` + cdnURL + `/data/`},
+		{`href='data/`, `href='` + cdnURL + `/data/`},
+	}
+
+	expr := column
+	for _, pair := range replacements {
+		expr = fmt.Sprintf("REPLACE(%s, '%s', '%s')", expr, escapeSQL(pair[0]), escapeSQL(pair[1]))
+	}
+	return expr
+}
+
+func normalizeWr10SQL(column, cdnURL string) string {
+	return fmt.Sprintf(
+		"CASE "+
+			"WHEN %s LIKE '/data/%%' THEN CONCAT('%s', %s) "+
+			"WHEN %s LIKE 'data/%%' THEN CONCAT('%s/', %s) "+
+			"ELSE %s END",
+		column, escapeSQL(cdnURL), column,
+		column, escapeSQL(cdnURL), column,
+		column,
+	)
+}
+
+func mediaContentWhereClause() string {
+	return strings.Join([]string{
+		"wr_content LIKE '%src=\"/data/%'",
+		"wr_content LIKE '%src=''/data/%'",
+		"wr_content LIKE '%src=\"data/%'",
+		"wr_content LIKE '%src=''data/%'",
+		"wr_content LIKE '%href=\"/data/%'",
+		"wr_content LIKE '%href=''/data/%'",
+		"wr_content LIKE '%href=\"data/%'",
+		"wr_content LIKE '%href=''data/%'",
+	}, " OR ")
+}
+
+func mediaWr10WhereClause() string {
+	return "wr_10 LIKE '/data/%' OR wr_10 LIKE 'data/%'"
+}
+
+func getBoardIDs(db *gorm.DB) ([]string, error) {
+	var boardIDs []string
+	if err := db.Raw("SELECT bo_table FROM g5_board").Scan(&boardIDs).Error; err != nil {
+		return nil, err
+	}
+	return boardIDs, nil
+}
+
+func tableExists(db *gorm.DB, tableName string) bool {
+	var count int64
+	db.Raw("SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?", tableName).Scan(&count)
+	return count > 0
+}
+
+func escapeSQL(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/cmd/sync-nariya-images/main.go
+++ b/cmd/sync-nariya-images/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"fmt"
+	"log"
+	"mime"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultLocalDir = "/home/damoang/www/data/nariya/image"
+	defaultBucket   = "damoang-data-v1"
+	defaultPrefix   = "data/nariya/image"
+)
+
+type syncResult struct {
+	checked  int
+	missing  int
+	uploaded int
+	failed   int
+}
+
+func main() {
+	localDir := flag.String("dir", defaultLocalDir, "local nariya image directory")
+	bucket := flag.String("bucket", defaultBucket, "target S3 bucket")
+	prefix := flag.String("prefix", defaultPrefix, "target S3 prefix")
+	match := flag.String("match", "", "only process files containing this substring")
+	limit := flag.Int("limit", 0, "maximum number of files to process (0 = unlimited)")
+	apply := flag.Bool("apply", false, "upload missing files")
+	flag.Parse()
+
+	entries, err := os.ReadDir(*localDir)
+	if err != nil {
+		log.Fatalf("failed to read directory: %v", err)
+	}
+
+	result := syncResult{}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if *match != "" && !strings.Contains(name, *match) {
+			continue
+		}
+
+		result.checked++
+		if *limit > 0 && result.checked > *limit {
+			break
+		}
+
+		localPath := filepath.Join(*localDir, name)
+		key := strings.TrimPrefix(filepath.ToSlash(filepath.Join(*prefix, name)), "/")
+
+		exists, err := objectExists(*bucket, key)
+		if err != nil {
+			result.failed++
+			log.Printf("[check] %s failed: %v", key, err)
+			continue
+		}
+		if exists {
+			log.Printf("[exists] %s", key)
+			continue
+		}
+
+		result.missing++
+		log.Printf("[missing] %s", key)
+
+		if !*apply {
+			continue
+		}
+
+		if err := uploadFile(localPath, *bucket, key); err != nil {
+			result.failed++
+			log.Printf("[upload] %s failed: %v", key, err)
+			continue
+		}
+
+		result.uploaded++
+		log.Printf("[upload] %s uploaded", key)
+	}
+
+	log.Printf("[summary] checked=%d missing=%d uploaded=%d failed=%d apply=%v",
+		result.checked, result.missing, result.uploaded, result.failed, *apply)
+}
+
+func objectExists(bucket, key string) (bool, error) {
+	cmd := exec.Command("aws", "s3api", "head-object", "--bucket", bucket, "--key", key)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+
+	text := string(output)
+	if strings.Contains(text, "Not Found") || strings.Contains(text, "404") {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("%w: %s", err, strings.TrimSpace(text))
+}
+
+func uploadFile(localPath, bucket, key string) error {
+	contentType, err := detectContentType(localPath)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(
+		"aws", "s3", "cp", localPath, fmt.Sprintf("s3://%s/%s", bucket, key),
+		"--cache-control", "public, max-age=31536000, immutable",
+		"--content-type", contentType,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func detectContentType(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	if contentType := mime.TypeByExtension(ext); contentType != "" {
+		return contentType, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	buf := make([]byte, 512)
+	n, err := bufio.NewReader(file).Read(buf)
+	if err != nil && err.Error() != "EOF" {
+		return "", err
+	}
+
+	return http.DetectContentType(bytes.TrimSpace(buf[:n])), nil
+}

--- a/cmd/sync-nariya-images/main.go
+++ b/cmd/sync-nariya-images/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -12,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -58,7 +60,12 @@ func main() {
 			break
 		}
 
-		localPath := filepath.Join(*localDir, name)
+		localPath, err := safeJoin(*localDir, name)
+		if err != nil {
+			result.failed++
+			log.Printf("[path] %s failed: %v", name, err)
+			continue
+		}
 		key := strings.TrimPrefix(filepath.ToSlash(filepath.Join(*prefix, name)), "/")
 
 		exists, err := objectExists(*bucket, key)
@@ -94,7 +101,11 @@ func main() {
 }
 
 func objectExists(bucket, key string) (bool, error) {
-	cmd := exec.Command("aws", "s3api", "head-object", "--bucket", bucket, "--key", key)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	//nolint:gosec // bucket and key are validated application inputs, and CommandContext avoids shell expansion.
+	cmd := exec.CommandContext(ctx, "aws", "s3api", "head-object", "--bucket", bucket, "--key", key)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil
@@ -114,7 +125,12 @@ func uploadFile(localPath, bucket, key string) error {
 		return err
 	}
 
-	cmd := exec.Command(
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	//nolint:gosec // localPath is validated by safeJoin and the command is executed without a shell.
+	cmd := exec.CommandContext(
+		ctx,
 		"aws", "s3", "cp", localPath, fmt.Sprintf("s3://%s/%s", bucket, key),
 		"--cache-control", "public, max-age=31536000, immutable",
 		"--content-type", contentType,
@@ -132,7 +148,10 @@ func detectContentType(path string) (string, error) {
 		return contentType, nil
 	}
 
-	file, err := os.Open(path)
+	cleanPath := filepath.Clean(path)
+
+	//nolint:gosec // path is prevalidated by safeJoin and cleaned here before opening.
+	file, err := os.Open(cleanPath)
 	if err != nil {
 		return "", err
 	}
@@ -145,4 +164,34 @@ func detectContentType(path string) (string, error) {
 	}
 
 	return http.DetectContentType(bytes.TrimSpace(buf[:n])), nil
+}
+
+func safeJoin(baseDir, name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("empty filename")
+	}
+	if filepath.Base(name) != name {
+		return "", fmt.Errorf("unexpected nested path: %s", name)
+	}
+
+	baseAbs, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", err
+	}
+
+	fullPath := filepath.Join(baseAbs, name)
+	fullAbs, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", err
+	}
+
+	rel, err := filepath.Rel(baseAbs, fullAbs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes base directory: %s", name)
+	}
+
+	return fullAbs, nil
 }

--- a/cmd/sync-nariya-images/main.go
+++ b/cmd/sync-nariya-images/main.go
@@ -104,7 +104,7 @@ func objectExists(bucket, key string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	//nolint:gosec // bucket and key are validated application inputs, and CommandContext avoids shell expansion.
+	// #nosec G204 -- bucket and key are validated application inputs, and CommandContext avoids shell expansion.
 	cmd := exec.CommandContext(ctx, "aws", "s3api", "head-object", "--bucket", bucket, "--key", key)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
@@ -128,7 +128,7 @@ func uploadFile(localPath, bucket, key string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	//nolint:gosec // localPath is validated by safeJoin and the command is executed without a shell.
+	// #nosec G204 -- localPath is validated by safeJoin and the command is executed without a shell.
 	cmd := exec.CommandContext(
 		ctx,
 		"aws", "s3", "cp", localPath, fmt.Sprintf("s3://%s/%s", bucket, key),
@@ -150,7 +150,7 @@ func detectContentType(path string) (string, error) {
 
 	cleanPath := filepath.Clean(path)
 
-	//nolint:gosec // path is prevalidated by safeJoin and cleaned here before opening.
+	// #nosec G304 -- path is prevalidated by safeJoin and cleaned here before opening.
 	file, err := os.Open(cleanPath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## 변경 사항\n- /data 본문 상대 경로를 점검/치환하는 Go 도구 추가\n- nariya/image 로컬 잔존 파일을 S3로 동기화하는 Go 도구 추가\n\n## 목적\n- /data/* outbound 절감을 위한 운영 점검/정리 작업을 반복 가능하게 만듭니다.\n- 레거시 본문과 로컬 잔존 파일을 단계적으로 정리할 수 있게 합니다.\n\n## 비고\n- 운영 점검용 도구라 기본 동작은 보수적으로 두었습니다.\n- rewrite-media-urls 는 기본 dry-run, --apply 시에만 실제 DB 반영\n- sync-nariya-images 는 기본 dry-run, --apply 시에만 실제 업로드