### PR TITLE
ci: verify backend canary via internal nodeport

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,42 +163,67 @@ jobs:
   verify-canary:
     needs: [build, deploy-canary]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - name: Verify canary endpoints
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::891376997084:role/GitHubActionsDeployRole
+          aws-region: ap-northeast-2
+
+      - name: Verify canary endpoints (via SSM)
         run: |
-          set -eu
-          for i in $(seq 1 6); do
-            echo "VERIFY ROUND $i"
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "i-038a1d1f00798d94b" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "{
+              \"commands\": [
+                \"set -eu\",
+                \"BASE='http://127.0.0.1:30083'\",
+                \"check_code() { path=\\\"$1\\\"; expected=\\\"$2\\\"; code=$(curl -sS -o /tmp/backend-canary.out -w '%{http_code}' --max-time 10 \\\"${BASE}${path}\\\"); echo \\\"CHECK ${path} -> ${code}\\\"; [ \\\"${code}\\\" = \\\"${expected}\\\" ] || { cat /tmp/backend-canary.out; return 1; }; }\",
+                \"check_body() { path=\\\"$1\\\"; pattern=\\\"$2\\\"; curl -sS --max-time 10 \\\"${BASE}${path}\\\" | tee /tmp/backend-canary-body.out | grep -q \\\"${pattern}\\\" || { cat /tmp/backend-canary-body.out; return 1; }; echo \\\"MATCH ${path} -> ${pattern}\\\"; }\",
+                \"for i in $(seq 1 6); do echo \\\"VERIFY ROUND ${i}\\\"; check_code '/health' '200'; check_code '/api/v1/boards/free/posts?page=1&limit=5' '200'; check_body '/api/v1/boards/free/posts?page=1&limit=5' '\\\"data\\\"'; sleep 5; done\"
+              ]
+            }" \
+            --timeout-seconds 180 \
+            --query "Command.CommandId" \
+            --output text)
 
-            HEALTH_STATUS=$(curl -sS -o /tmp/backend-health.out -w "%{http_code}" -A "GitHub-Actions-Verify" --max-time 10 https://canary.damoang.net/api/v1/health || echo "000")
-            echo "CHECK /api/v1/health -> $HEALTH_STATUS"
-            if [ "$HEALTH_STATUS" != "200" ]; then
-              cat /tmp/backend-health.out || true
+          for i in $(seq 1 36); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            if [ "$STATUS" = "Success" ]; then
+              echo "✅ Canary verification passed"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text || true
+              exit 0
+            elif [ "$STATUS" = "Failed" ]; then
+              echo "❌ Canary verification failed"
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text || true
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text || true
               exit 1
             fi
-
-            ROOT_STATUS=$(curl -sS -o /tmp/backend-root.out -w "%{http_code}" -A "GitHub-Actions-Verify" --max-time 10 https://canary.damoang.net/ || echo "000")
-            echo "CHECK / -> $ROOT_STATUS"
-            if [ "$ROOT_STATUS" != "200" ] && [ "$ROOT_STATUS" != "302" ]; then
-              cat /tmp/backend-root.out || true
-              exit 1
-            fi
-
-            API_STATUS=$(curl -sS -o /tmp/backend-posts.out -w "%{http_code}" -A "GitHub-Actions-Verify" --max-time 10 "https://canary.damoang.net/api/v1/boards/free/posts?page=1&limit=5" || echo "000")
-            echo "CHECK /api/v1/boards/free/posts?page=1&limit=5 -> $API_STATUS"
-            if [ "$API_STATUS" != "200" ]; then
-              cat /tmp/backend-posts.out || true
-              exit 1
-            fi
-
-            grep -q '"data"' /tmp/backend-posts.out || {
-              cat /tmp/backend-posts.out || true
-              exit 1
-            }
-            echo 'MATCH /api/v1/boards/free/posts?page=1&limit=5 -> "data"'
-
             sleep 5
           done
+          echo "Timeout"
+          exit 1
 
       - name: Notify Telegram (Approval)
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,18 +175,31 @@ jobs:
 
       - name: Verify canary endpoints (via SSM)
         run: |
+          cat > /tmp/backend-canary-verify-params.json <<'JSON'
+          {
+            "commands": [
+              "set -eu",
+              "BASE='http://127.0.0.1:30083'",
+              "for i in 1 2 3 4 5 6; do",
+              "  echo \"VERIFY ROUND ${i}\"",
+              "  code=$(curl -sS -o /tmp/backend-canary-health.out -w \"%{http_code}\" --max-time 10 \"${BASE}/health\")",
+              "  echo \"CHECK /health -> ${code}\"",
+              "  [ \"${code}\" = \"200\" ] || { cat /tmp/backend-canary-health.out; exit 1; }",
+              "  code=$(curl -sS -o /tmp/backend-canary-posts.out -w \"%{http_code}\" --max-time 10 \"${BASE}/api/v1/boards/free/posts?page=1&limit=5\")",
+              "  echo \"CHECK /api/v1/boards/free/posts?page=1&limit=5 -> ${code}\"",
+              "  [ \"${code}\" = \"200\" ] || { cat /tmp/backend-canary-posts.out; exit 1; }",
+              "  grep -q '\"data\"' /tmp/backend-canary-posts.out || { cat /tmp/backend-canary-posts.out; exit 1; }",
+              "  echo \"MATCH /api/v1/boards/free/posts?page=1&limit=5 -> \\\"data\\\"\"",
+              "  sleep 5",
+              "done"
+            ]
+          }
+          JSON
+
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "i-038a1d1f00798d94b" \
             --document-name "AWS-RunShellScript" \
-            --parameters "{
-              \"commands\": [
-                \"set -eu\",
-                \"BASE='http://127.0.0.1:30083'\",
-                \"check_code() { path=\\\"$1\\\"; expected=\\\"$2\\\"; code=$(curl -sS -o /tmp/backend-canary.out -w '%{http_code}' --max-time 10 \\\"${BASE}${path}\\\"); echo \\\"CHECK ${path} -> ${code}\\\"; [ \\\"${code}\\\" = \\\"${expected}\\\" ] || { cat /tmp/backend-canary.out; return 1; }; }\",
-                \"check_body() { path=\\\"$1\\\"; pattern=\\\"$2\\\"; curl -sS --max-time 10 \\\"${BASE}${path}\\\" | tee /tmp/backend-canary-body.out | grep -q \\\"${pattern}\\\" || { cat /tmp/backend-canary-body.out; return 1; }; echo \\\"MATCH ${path} -> ${pattern}\\\"; }\",
-                \"for i in $(seq 1 6); do echo \\\"VERIFY ROUND ${i}\\\"; check_code '/health' '200'; check_code '/api/v1/boards/free/posts?page=1&limit=5' '200'; check_body '/api/v1/boards/free/posts?page=1&limit=5' '\\\"data\\\"'; sleep 5; done\"
-              ]
-            }" \
+            --parameters file:///tmp/backend-canary-verify-params.json \
             --timeout-seconds 180 \
             --query "Command.CommandId" \
             --output text)


### PR DESCRIPTION
## Summary
- replace public canary verification with SSM-based internal nodeport checks
- verify backend canary through 127.0.0.1:30083 to avoid Cloudflare blocking
- keep production approval gated on successful canary verification

## Testing
- not run (workflow YAML changes only)
