### PR TITLE
feat: 회원 활동 API Go 백엔드 UNION ALL 이전

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -420,6 +420,7 @@ func main() {
 		myPageRepo := gnurepo.NewMyPageRepository(db, gnuBoardRepo)
 		myPageHandler := handler.NewMyPageHandler(myPageRepo)
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)
+		v2routes.SetupMemberActivity(router, myPageHandler)
 
 		// Admin XP + Point config management routes
 		v2routes.SetupAdminXP(router, expHandler, jwtManager)

--- a/internal/domain/gnuboard/mypage.go
+++ b/internal/domain/gnuboard/mypage.go
@@ -73,6 +73,23 @@ func (c *MyCommentRow) ToCommentResponse() map[string]interface{} {
 	}
 }
 
+// ActivityPost represents a public post for member activity API
+type ActivityPost struct {
+	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
+	WrSubject  string    `gorm:"column:wr_subject" json:"wr_subject"`
+	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
+	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+}
+
+// ActivityComment represents a public comment for member activity API
+type ActivityComment struct {
+	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
+	WrContent  string    `gorm:"column:wr_content" json:"wr_content"`
+	WrParent   int       `gorm:"column:wr_parent" json:"wr_parent"`
+	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
+	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+}
+
 // BoardStat represents post/comment counts per board for a member
 type BoardStat struct {
 	BoardID      string `json:"board_id"`

--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -1,8 +1,12 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/middleware"
@@ -107,6 +111,122 @@ func (h *MyPageHandler) GetBoardStats(c *gin.Context) {
 	}
 
 	common.V2Success(c, stats)
+}
+
+var htmlTagRe = regexp.MustCompile(`<[^>]*>`)
+var emoRe = regexp.MustCompile(`\{emo:[^}]+\}`)
+var whitespaceRe = regexp.MustCompile(`\s+`)
+
+// stripHTMLPreview removes HTML tags, emoji codes, HTML entities and truncates
+func stripHTMLPreview(content string, maxLen int) string {
+	s := htmlTagRe.ReplaceAllString(content, "")
+	s = emoRe.ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = whitespaceRe.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	runes := []rune(s)
+	if len(runes) > maxLen {
+		return string(runes[:maxLen])
+	}
+	return s
+}
+
+// GetMemberActivity handles GET /api/v1/members/:mb_id/activity
+func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
+	mbID := c.Param("id")
+	if mbID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 20 {
+		limit = 20
+	}
+
+	// Get board subjects map
+	boards, err := h.myPageRepo.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+	boardSubjects := make(map[string]string, len(boards))
+	for _, b := range boards {
+		boardSubjects[b.BoTable] = b.BoSubject
+	}
+
+	// Parallel fetch posts and comments
+	var (
+		wg       sync.WaitGroup
+		posts    []map[string]interface{}
+		comments []map[string]interface{}
+		postsErr error
+		commsErr error
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		rawPosts, err := h.myPageRepo.FindPublicPostsByMember(mbID, limit)
+		if err != nil {
+			postsErr = err
+			return
+		}
+		posts = make([]map[string]interface{}, 0, len(rawPosts))
+		for _, p := range rawPosts {
+			posts = append(posts, map[string]interface{}{
+				"bo_table":    p.BoardID,
+				"bo_subject":  boardSubjects[p.BoardID],
+				"wr_id":       p.WrID,
+				"wr_subject":  p.WrSubject,
+				"wr_datetime": p.WrDatetime.Format("2006-01-02 15:04:05"),
+				"href":        fmt.Sprintf("/%s/%d", p.BoardID, p.WrID),
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		rawComments, err := h.myPageRepo.FindPublicCommentsByMember(mbID, limit)
+		if err != nil {
+			commsErr = err
+			return
+		}
+		comments = make([]map[string]interface{}, 0, len(rawComments))
+		for _, cm := range rawComments {
+			comments = append(comments, map[string]interface{}{
+				"bo_table":     cm.BoardID,
+				"bo_subject":   boardSubjects[cm.BoardID],
+				"wr_id":        cm.WrID,
+				"parent_wr_id": cm.WrParent,
+				"preview":      stripHTMLPreview(cm.WrContent, 80),
+				"wr_datetime":  cm.WrDatetime.Format("2006-01-02 15:04:05"),
+				"href":         fmt.Sprintf("/%s/%d#c_%d", cm.BoardID, cm.WrParent, cm.WrID),
+			})
+		}
+	}()
+	wg.Wait()
+
+	if postsErr != nil || commsErr != nil {
+		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+	if posts == nil {
+		posts = make([]map[string]interface{}, 0)
+	}
+	if comments == nil {
+		comments = make([]map[string]interface{}, 0)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"recentPosts":    posts,
+		"recentComments": comments,
+	})
 }
 
 func parseMyPagePagination(c *gin.Context) (int, int) {

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -14,6 +14,14 @@ type MyPageRepository interface {
 	FindCommentsByMember(mbID string, page, limit int) ([]gnuboard.MyCommentRow, int64, error)
 	FindLikedPostsByMember(mbID string, page, limit int) ([]gnuboard.MyPost, int64, error)
 	GetBoardStats(mbID string) ([]gnuboard.BoardStat, error)
+	FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error)
+	FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error)
+	GetSearchableBoards() ([]searchableBoard, error)
+}
+
+type searchableBoard struct {
+	BoTable   string `gorm:"column:bo_table"`
+	BoSubject string `gorm:"column:bo_subject"`
 }
 
 type myPageRepository struct {
@@ -271,4 +279,95 @@ func (r *myPageRepository) GetBoardStats(mbID string) ([]gnuboard.BoardStat, err
 	}
 
 	return stats, nil
+}
+
+// GetSearchableBoards returns boards with bo_use_search=1 that have existing write tables
+func (r *myPageRepository) GetSearchableBoards() ([]searchableBoard, error) {
+	boards, err := r.boardRepo.FindAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(boards) == 0 {
+		return nil, nil
+	}
+
+	tableNames := make([]string, len(boards))
+	boardMap := make(map[string]*gnuboard.G5Board, len(boards))
+	for i, b := range boards {
+		tableName := fmt.Sprintf("g5_write_%s", b.BoTable)
+		tableNames[i] = tableName
+		boardMap[tableName] = b
+	}
+
+	var existingTables []string
+	r.db.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ?", tableNames).Scan(&existingTables)
+
+	var result []searchableBoard
+	for _, t := range existingTables {
+		b, ok := boardMap[t]
+		if !ok || b.BoUseSearch != 1 {
+			continue
+		}
+		result = append(result, searchableBoard{
+			BoTable:   b.BoTable,
+			BoSubject: b.BoSubject,
+		})
+	}
+	return result, nil
+}
+
+// FindPublicPostsByMember returns recent public posts by a member using UNION ALL
+func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error) {
+	boards, err := r.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		return nil, err
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, b := range boards {
+		table := fmt.Sprintf("g5_write_%s", b.BoTable)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT wr_id, wr_subject, wr_datetime, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND (wr_option NOT LIKE '%%secret%%' OR wr_option IS NULL) AND (wr_7 IS NULL OR wr_7 != 'lock') AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00'))",
+			b.BoTable, table))
+		args = append(args, mbID)
+	}
+
+	unionQuery := strings.Join(unions, " UNION ALL ")
+	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", unionQuery)
+	args = append(args, limit)
+
+	var posts []gnuboard.ActivityPost
+	if err := r.db.Raw(dataSQL, args...).Scan(&posts).Error; err != nil {
+		return nil, err
+	}
+	return posts, nil
+}
+
+// FindPublicCommentsByMember returns recent public comments by a member using UNION ALL
+func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error) {
+	boards, err := r.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		return nil, err
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, b := range boards {
+		table := fmt.Sprintf("g5_write_%s", b.BoTable)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT c.wr_id, c.wr_content, c.wr_parent, c.wr_datetime, '%s' as board_id FROM `%s` c INNER JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 AND (p.wr_option NOT LIKE '%%secret%%' OR p.wr_option IS NULL) AND (p.wr_7 IS NULL OR p.wr_7 != 'lock') AND (p.wr_deleted_at IS NULL OR p.wr_deleted_at = '0000-00-00 00:00:00') WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND (c.wr_deleted_at IS NULL OR c.wr_deleted_at = '0000-00-00 00:00:00'))",
+			b.BoTable, table, table))
+		args = append(args, mbID)
+	}
+
+	unionQuery := strings.Join(unions, " UNION ALL ")
+	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", unionQuery)
+	args = append(args, limit)
+
+	var comments []gnuboard.ActivityComment
+	if err := r.db.Raw(dataSQL, args...).Scan(&comments).Error; err != nil {
+		return nil, err
+	}
+	return comments, nil
 }

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -215,6 +215,11 @@ func SetupMyPage(router *gin.Engine, pointHandler *v2handler.PointHandler, expHa
 	my.GET("/stats", myPageHandler.GetBoardStats)
 }
 
