### PR TITLE
fix: 쪽지 알림 제목 올바르게 표시

### DIFF
--- a/internal/handler/noti_handler.go
+++ b/internal/handler/noti_handler.go
@@ -296,6 +296,8 @@ func generateGroupTitle(fromCase, latestSender string, senderCount int) string {
 		action = "비추천했습니다"
 	case "write":
 		action = "새 글을 작성했습니다"
+	case "memo":
+		action = "쪽지를 보냈습니다"
 	case "inquire":
 		return "새 문의가 등록되었습니다"
 	case "answer":


### PR DESCRIPTION
## Summary
- 쪽지 알림이 "새 알림이 있습니다" 대신 "OO님이 쪽지를 보냈습니다"로 표시
- `generateGroupTitle`에 memo 케이스 추가

## Test plan
- [ ] 쪽지 수신 시 알림 제목이 "OO님이 쪽지를 보냈습니다"로 표시되는지 확인