### PR TITLE
feat: 회원 활동 API UNION ALL + 2-tier 캐시

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -419,6 +419,9 @@ func main() {
 		v2Handler.SetExpRepository(v2ExpRepo)
 		myPageRepo := gnurepo.NewMyPageRepository(db, gnuBoardRepo)
 		myPageHandler := handler.NewMyPageHandler(myPageRepo)
+		if redisClient != nil {
+			myPageHandler.SetRedisClient(redisClient)
+		}
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)
 		v2routes.SetupMemberActivity(router, myPageHandler)
 

--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -1,25 +1,39 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/middleware"
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 )
+
+const activityCacheTTL = 60 * time.Second
 
 // MyPageHandler handles /api/v1/my/* endpoints for user's posts, comments, liked posts, and stats
 type MyPageHandler struct {
-	myPageRepo gnurepo.MyPageRepository
+	myPageRepo  gnurepo.MyPageRepository
+	redisClient *redis.Client
 }
 
 // NewMyPageHandler creates a new MyPageHandler
 func NewMyPageHandler(myPageRepo gnurepo.MyPageRepository) *MyPageHandler {
 	return &MyPageHandler{myPageRepo: myPageRepo}
+}
+
+// SetRedisClient injects Redis client for response caching
+func (h *MyPageHandler) SetRedisClient(client *redis.Client) {
+	h.redisClient = client
 }
 
 // GetMyPosts handles GET /api/v1/my/posts
@@ -132,14 +146,124 @@ func stripHTMLPreview(content string, maxLen int) string {
 	return s
 }
 
-// GetMemberActivity handles GET /api/v1/members/:mb_id/activity
-// Temporarily disabled: returns empty arrays to prevent slow queries
-// under high concurrency (~10k concurrent users, ~90 boards).
+// activityResponse is the JSON structure for member activity (cached in Redis)
+type activityResponse struct {
+	RecentPosts    []map[string]interface{} `json:"recentPosts"`
+	RecentComments []map[string]interface{} `json:"recentComments"`
+}
+
+// GetMemberActivity handles GET /api/v1/members/:id/activity
 func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{
-		"recentPosts":    []interface{}{},
-		"recentComments": []interface{}{},
-	})
+	mbID := c.Param("id")
+	if mbID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 20 {
+		limit = 20
+	}
+
+	// 1. Try Redis cache (DB 0 queries on hit)
+	cacheKey := fmt.Sprintf("member_activity:%s:%d", mbID, limit)
+	if h.redisClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		if cached, err := h.redisClient.Get(ctx, cacheKey).Bytes(); err == nil {
+			c.Data(http.StatusOK, "application/json; charset=utf-8", cached)
+			return
+		}
+	}
+
+	// 2. Cache miss — get board subjects map (memory cached, 5 min TTL)
+	boards, err := h.myPageRepo.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+	boardSubjects := make(map[string]string, len(boards))
+	for _, b := range boards {
+		boardSubjects[b.BoTable] = b.BoSubject
+	}
+
+	// 3. Parallel fetch posts and comments (2 UNION ALL queries)
+	var (
+		wg       sync.WaitGroup
+		posts    []map[string]interface{}
+		comments []map[string]interface{}
+		postsErr error
+		commsErr error
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		rawPosts, err := h.myPageRepo.FindPublicPostsByMember(mbID, limit)
+		if err != nil {
+			postsErr = err
+			return
+		}
+		posts = make([]map[string]interface{}, 0, len(rawPosts))
+		for _, p := range rawPosts {
+			posts = append(posts, map[string]interface{}{
+				"bo_table":    p.BoardID,
+				"bo_subject":  boardSubjects[p.BoardID],
+				"wr_id":       p.WrID,
+				"wr_subject":  p.WrSubject,
+				"wr_datetime": p.WrDatetime.Format("2006-01-02 15:04:05"),
+				"href":        fmt.Sprintf("/%s/%d", p.BoardID, p.WrID),
+			})
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		rawComments, err := h.myPageRepo.FindPublicCommentsByMember(mbID, limit)
+		if err != nil {
+			commsErr = err
+			return
+		}
+		comments = make([]map[string]interface{}, 0, len(rawComments))
+		for _, cm := range rawComments {
+			comments = append(comments, map[string]interface{}{
+				"bo_table":     cm.BoardID,
+				"bo_subject":   boardSubjects[cm.BoardID],
+				"wr_id":        cm.WrID,
+				"parent_wr_id": cm.WrParent,
+				"preview":      stripHTMLPreview(cm.WrContent, 80),
+				"wr_datetime":  cm.WrDatetime.Format("2006-01-02 15:04:05"),
+				"href":         fmt.Sprintf("/%s/%d#c_%d", cm.BoardID, cm.WrParent, cm.WrID),
+			})
+		}
+	}()
+	wg.Wait()
+
+	if postsErr != nil || commsErr != nil {
+		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
+		return
+	}
+	if posts == nil {
+		posts = make([]map[string]interface{}, 0)
+	}
+	if comments == nil {
+		comments = make([]map[string]interface{}, 0)
+	}
+
+	resp := activityResponse{RecentPosts: posts, RecentComments: comments}
+
+	// 4. Store in Redis (60s TTL, non-blocking)
+	if h.redisClient != nil {
+		if data, err := json.Marshal(resp); err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			h.redisClient.Set(ctx, cacheKey, data, activityCacheTTL)
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 func parseMyPagePagination(c *gin.Context) (int, int) {

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"golang.org/x/sync/errgroup"
@@ -28,6 +29,15 @@ type searchableBoard struct {
 	BoTable   string `gorm:"column:bo_table"`
 	BoSubject string `gorm:"column:bo_subject"`
 }
+
+// searchableBoardsCache caches the searchable boards list (5 min TTL)
+var searchableBoardsCache struct {
+	sync.RWMutex
+	boards    []searchableBoard
+	expiresAt time.Time
+}
+
+const boardsCacheTTL = 5 * time.Minute
 
 type myPageRepository struct {
 	db        *gorm.DB
@@ -390,8 +400,19 @@ func (r *myPageRepository) GetBoardStats(mbID string) ([]gnuboard.BoardStat, err
 	return stats, nil
 }
 
-// GetSearchableBoards returns boards with bo_use_search=1 that have existing write tables
+// GetSearchableBoards returns boards with bo_use_search=1 that have existing write tables.
+// Results are cached in memory for 5 minutes.
 func (r *myPageRepository) GetSearchableBoards() ([]searchableBoard, error) {
+	// Check memory cache first
+	searchableBoardsCache.RLock()
+	if time.Now().Before(searchableBoardsCache.expiresAt) && searchableBoardsCache.boards != nil {
+		cached := searchableBoardsCache.boards
+		searchableBoardsCache.RUnlock()
+		return cached, nil
+	}
+	searchableBoardsCache.RUnlock()
+
+	// Cache miss — query DB
 	boards, err := r.boardRepo.FindAll()
 	if err != nil {
 		return nil, err
@@ -422,17 +443,69 @@ func (r *myPageRepository) GetSearchableBoards() ([]searchableBoard, error) {
 			BoSubject: b.BoSubject,
 		})
 	}
+
+	// Store in cache
+	searchableBoardsCache.Lock()
+	searchableBoardsCache.boards = result
+	searchableBoardsCache.expiresAt = time.Now().Add(boardsCacheTTL)
+	searchableBoardsCache.Unlock()
+
 	return result, nil
 }
 
 // FindPublicPostsByMember returns recent public posts by a member.
-// Temporarily disabled: returns empty to prevent slow queries under high concurrency.
+// Uses UNION ALL with per-subquery LIMIT for efficiency.
+// Each subquery leverages mb_id index + PK ordering.
 func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error) {
-	return nil, nil
+	boards, err := r.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		return nil, err
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, b := range boards {
+		table := fmt.Sprintf("g5_write_%s", b.BoTable)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT wr_id, wr_subject, wr_datetime, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND (wr_option NOT LIKE '%%secret%%' OR wr_option IS NULL) AND (wr_7 IS NULL OR wr_7 != 'lock') AND wr_deleted_at IS NULL ORDER BY wr_id DESC LIMIT %d)",
+			b.BoTable, table, limit))
+		args = append(args, mbID)
+	}
+
+	sql := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", strings.Join(unions, " UNION ALL "))
+	args = append(args, limit)
+
+	var posts []gnuboard.ActivityPost
+	if err := r.db.Raw(sql, args...).Scan(&posts).Error; err != nil {
+		return nil, err
+	}
+	return posts, nil
 }
 
 // FindPublicCommentsByMember returns recent public comments by a member.
