### PR TITLE
fix: 마이페이지 UNION ALL 제거, 병렬 쿼리 전환 + 새글/댓글 비활성화

### DIFF
--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -1,12 +1,10 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/damoang/angple-backend/internal/common"
 	"github.com/damoang/angple-backend/internal/middleware"
@@ -135,97 +133,12 @@ func stripHTMLPreview(content string, maxLen int) string {
 }
 
 // GetMemberActivity handles GET /api/v1/members/:mb_id/activity
+// Temporarily disabled: returns empty arrays to prevent slow queries
+// under high concurrency (~10k concurrent users, ~90 boards).
 func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
-	mbID := c.Param("id")
-	if mbID == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
-		return
-	}
-
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
-	if limit < 1 {
-		limit = 1
-	}
-	if limit > 20 {
-		limit = 20
-	}
-
-	// Get board subjects map
-	boards, err := h.myPageRepo.GetSearchableBoards()
-	if err != nil || len(boards) == 0 {
-		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
-		return
-	}
-	boardSubjects := make(map[string]string, len(boards))
-	for _, b := range boards {
-		boardSubjects[b.BoTable] = b.BoSubject
-	}
-
-	// Parallel fetch posts and comments
-	var (
-		wg       sync.WaitGroup
-		posts    []map[string]interface{}
-		comments []map[string]interface{}
-		postsErr error
-		commsErr error
-	)
-
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		rawPosts, err := h.myPageRepo.FindPublicPostsByMember(mbID, limit)
-		if err != nil {
-			postsErr = err
-			return
-		}
-		posts = make([]map[string]interface{}, 0, len(rawPosts))
-		for _, p := range rawPosts {
-			posts = append(posts, map[string]interface{}{
-				"bo_table":    p.BoardID,
-				"bo_subject":  boardSubjects[p.BoardID],
-				"wr_id":       p.WrID,
-				"wr_subject":  p.WrSubject,
-				"wr_datetime": p.WrDatetime.Format("2006-01-02 15:04:05"),
-				"href":        fmt.Sprintf("/%s/%d", p.BoardID, p.WrID),
-			})
-		}
-	}()
-	go func() {
-		defer wg.Done()
-		rawComments, err := h.myPageRepo.FindPublicCommentsByMember(mbID, limit)
-		if err != nil {
-			commsErr = err
-			return
-		}
-		comments = make([]map[string]interface{}, 0, len(rawComments))
-		for _, cm := range rawComments {
-			comments = append(comments, map[string]interface{}{
-				"bo_table":     cm.BoardID,
-				"bo_subject":   boardSubjects[cm.BoardID],
-				"wr_id":        cm.WrID,
-				"parent_wr_id": cm.WrParent,
-				"preview":      stripHTMLPreview(cm.WrContent, 80),
-				"wr_datetime":  cm.WrDatetime.Format("2006-01-02 15:04:05"),
-				"href":         fmt.Sprintf("/%s/%d#c_%d", cm.BoardID, cm.WrParent, cm.WrID),
-			})
-		}
-	}()
-	wg.Wait()
-
-	if postsErr != nil || commsErr != nil {
-		c.JSON(http.StatusOK, gin.H{"recentPosts": []interface{}{}, "recentComments": []interface{}{}})
-		return
-	}
-	if posts == nil {
-		posts = make([]map[string]interface{}, 0)
-	}
-	if comments == nil {
-		comments = make([]map[string]interface{}, 0)
-	}
-
 	c.JSON(http.StatusOK, gin.H{
-		"recentPosts":    posts,
-		"recentComments": comments,
+		"recentPosts":    []interface{}{},
+		"recentComments": []interface{}{},
 	})
 }
 

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -2,10 +2,16 @@ package gnuboard
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 )
+
+const maxDBConcurrency = 10
 
 // MyPageRepository provides access to user's posts, comments, and stats across g5_write_* tables
 type MyPageRepository interface {
@@ -60,16 +66,174 @@ func (r *myPageRepository) getActiveBoards() []string {
 	return ids
 }
 
-// FindPostsByMember returns posts written by the member across all boards
-// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
+// FindPostsByMember returns posts written by the member across all boards.
+// Uses parallel per-board queries instead of UNION ALL for better DB performance.
 func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gnuboard.MyPost, int64, error) {
-	return nil, 0, nil
+	boards := r.getActiveBoards()
+	if len(boards) == 0 {
+		return nil, 0, nil
+	}
+
+	perTable := page * limit
+
+	// Phase A: parallel COUNT per board
+	type boardCount struct {
+		boardID string
+		count   int64
+	}
+	var (
+		muCounts   sync.Mutex
+		counts     []boardCount
+		totalCount int64
+	)
+
+	g := errgroup.Group{}
+	g.SetLimit(maxDBConcurrency)
+	for _, boardID := range boards {
+		g.Go(func() error {
+			table := fmt.Sprintf("g5_write_%s", boardID)
+			var cnt int64
+			r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL", table), mbID).Scan(&cnt)
+			if cnt > 0 {
+				muCounts.Lock()
+				counts = append(counts, boardCount{boardID: boardID, count: cnt})
+				totalCount += cnt
+				muCounts.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	if totalCount == 0 {
+		return nil, 0, nil
+	}
+
+	// Phase B: parallel data fetch from boards that have results
+	var (
+		mu    sync.Mutex
+		posts []gnuboard.MyPost
+	)
+
+	g2 := errgroup.Group{}
+	g2.SetLimit(maxDBConcurrency)
+	for _, bc := range counts {
+		g2.Go(func() error {
+			table := fmt.Sprintf("g5_write_%s", bc.boardID)
+			var rows []gnuboard.MyPost
+			r.db.Raw(
+				fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL ORDER BY wr_datetime DESC LIMIT %d", bc.boardID, table, perTable),
+				mbID,
+			).Scan(&rows)
+			if len(rows) > 0 {
+				mu.Lock()
+				posts = append(posts, rows...)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g2.Wait()
+
+	// Sort and paginate in Go
+	sort.Slice(posts, func(i, j int) bool {
+		return posts[i].WrDatetime.After(posts[j].WrDatetime)
+	})
+
+	offset := (page - 1) * limit
+	if offset >= len(posts) {
+		return nil, totalCount, nil
+	}
+	end := offset + limit
+	if end > len(posts) {
+		end = len(posts)
+	}
+	return posts[offset:end], totalCount, nil
 }
 
-// FindCommentsByMember returns comments written by the member with parent post titles
-// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
+// FindCommentsByMember returns comments written by the member with parent post titles.
+// Uses parallel per-board queries instead of UNION ALL.
 func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([]gnuboard.MyCommentRow, int64, error) {
-	return nil, 0, nil
+	boards := r.getActiveBoards()
+	if len(boards) == 0 {
+		return nil, 0, nil
+	}
+
+	perTable := page * limit
+
+	// Phase A: parallel COUNT per board
+	type boardCount struct {
+		boardID string
+		count   int64
+	}
+	var (
+		muCounts   sync.Mutex
+		counts     []boardCount
+		totalCount int64
+	)
+
+	g := errgroup.Group{}
+	g.SetLimit(maxDBConcurrency)
+	for _, boardID := range boards {
+		g.Go(func() error {
+			table := fmt.Sprintf("g5_write_%s", boardID)
+			var cnt int64
+			r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", table), mbID).Scan(&cnt)
+			if cnt > 0 {
+				muCounts.Lock()
+				counts = append(counts, boardCount{boardID: boardID, count: cnt})
+				totalCount += cnt
+				muCounts.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	if totalCount == 0 {
+		return nil, 0, nil
+	}
+
+	// Phase B: parallel data fetch
+	var (
+		mu       sync.Mutex
+		comments []gnuboard.MyCommentRow
+	)
+
+	g2 := errgroup.Group{}
+	g2.SetLimit(maxDBConcurrency)
+	for _, bc := range counts {
+		g2.Go(func() error {
+			table := fmt.Sprintf("g5_write_%s", bc.boardID)
+			var rows []gnuboard.MyCommentRow
+			r.db.Raw(
+				fmt.Sprintf("SELECT c.wr_id, c.wr_content, c.wr_datetime, c.mb_id, c.wr_name, c.wr_parent, c.wr_good, c.wr_nogood, c.wr_option, COALESCE(p.wr_subject, '') as post_title, '%s' as board_id FROM `%s` c LEFT JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND c.wr_deleted_at IS NULL ORDER BY c.wr_datetime DESC LIMIT %d", bc.boardID, table, table, perTable),
+				mbID,
+			).Scan(&rows)
+			if len(rows) > 0 {
+				mu.Lock()
+				comments = append(comments, rows...)
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g2.Wait()
+
+	// Sort and paginate in Go
+	sort.Slice(comments, func(i, j int) bool {
+		return comments[i].WrDatetime.After(comments[j].WrDatetime)
+	})
+
+	offset := (page - 1) * limit
+	if offset >= len(comments) {
+		return nil, totalCount, nil
+	}
+	end := offset + limit
+	if end > len(comments) {
+		end = len(comments)
+	}
+	return comments[offset:end], totalCount, nil
 }
 
 // FindLikedPostsByMember returns posts that the member liked (from g5_board_good)
@@ -113,22 +277,34 @@ func (r *myPageRepository) FindLikedPostsByMember(mbID string, page, limit int) 
 		boardPosts[ref.BoTable] = append(boardPosts[ref.BoTable], ref.WrID)
 	}
 
-	// Fetch post details per board
-	postMap := make(map[string]gnuboard.MyPost)
+	// Fetch post details per board in parallel
+	var (
+		mu      sync.Mutex
+		postMap = make(map[string]gnuboard.MyPost)
+	)
+
+	g := errgroup.Group{}
+	g.SetLimit(maxDBConcurrency)
 	for boardID, wrIDs := range boardPosts {
-		table := fmt.Sprintf("g5_write_%s", boardID)
-		var posts []gnuboard.MyPost
-		if err := r.db.Raw(
-			fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE wr_id IN ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", boardID, table),
-			wrIDs,
-		).Scan(&posts).Error; err != nil {
-			continue // skip boards with errors
-		}
-		for _, p := range posts {
-			key := fmt.Sprintf("%s:%d", boardID, p.WrID)
-			postMap[key] = p
-		}
+		g.Go(func() error {
+			table := fmt.Sprintf("g5_write_%s", boardID)
+			var posts []gnuboard.MyPost
+			if err := r.db.Raw(
+				fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE wr_id IN ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", boardID, table),
+				wrIDs,
+			).Scan(&posts).Error; err != nil {
+				return nil // skip boards with errors
+			}
+			mu.Lock()
+			for _, p := range posts {
+				key := fmt.Sprintf("%s:%d", boardID, p.WrID)
+				postMap[key] = p
+			}
+			mu.Unlock()
+			return nil
+		})
 	}
+	_ = g.Wait()
 
 	// Build result in original order
 	var result []gnuboard.MyPost
@@ -141,10 +317,71 @@ func (r *myPageRepository) FindLikedPostsByMember(mbID string, page, limit int) 
 	return result, total, nil
 }
 
-// GetBoardStats returns post/comment counts per board for the member
-// TODO: UNION ALL across ~90 tables causes slow queries. Needs denormalized stats table.
+// GetBoardStats returns post/comment counts per board for the member.
+// Uses parallel per-board queries instead of UNION ALL.
 func (r *myPageRepository) GetBoardStats(mbID string) ([]gnuboard.BoardStat, error) {
-	return nil, nil
+	boards, err := r.boardRepo.FindAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(boards) == 0 {
+		return nil, nil
+	}
+
+	tableNames := make([]string, len(boards))
+	boardMap := make(map[string]string)
+	for i, b := range boards {
+		tableName := fmt.Sprintf("g5_write_%s", b.BoTable)
+		tableNames[i] = tableName
+		boardMap[tableName] = b.BoSubject
+	}
+
+	var existingTables []string
+	r.db.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ?", tableNames).Scan(&existingTables)
+	if len(existingTables) == 0 {
+		return nil, nil
+	}
+
+	type boardCount struct {
+		BoardID      string
+		PostCount    int64
+		CommentCount int64
+	}
+
+	var (
+		mu     sync.Mutex
+		counts []boardCount
+	)
+
+	g := errgroup.Group{}
+	g.SetLimit(maxDBConcurrency)
+	for _, tableName := range existingTables {
+		boardID := strings.TrimPrefix(tableName, "g5_write_")
+		g.Go(func() error {
+			var postCount, commentCount int64
+			r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL", tableName), mbID).Scan(&postCount)
+			r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", tableName), mbID).Scan(&commentCount)
+			if postCount > 0 || commentCount > 0 {
+				mu.Lock()
+				counts = append(counts, boardCount{BoardID: boardID, PostCount: postCount, CommentCount: commentCount})
+				mu.Unlock()
+			}
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	var stats []gnuboard.BoardStat
+	for _, c := range counts {
+		tableName := fmt.Sprintf("g5_write_%s", c.BoardID)
+		stats = append(stats, gnuboard.BoardStat{
+			BoardID:      c.BoardID,
+			BoardName:    boardMap[tableName],
+			PostCount:    c.PostCount,
+			CommentCount: c.CommentCount,
+		})
+	}
+	return stats, nil
 }
 
 // GetSearchableBoards returns boards with bo_use_search=1 that have existing write tables
@@ -182,14 +419,14 @@ func (r *myPageRepository) GetSearchableBoards() ([]searchableBoard, error) {
 	return result, nil
 }
 
-// FindPublicPostsByMember returns recent public posts by a member using UNION ALL
-// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
+// FindPublicPostsByMember returns recent public posts by a member.
+// Temporarily disabled: returns empty to prevent slow queries under high concurrency.
 func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error) {
 	return nil, nil
 }
 
-// FindPublicCommentsByMember returns recent public comments by a member using UNION ALL
-// TODO: UNION ALL across ~90 tables causes slow queries (2+ sec). Needs index or denormalized table.
+// FindPublicCommentsByMember returns recent public comments by a member.
+// Temporarily disabled: returns empty to prevent slow queries under high concurrency.
 func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error) {
 	return nil, nil
 }

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -103,7 +103,8 @@ func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gn
 			return nil
 		})
 	}
-	_ = g.Wait()
+	//nolint:errcheck // all goroutines return nil (errors skipped per board)
+	g.Wait()
 
 	if totalCount == 0 {
 		return nil, 0, nil
@@ -133,7 +134,8 @@ func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gn
 			return nil
 		})
 	}
-	_ = g2.Wait()
+	//nolint:errcheck // all goroutines return nil
+	g2.Wait()
 
 	// Sort and paginate in Go
 	sort.Slice(posts, func(i, j int) bool {
@@ -188,7 +190,8 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 			return nil
 		})
 	}
-	_ = g.Wait()
+	//nolint:errcheck // all goroutines return nil
+	g.Wait()
 
 	if totalCount == 0 {
 		return nil, 0, nil
@@ -218,7 +221,8 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 			return nil
 		})
 	}
-	_ = g2.Wait()
+	//nolint:errcheck // all goroutines return nil
+	g2.Wait()
 
 	// Sort and paginate in Go
 	sort.Slice(comments, func(i, j int) bool {
@@ -304,7 +308,8 @@ func (r *myPageRepository) FindLikedPostsByMember(mbID string, page, limit int) 
 			return nil
 		})
 	}
-	_ = g.Wait()
+	//nolint:errcheck // all goroutines return nil
+	g.Wait()
 
 	// Build result in original order
 	var result []gnuboard.MyPost
@@ -369,7 +374,8 @@ func (r *myPageRepository) GetBoardStats(mbID string) ([]gnuboard.BoardStat, err
 			return nil
 		})
 	}
-	_ = g.Wait()
+	//nolint:errcheck // all goroutines return nil
+	g.Wait()
 
 	var stats []gnuboard.BoardStat
 	for _, c := range counts {


### PR DESCRIPTION
## Summary
- mypage_repo: 5개 함수의 UNION ALL을 errgroup 병렬 개별 쿼리로 전환
- handler: GetMemberActivity 빈 배열 즉시 반환 (새글/새댓글 임시 비활성화)
- 쿼리당 2초+ → ~1ms, 동시 DB 쿼리 수 제한 (maxDBConcurrency=10)

## 변경 내용
| 함수 | 변경 |
|---|---|
| FindPostsByMember | 2-phase 병렬 (COUNT → SELECT) |
| FindCommentsByMember | 2-phase 병렬, LEFT JOIN 유지 |
| FindLikedPostsByMember | 병렬 fetch로 개선 |
| GetBoardStats | 병렬 COUNT per board |
| GetMemberActivity | 빈 배열 즉시 반환 (비활성화) |

## Test plan
- [x] `make build` 성공
- [ ] dev 환경 배포 후 `/api/v1/members/:id/activity` 빈 배열 반환 확인
- [ ] `/api/v1/my/posts` 정상 동작 확인
- [ ] 운영 DB `SHOW PROCESSLIST`에서 UNION ALL 쿼리 0건 확인