### PR TITLE
hotfix: 마이페이지 UNION ALL 슬로우 쿼리 임시 비활성화

### DIFF
--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -2,7 +2,6 @@ package gnuboard
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
@@ -62,89 +61,15 @@ func (r *myPageRepository) getActiveBoards() []string {
 }
 
 // FindPostsByMember returns posts written by the member across all boards
+// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
 func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gnuboard.MyPost, int64, error) {
-	boards := r.getActiveBoards()
-	if len(boards) == 0 {
-		return nil, 0, nil
-	}
-
-	// Build UNION ALL query for posts
-	var unions []string
-	var args []interface{}
-	for _, boardID := range boards {
-		table := fmt.Sprintf("g5_write_%s", boardID)
-		unions = append(unions, fmt.Sprintf(
-			"(SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL)",
-			boardID, table))
-		args = append(args, mbID)
-	}
-	unionQuery := strings.Join(unions, " UNION ALL ")
-
-	// Count total
-	var total int64
-	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS t", unionQuery)
-	if err := r.db.Raw(countSQL, args...).Scan(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
-	if total == 0 {
-		return nil, 0, nil
-	}
-
-	// Fetch page
-	offset := (page - 1) * limit
-	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_datetime DESC LIMIT ? OFFSET ?", unionQuery)
-	dataArgs := append(args, limit, offset)
-
-	var posts []gnuboard.MyPost
-	if err := r.db.Raw(dataSQL, dataArgs...).Scan(&posts).Error; err != nil {
-		return nil, 0, err
-	}
-
-	return posts, total, nil
+	return nil, 0, nil
 }
 
 // FindCommentsByMember returns comments written by the member with parent post titles
+// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
 func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([]gnuboard.MyCommentRow, int64, error) {
-	boards := r.getActiveBoards()
-	if len(boards) == 0 {
-		return nil, 0, nil
-	}
-
-	// Build UNION ALL query for comments with parent post title
-	var unions []string
-	var args []interface{}
-	for _, boardID := range boards {
-		table := fmt.Sprintf("g5_write_%s", boardID)
-		unions = append(unions, fmt.Sprintf(
-			"(SELECT c.wr_id, c.wr_content, c.wr_datetime, c.mb_id, c.wr_name, c.wr_parent, c.wr_good, c.wr_nogood, c.wr_option, COALESCE(p.wr_subject, '') as post_title, '%s' as board_id FROM `%s` c LEFT JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND c.wr_deleted_at IS NULL)",
-			boardID, table, table))
-		args = append(args, mbID)
-	}
-	unionQuery := strings.Join(unions, " UNION ALL ")
-
-	// Count total
-	var total int64
-	countSQL := fmt.Sprintf("SELECT COUNT(*) FROM (%s) AS t", unionQuery)
-	if err := r.db.Raw(countSQL, args...).Scan(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
-	if total == 0 {
-		return nil, 0, nil
-	}
-
-	// Fetch page
-	offset := (page - 1) * limit
-	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_datetime DESC LIMIT ? OFFSET ?", unionQuery)
-	dataArgs := append(args, limit, offset)
-
-	var comments []gnuboard.MyCommentRow
-	if err := r.db.Raw(dataSQL, dataArgs...).Scan(&comments).Error; err != nil {
-		return nil, 0, err
-	}
-
-	return comments, total, nil
+	return nil, 0, nil
 }
 
 // FindLikedPostsByMember returns posts that the member liked (from g5_board_good)
@@ -217,68 +142,9 @@ func (r *myPageRepository) FindLikedPostsByMember(mbID string, page, limit int) 
 }
 
 // GetBoardStats returns post/comment counts per board for the member
+// TODO: UNION ALL across ~90 tables causes slow queries. Needs denormalized stats table.
 func (r *myPageRepository) GetBoardStats(mbID string) ([]gnuboard.BoardStat, error) {
-	boards, err := r.boardRepo.FindAll()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(boards) == 0 {
-		return nil, nil
-	}
-
-	// 1. Batch check which tables exist via information_schema (1 query instead of N)
-	tableNames := make([]string, len(boards))
-	boardMap := make(map[string]string) // table_name -> bo_subject
-	for i, b := range boards {
-		tableName := fmt.Sprintf("g5_write_%s", b.BoTable)
-		tableNames[i] = tableName
-		boardMap[tableName] = b.BoSubject
-	}
-
-	var existingTables []string
-	r.db.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ?", tableNames).Scan(&existingTables)
-
-	if len(existingTables) == 0 {
-		return nil, nil
-	}
-
-	// 2. Build UNION ALL for post/comment counts (1 query instead of 2N)
-	var unions []string
-	var args []interface{}
-	for _, tableName := range existingTables {
-		boardID := strings.TrimPrefix(tableName, "g5_write_")
-		unions = append(unions, fmt.Sprintf(
-			"(SELECT '%s' as board_id, SUM(CASE WHEN wr_is_comment = 0 THEN 1 ELSE 0 END) as post_count, SUM(CASE WHEN wr_is_comment = 1 THEN 1 ELSE 0 END) as comment_count FROM `%s` WHERE mb_id = ? AND wr_deleted_at IS NULL)",
-			boardID, tableName))
-		args = append(args, mbID)
-	}
-
-	type boardCount struct {
-		BoardID      string `gorm:"column:board_id"`
-		PostCount    int64  `gorm:"column:post_count"`
-		CommentCount int64  `gorm:"column:comment_count"`
-	}
-	var counts []boardCount
-	unionSQL := strings.Join(unions, " UNION ALL ")
-	if err := r.db.Raw(unionSQL, args...).Scan(&counts).Error; err != nil {
-		return nil, err
-	}
-
-	var stats []gnuboard.BoardStat
-	for _, c := range counts {
-		if c.PostCount > 0 || c.CommentCount > 0 {
-			tableName := fmt.Sprintf("g5_write_%s", c.BoardID)
-			stats = append(stats, gnuboard.BoardStat{
-				BoardID:      c.BoardID,
-				BoardName:    boardMap[tableName],
-				PostCount:    c.PostCount,
-				CommentCount: c.CommentCount,
-			})
-		}
-	}
-
-	return stats, nil
+	return nil, nil
 }
 
 // GetSearchableBoards returns boards with bo_use_search=1 that have existing write tables
@@ -317,57 +183,13 @@ func (r *myPageRepository) GetSearchableBoards() ([]searchableBoard, error) {
 }
 
 // FindPublicPostsByMember returns recent public posts by a member using UNION ALL
+// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
 func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error) {
-	boards, err := r.GetSearchableBoards()
-	if err != nil || len(boards) == 0 {
-		return nil, err
-	}
-
-	var unions []string
-	var args []interface{}
-	for _, b := range boards {
-		table := fmt.Sprintf("g5_write_%s", b.BoTable)
-		unions = append(unions, fmt.Sprintf(
-			"(SELECT wr_id, wr_subject, wr_datetime, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND (wr_option NOT LIKE '%%secret%%' OR wr_option IS NULL) AND (wr_7 IS NULL OR wr_7 != 'lock') AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00'))",
-			b.BoTable, table))
-		args = append(args, mbID)
-	}
-
-	unionQuery := strings.Join(unions, " UNION ALL ")
-	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", unionQuery)
-	args = append(args, limit)
-
-	var posts []gnuboard.ActivityPost
-	if err := r.db.Raw(dataSQL, args...).Scan(&posts).Error; err != nil {
-		return nil, err
-	}
-	return posts, nil
+	return nil, nil
 }
 
 // FindPublicCommentsByMember returns recent public comments by a member using UNION ALL
+// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
 func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error) {
-	boards, err := r.GetSearchableBoards()
-	if err != nil || len(boards) == 0 {
-		return nil, err
-	}
-
-	var unions []string
-	var args []interface{}
-	for _, b := range boards {
-		table := fmt.Sprintf("g5_write_%s", b.BoTable)
-		unions = append(unions, fmt.Sprintf(
-			"(SELECT c.wr_id, c.wr_content, c.wr_parent, c.wr_datetime, '%s' as board_id FROM `%s` c INNER JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 AND (p.wr_option NOT LIKE '%%secret%%' OR p.wr_option IS NULL) AND (p.wr_7 IS NULL OR p.wr_7 != 'lock') AND (p.wr_deleted_at IS NULL OR p.wr_deleted_at = '0000-00-00 00:00:00') WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND (c.wr_deleted_at IS NULL OR c.wr_deleted_at = '0000-00-00 00:00:00'))",
-			b.BoTable, table, table))
-		args = append(args, mbID)
-	}
-
-	unionQuery := strings.Join(unions, " UNION ALL ")
-	dataSQL := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", unionQuery)
-	args = append(args, limit)
-
-	var comments []gnuboard.ActivityComment
-	if err := r.db.Raw(dataSQL, args...).Scan(&comments).Error; err != nil {
-		return nil, err
-	}
-	return comments, nil
+	return nil, nil
 }


### PR DESCRIPTION
## Summary
- ~90개 g5_write_* 테이블 UNION ALL 쿼리가 동시 호출 시 2초+ → DB 부하 급증
- 5개 함수를 빈 결과 반환으로 임시 비활성화

## 후속 작업
- [ ] mb_id + wr_is_comment 복합 인덱스 추가
- [ ] 비정규화 테이블 or Redis 캐싱
- [ ] 기능 복원