-// Temporarily disabled: returns empty to prevent slow queries under high concurrency.
+// Uses UNION ALL + INNER JOIN to filter out comments on secret/locked/deleted parent posts.
 func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error) {
-	return nil, nil
+	boards, err := r.GetSearchableBoards()
+	if err != nil || len(boards) == 0 {
+		return nil, err
+	}
+
+	var unions []string
+	var args []interface{}
+	for _, b := range boards {
+		table := fmt.Sprintf("g5_write_%s", b.BoTable)
+		unions = append(unions, fmt.Sprintf(
+			"(SELECT c.wr_id, c.wr_content, c.wr_parent, c.wr_datetime, '%s' as board_id FROM `%s` c INNER JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 AND (p.wr_option NOT LIKE '%%secret%%' OR p.wr_option IS NULL) AND (p.wr_7 IS NULL OR p.wr_7 != 'lock') AND p.wr_deleted_at IS NULL WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND c.wr_deleted_at IS NULL ORDER BY c.wr_id DESC LIMIT %d)",
+			b.BoTable, table, table, limit))
+		args = append(args, mbID)
+	}
+
+	sql := fmt.Sprintf("SELECT * FROM (%s) AS t ORDER BY wr_id DESC LIMIT ?", strings.Join(unions, " UNION ALL "))
+	args = append(args, limit)
+
+	var comments []gnuboard.ActivityComment
+	if err := r.db.Raw(sql, args...).Scan(&comments).Error; err != nil {
+		return nil, err
+	}
+	return comments, nil
 }


### PR DESCRIPTION
## Summary
- g5_board_new 의존 제거 → g5_write_* UNION ALL 직접 조회 (8% 데이터 누락 해결)
- Redis 응답 캐시 (60초 TTL): 동일 회원 반복 요청 시 DB 0회
- 게시판 목록 메모리 캐시 (5분 TTL): information_schema 쿼리 최소화
- 캐시 MISS 시에도 DB 3회 고정 (O(1), N+1 없음)

## 변경 파일
- `cmd/api/main.go` — Redis 클라이언트 DI
- `internal/handler/mypage_handler.go` — Redis 캐시 + GetMemberActivity 핸들러
- `internal/repository/gnuboard/mypage_repo.go` — UNION ALL 쿼리 + 메모리 캐시

## Test plan
- [ ] `make build` 성공
- [ ] `curl localhost:8090/api/v1/members/{id}/activity?limit=20` 응답 확인
- [ ] DB 실제 글 수와 API 응답 비교 (누락 없는지)
- [ ] Redis 캐시 동작 확인 (2번째 요청 시 DB 로그 없음)
- [ ] 프로필 페이지 + AuthorActivityPanel UI 정상 표시