### PR TITLE
글/댓글 수정·삭제 시 g5_da_content_history 이중 기록

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2414,6 +2414,20 @@ func main() {
 				VALUES (?, ?, ?, 'update', ?, ?, ?, ?, NOW())`,
 				slug, postID, nextVersion, post.WrSubject, post.WrContent, userID, post.WrName)
 
+			// g5_da_content_history에도 이중 기록
+			{
+				prevData, _ := json.Marshal(map[string]interface{}{
+					"wr_subject": post.WrSubject,
+					"wr_content": post.WrContent,
+					"wr_name":    post.WrName,
+					"mb_id":      post.MbID,
+				})
+				db.Exec(`INSERT INTO g5_da_content_history
+					(bo_table, wr_id, wr_is_comment, mb_id, wr_name, operation, operated_by, operated_at, previous_data)
+					VALUES (?, ?, 0, ?, ?, '수정', ?, NOW(), ?)`,
+					slug, postID, post.MbID, post.WrName, userID, string(prevData))
+			}
+
 			// 업데이트할 필드 구성
 			updates := map[string]interface{}{}
 			if req.Title != nil {
@@ -2515,6 +2529,19 @@ func main() {
 				(board_id, wr_id, version, change_type, title, content, edited_by, edited_by_name, edited_at)
 				VALUES (?, ?, ?, 'update', NULL, ?, ?, ?, NOW())`,
 				slug, commentID, nextVersion, comment.WrContent, userID, comment.WrName)
+
+			// g5_da_content_history에도 이중 기록
+			{
+				prevData, _ := json.Marshal(map[string]interface{}{
+					"wr_content": comment.WrContent,
+					"wr_name":    comment.WrName,
+					"mb_id":      comment.MbID,
+				})
+				db.Exec(`INSERT INTO g5_da_content_history
+					(bo_table, wr_id, wr_is_comment, mb_id, wr_name, operation, operated_by, operated_at, previous_data)
+					VALUES (?, ?, 1, ?, ?, '수정', ?, NOW(), ?)`,
+					slug, commentID, comment.MbID, comment.WrName, userID, string(prevData))
+			}
 
 			tableName := fmt.Sprintf("g5_write_%s", slug)
 			now := time.Now().Format("2006-01-02 15:04:05")

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -2,6 +2,7 @@ package gnuboard
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -567,8 +568,9 @@ func (r *writeRepository) SoftDeletePost(boardID string, wrID int, deletedBy str
 		WrSubject string `gorm:"column:wr_subject"`
 		WrContent string `gorm:"column:wr_content"`
 		WrName    string `gorm:"column:wr_name"`
+		MbID      string `gorm:"column:mb_id"`
 	}
-	if err := r.db.Table(table).Select("wr_subject, wr_content, wr_name").Where("wr_id = ?", wrID).Scan(&post).Error; err == nil {
+	if err := r.db.Table(table).Select("wr_subject, wr_content, wr_name, mb_id").Where("wr_id = ?", wrID).Scan(&post).Error; err == nil {
 		var nextVersion int
 		r.db.Raw("SELECT COALESCE(MAX(version), 0) + 1 FROM g5_write_revisions WHERE board_id = ? AND wr_id = ?", boardID, wrID).Scan(&nextVersion)
 		if err := r.db.Exec(`INSERT INTO g5_write_revisions
@@ -578,6 +580,18 @@ func (r *writeRepository) SoftDeletePost(boardID string, wrID int, deletedBy str
 		).Error; err != nil {
 			log.Printf("[SoftDeletePost] Failed to record revision for %s/%d: %v", boardID, wrID, err)
 		}
+
+		// g5_da_content_history에도 이중 기록
+		prevData, _ := json.Marshal(map[string]interface{}{
+			"wr_subject": post.WrSubject,
+			"wr_content": post.WrContent,
+			"wr_name":    post.WrName,
+			"mb_id":      post.MbID,
+		})
+		r.db.Exec(`INSERT INTO g5_da_content_history
+			(bo_table, wr_id, wr_is_comment, mb_id, wr_name, operation, operated_by, operated_at, previous_data)
+			VALUES (?, ?, 0, ?, ?, '삭제', ?, ?, ?)`,
+			boardID, wrID, post.MbID, post.WrName, deletedBy, now, string(prevData))
 	}
 
 	// Soft delete the post only (comments are preserved)
@@ -666,8 +680,29 @@ func (r *writeRepository) DeleteComment(boardID string, wrID int) error {
 
 // SoftDeleteComment marks a comment as deleted
 func (r *writeRepository) SoftDeleteComment(boardID string, wrID int, deletedBy string) error {
+	table := tableName(boardID)
 	now := time.Now()
-	return r.db.Table(tableName(boardID)).
+
+	// 삭제 전 댓글 데이터 읽기 + g5_da_content_history 기록
+	var comment struct {
+		WrContent string `gorm:"column:wr_content"`
+		WrName    string `gorm:"column:wr_name"`
+		MbID      string `gorm:"column:mb_id"`
+	}
+	if err := r.db.Table(table).Select("wr_content, wr_name, mb_id").
+		Where("wr_id = ? AND wr_is_comment = 1", wrID).Scan(&comment).Error; err == nil {
+		prevData, _ := json.Marshal(map[string]interface{}{
+			"wr_content": comment.WrContent,
+			"wr_name":    comment.WrName,
+			"mb_id":      comment.MbID,
+		})
+		r.db.Exec(`INSERT INTO g5_da_content_history
+			(bo_table, wr_id, wr_is_comment, mb_id, wr_name, operation, operated_by, operated_at, previous_data)
+			VALUES (?, ?, 1, ?, ?, '삭제', ?, ?, ?)`,
+			boardID, wrID, comment.MbID, comment.WrName, deletedBy, now, string(prevData))
+	}
+
+	return r.db.Table(table).
 		Where("wr_id = ? AND wr_is_comment = 1", wrID).
 		Updates(map[string]interface{}{
 			"wr_deleted_at": now,


### PR DESCRIPTION
## Summary
- 게시글/댓글 수정 시 기존 `g5_write_revisions` 기록에 더해 `g5_da_content_history`에도 이중 기록
- `SoftDeletePost`: `mb_id` 추가 조회 후 content_history에 삭제 기록
- `SoftDeleteComment`: 삭제 전 데이터 조회 후 content_history에 기록
- ops.damoang.net 수정이력 페이지에서 angple-backend 경유 수정/삭제도 조회 가능하도록 함

## 변경 파일
- `cmd/api/main.go`: 게시글·댓글 수정 핸들러에 dual-write 추가
- `internal/repository/gnuboard/write_repo.go`: SoftDeletePost, SoftDeleteComment에 dual-write 추가 + `encoding/json` import

## Test plan
- [ ] 게시글 수정 후 `g5_da_content_history` 테이블에 '수정' 기록 확인
- [ ] 댓글 수정 후 동일 확인
- [ ] 게시글 삭제 후 '삭제' 기록 확인
- [ ] 댓글 삭제 후 '삭제' 기록 확인
- [ ] ops.damoang.net/admin/content-history에서 새 기록 조회 확인