### PR TITLE
feat: 가입인사 1회 제한 + 소명글 연동

### DIFF
--- a/internal/domain/v2/nariya_php.go
+++ b/internal/domain/v2/nariya_php.go
@@ -64,6 +64,7 @@ type NariyaNotification struct {
 // NariyaWriting holds writing restriction settings
 type NariyaWriting struct {
 	MaxPosts            int    `json:"maxPosts"`
+	MaxPostsTotal       int    `json:"maxPostsTotal"`
 	AllowedLevels       string `json:"allowedLevels"`
 	RestrictedUsers     bool   `json:"restrictedUsers"`
 	MemberOnly          bool   `json:"memberOnly"`

--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -131,6 +131,7 @@ type DisciplineLogDetail struct {
 	Memo            string          `json:"memo,omitempty"`
 	CreatedBy       string          `json:"created_by"`
 	CreatedAt       string          `json:"created_at"`
+	ClaimPostID     *int            `json:"claim_post_id,omitempty"`
 }
 
 // parseContentJSON parses the wr_content JSON or extracts from HTML
@@ -330,6 +331,19 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		Memo:            data.Content,
 		CreatedBy:       post.MbID,
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
+	}
+
+	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 = 'disciplinelog:{id}')
+	var claimPostID int
+	linkValue := "disciplinelog:" + strconv.Itoa(id)
+	err = h.db.Table("g5_write_claim").
+		Select("wr_id").
+		Where("wr_link1 = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkValue).
+		Order("wr_id DESC").
+		Limit(1).
+		Scan(&claimPostID).Error
+	if err == nil && claimPostID > 0 {
+		detail.ClaimPostID = &claimPostID
 	}
 
 	common.V2Success(c, detail)

--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -16,6 +16,7 @@ import (
 // WritingSettings mirrors the frontend WritingSettings interface from v2_board_extended_settings JSON.
 type WritingSettings struct {
 	MaxPosts            int    `json:"maxPosts,omitempty"`
+	MaxPostsTotal       int    `json:"maxPostsTotal,omitempty"`
 	AllowedLevels       string `json:"allowedLevels,omitempty"`
 	RestrictedUsers     bool   `json:"restrictedUsers,omitempty"`
 	MemberOnly          bool   `json:"memberOnly,omitempty"`
@@ -35,6 +36,8 @@ type WriteRestrictionResult struct {
 	CanWrite   bool   `json:"can_write"`
 	Remaining  int    `json:"remaining"`   // -1 = unlimited
 	DailyLimit int    `json:"daily_limit"` // 0 = unlimited
+	TotalLimit int    `json:"total_limit"` // 0 = unlimited
+	TotalCount int    `json:"total_count"`
 	Reason     string `json:"reason,omitempty"`
 }
 
@@ -86,7 +89,33 @@ func (s *BoardWriteRestrictionService) Check(boardSlug, memberID string, memberL
 		}
 	}
 
-	// 2. restrictedUsers → only allowed members can write
+	// 2. maxPostsTotal — lifetime total limit (e.g. 가입인사 1회)
+	if writing.MaxPostsTotal > 0 {
+		totalCount, err := s.countTotalPosts(boardSlug, memberID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to count total posts: %w", err)
+		}
+
+		if totalCount >= writing.MaxPostsTotal {
+			return &WriteRestrictionResult{
+				CanWrite:   false,
+				Remaining:  0,
+				TotalLimit: writing.MaxPostsTotal,
+				TotalCount: totalCount,
+				Reason:     fmt.Sprintf("이 게시판에는 총 %d개까지 작성 가능합니다. (이미 %d개 작성)", writing.MaxPostsTotal, totalCount),
+			}, nil
+		}
+
+		remaining := writing.MaxPostsTotal - totalCount
+		return &WriteRestrictionResult{
+			CanWrite:   true,
+			Remaining:  remaining,
+			TotalLimit: writing.MaxPostsTotal,
+			TotalCount: totalCount,
+		}, nil
+	}
+
+	// 3. restrictedUsers → only allowed members can write
 	if writing.RestrictedUsers {
 		dailyLimit := findMemberDailyLimit(memberID, writing)
 		if dailyLimit == 0 {
@@ -117,7 +146,7 @@ func (s *BoardWriteRestrictionService) Check(boardSlug, memberID string, memberL
 		}, nil
 	}
 
-	// 3. maxPosts global daily limit (applies regardless of restrictedUsers)
+	// 4. maxPosts global daily limit (applies regardless of restrictedUsers)
 	if writing.MaxPosts > 0 {
 		todayCount, err := s.countTodayPosts(boardSlug, memberID)
 		if err != nil {
@@ -154,6 +183,20 @@ func (s *BoardWriteRestrictionService) countTodayPosts(boardSlug, memberID strin
 	var count int64
 	err := s.db.Table(tableName).
 		Where("mb_id = ? AND DATE(wr_datetime) = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", memberID, today).
+		Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}
+
+// countTotalPosts counts all non-comment posts ever written by the member in the board.
+func (s *BoardWriteRestrictionService) countTotalPosts(boardSlug, memberID string) (int, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardSlug)
+
+	var count int64
+	err := s.db.Table(tableName).
+		Where("mb_id = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", memberID).
 		Count(&count).Error
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Summary
- WritingSettings에 `maxPostsTotal` 필드 추가 (평생 총 글수 제한, 가입인사 1회용)
- `countTotalPosts()` 메서드로 전체 글 수 카운트, Check() 로직에 반영
- disciplinelog 상세 API에 `claim_post_id` 반환 (소명글 존재 여부)

## Test plan
- [ ] `curl -i http://localhost:8090/api/v1/boards/hello/write-permission` → totalLimit 확인
- [ ] hello 게시판에 maxPostsTotal: 1 설정 후 글 1개 작성 → 재시도 시 차단 확인
- [ ] disciplinelog 상세 API에서 소명글 존재 시 claim_post_id 반환 확인