### PR TITLE
fix: 제재 시 mb_level 강등 제거

### DIFF
--- a/internal/cron/discipline_release.go
+++ b/internal/cron/discipline_release.go
@@ -23,42 +23,10 @@ func runDisciplineRelease(db *gorm.DB) (*DisciplineReleaseResult, error) {
 		ExecutedAt: now.Format("2006-01-02 15:04:05"),
 	}
 
-	// 1. Restore levels for expired level-type disciplines
-	// Conditions: penalty_type includes 'level' or 'all', period > 0 (not permanent), expired, member still at level 1
-	type expiredDiscipline struct {
-		PenaltyMbID string `gorm:"column:penalty_mb_id"`
-		PrevLevel   int    `gorm:"column:prev_level"`
-	}
+	// mb_level 복구는 더 이상 수행하지 않음 (제재 시 레벨 강등을 하지 않으므로)
+	// LevelRestoredCount, LevelRestoredIDs는 항상 0/empty (struct 호환성 유지)
 
-	var expired []expiredDiscipline
-	if err := db.Raw(`
-		SELECT d.penalty_mb_id, d.prev_level
-		FROM g5_da_member_discipline d
-		JOIN g5_member m ON m.mb_id = d.penalty_mb_id
-		WHERE d.penalty_type IN ('level', 'all')
-		  AND d.penalty_period > 0
-		  AND d.penalty_period != -1
-		  AND m.mb_level <= 1
-		  AND DATE_ADD(d.penalty_date_from, INTERVAL d.penalty_period DAY) < NOW()
-	`).Scan(&expired).Error; err != nil {
-		return nil, err
-	}
-
-	for _, e := range expired {
-		if e.PrevLevel <= 1 {
-			e.PrevLevel = 2 // minimum restore level
-		}
-		if err := db.Table("g5_member").
-			Where("mb_id = ? AND mb_level <= 1", e.PenaltyMbID).
-			Update("mb_level", e.PrevLevel).Error; err != nil {
-			log.Printf("[Cron:discipline-release] failed to restore level for %s: %v", e.PenaltyMbID, err)
-			continue
-		}
-		result.LevelRestoredIDs = append(result.LevelRestoredIDs, e.PenaltyMbID)
-		result.LevelRestoredCount++
-	}
-
-	// 2. Clear expired intercept dates
+	// Clear expired intercept dates
 	var interceptIDs []string
 	if err := db.Raw(`
 		SELECT mb_id FROM g5_member

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -441,31 +441,16 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 		restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
 	}
 
-	// 제재 적용
+	// 제재 적용 (글쓰기 차단만, mb_level 강등 없음)
 	updates := map[string]interface{}{}
-	if disciplineType == "level_down" || disciplineType == "level" || disciplineType == "both" || disciplineType == "demotion_and_block" {
-		updates["mb_level"] = 1
-	}
-	// disciplineDays > 0이면 항상 글쓰기 차단 (type이 빈 문자열/warning이어도)
 	updates["mb_intercept_date"] = restrictionEndDate
 
 	if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).Updates(updates).Error; err != nil {
 		return err
 	}
 
-	// g5_da_member_discipline 테이블에 제재 정보 저장
-	penaltyTypeValue := ""
-	switch {
-	case disciplineType == "level_down" || disciplineType == "level":
-		penaltyTypeValue = "level"
-	case disciplineType == "access_block" || disciplineType == "access":
-		penaltyTypeValue = "intercept"
-	case disciplineType == "both" || disciplineType == "demotion_and_block":
-		penaltyTypeValue = "all"
-	default:
-		// 빈 문자열, warning 등 — 기간이 있으면 intercept로 처리
-		penaltyTypeValue = "intercept"
-	}
+	// g5_da_member_discipline 테이블에 제재 정보 저장 (모든 타입을 intercept로 통일)
+	penaltyTypeValue := "intercept"
 
 	penaltyPeriod := disciplineDays
 	if disciplineDays == 9999 {


### PR DESCRIPTION
## Summary
- 제재 시 `mb_level = 1` 강등 완전 제거 → `mb_intercept_date`(글쓰기 차단)만으로 운영
- 재제재 시 `prev_level`이 이미 1인 값으로 덮어써져 원래 레벨 유실되는 버그 근본 해결
- `discipline_release` 크론에서 레벨 복구 로직 제거 (intercept 해제만 유지)

## Changes
- `report_process.go`: `applyUserRestriction()`에서 `mb_level=1` 설정 제거, `penaltyTypeValue`를 항상 `"intercept"`로 통일
- `discipline_release.go`: `runDisciplineRelease()`에서 레벨 복구 쿼리/루프 제거 (`DisciplineReleaseResult` struct는 호환성 유지)

## Test plan
- [ ] `make build` 성공 확인
- [ ] `make test` 통과 확인
- [ ] 제재 적용 시 `mb_level` 변경 없이 `mb_intercept_date`만 설정되는지 확인
- [ ] `discipline-release` 크론 실행 시 intercept 해제 정상 동작 확인
- [ ] 피해 회원 레벨 복구 SQL 별도 실행