### PR TITLE
fix: likers API 응답 키 mb_image_url → mb_image 통일

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1743,7 +1743,7 @@ func main() {
 				MbID             string     `json:"mb_id"`
 				MbName           string     `json:"mb_name"`
 				MbNick           string     `json:"mb_nick"`
-				MbImageUrl       string     `json:"mb_image_url,omitempty"`
+				MbImageUrl       string     `json:"mb_image,omitempty"`
 				MbImageUpdatedAt *time.Time `json:"mb_image_updated_at,omitempty"`
 				BgIP             string     `json:"bg_ip,omitempty"`
 				LikedAt          *time.Time `json:"liked_at"`


### PR DESCRIPTION
## Summary
- `LikerInfo` struct의 JSON 태그를 `mb_image_url` → `mb_image`로 변경
- 프론트엔드 타입(`LikerInfo.mb_image`)과 키가 일치하도록 통일
- 프론트엔드 PR: damoang/angple#640 (매핑 코드 제거)

## Test plan
- [ ] `/economy/70535` 등에서 공감한 사람들 다이얼로그 프로필 이미지 확인
- [ ] 추천자 아바타 스택 이미지 표시 확인