### PR TITLE
업로드 응답 URL을 CDN 기준으로 정규화

### DIFF
--- a/internal/service/media_service.go
+++ b/internal/service/media_service.go
@@ -45,6 +45,7 @@ type MediaUploadResult struct {
 	Key         string `json:"key"`
 	URL         string `json:"url"`
 	CDNURL      string `json:"cdn_url,omitempty"`
+	OriginURL   string `json:"origin_url,omitempty"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	Size        int64  `json:"size"`
@@ -134,6 +135,7 @@ func (s *MediaService) UploadImage(ctx context.Context, file *multipart.FileHead
 		Key:         result.Key,
 		URL:         result.URL,
 		CDNURL:      result.CDNURL,
+		OriginURL:   result.OriginURL,
 		Filename:    file.Filename,
 		ContentType: contentType,
 		Size:        size,
@@ -194,6 +196,7 @@ func (s *MediaService) UploadAttachment(ctx context.Context, file *multipart.Fil
 		Key:         result.Key,
 		URL:         result.URL,
 		CDNURL:      result.CDNURL,
+		OriginURL:   result.OriginURL,
 		Filename:    file.Filename,
 		ContentType: contentType,
 		Size:        file.Size,
@@ -239,6 +242,7 @@ func (s *MediaService) UploadVideo(ctx context.Context, file *multipart.FileHead
 		Key:         result.Key,
 		URL:         result.URL,
 		CDNURL:      result.CDNURL,
+		OriginURL:   result.OriginURL,
 		Filename:    file.Filename,
 		ContentType: contentType,
 		Size:        file.Size,

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -66,6 +66,7 @@ type UploadResult struct {
 	Key         string `json:"key"`
 	URL         string `json:"url"`
 	CDNURL      string `json:"cdn_url,omitempty"`
+	OriginURL   string `json:"origin_url,omitempty"`
 	ContentType string `json:"content_type"`
 	Size        int64  `json:"size"`
 }
@@ -85,15 +86,19 @@ func (c *S3Client) Upload(ctx context.Context, key string, body io.Reader, conte
 		return nil, fmt.Errorf("s3 upload failed: %w", err)
 	}
 
+	originURL := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", c.bucket, fullKey)
 	result := &UploadResult{
 		Key:         fullKey,
-		URL:         fmt.Sprintf("https://%s.s3.amazonaws.com/%s", c.bucket, fullKey),
+		URL:         originURL,
+		CDNURL:      "",
+		OriginURL:   originURL,
 		ContentType: contentType,
 		Size:        size,
 	}
 
 	if c.cdnURL != "" {
 		result.CDNURL = c.cdnURL + "/" + fullKey
+		result.URL = result.CDNURL
 	}
 
 	return result, nil


### PR DESCRIPTION
## 목적
- 이미지/파일 업로드 응답에서 url 과 cdn_url 이 서로 다른 호스트를 가리키며 생기는 혼선을 제거합니다.
- 업로드 직후 표시와 이후 조회 응답이 같은 기준 URL 을 보게 만듭니다.

## 변경
- pkg/storage/s3.go
  - CDN_URL 이 있으면 url 을 canonical CDN URL 로 반환
  - 원본 S3 URL 은 origin_url 로 별도 제공
- internal/service/media_service.go
  - origin_url 필드 전달

## 기대 효과
- 업로드 직후와 조회 시점의 이미지 URL 기준이 일치
- 일부 호출자가 url 만 사용해도 CDN 경로를 타게 되어 이미지 깨짐/혼선 가능성 감소