+// SetupMemberActivity configures public member activity route
+func SetupMemberActivity(router *gin.Engine, myPageHandler *handler.MyPageHandler) {
+	router.GET("/api/v1/members/:id/activity", myPageHandler.GetMemberActivity)
+}
+
 // SetupDisciplineLog configures discipline log routes (read-only, uses gnuboard g5_write_disciplinelog)
 func SetupDisciplineLog(router *gin.Engine, h *v2handler.DisciplineLogHandler, _ *jwt.Manager) {
 	// Public routes (read-only)


### PR DESCRIPTION
## Summary
- g5_board_new 의존 제거 → g5_board + information_schema 기반 UNION ALL 직접 조회
- 회원 프로필/작성자 패널의 "최근 글/댓글" 8% 누락 해소
- 비밀글/잠금/삭제 필터, HTML 스트립 + 80자 truncate 포함
- 총 쿼리 3개 고정 (게시판 목록 1 + 글 UNION ALL 1 + 댓글 UNION ALL 1)

## 변경 파일
- `internal/domain/gnuboard/mypage.go` — ActivityPost, ActivityComment 구조체
- `internal/repository/gnuboard/mypage_repo.go` — GetSearchableBoards, FindPublicPostsByMember, FindPublicCommentsByMember
- `internal/handler/mypage_handler.go` — GetMemberActivity 핸들러
- `internal/routes/v2/routes.go` — SetupMemberActivity 라우트
- `cmd/api/main.go` — 라우트 등록 1줄

## Test plan
- [x] `make build` 성공
- [x] dev 환경 배포 후 `curl localhost:8090/api/v1/members/{mb_id}/activity` 정상 응답 확인
- [x] SvelteKit 프록시 `curl localhost:5173/api/members/{mb_id}/activity` 정상 응답 확인
- [ ] CI 통과