### PR TITLE
feat: 게시판 즐겨찾기 서버 동기화 API

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3822,6 +3822,7 @@ func main() {
 		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager)
 		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
 		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
+		v2routes.SetupFavorite(router, v2handler.NewFavoriteHandler(db), jwtManager)
 
 		// v1 message routes (uses g5_memo table directly)
 		gnuMemoRepo := gnurepo.NewMemoRepository(db)

--- a/internal/handler/v2/favorite_handler.go
+++ b/internal/handler/v2/favorite_handler.go
@@ -28,7 +28,7 @@ type FavoriteEntry struct {
 	Title   string `json:"title"`
 }
 
-// GetFavorites handles GET /api/v1/members/me/favorites
+// GetFavorites handles GET /api/v1/my/favorites
 func (h *FavoriteHandler) GetFavorites(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	if userID == "" {
@@ -57,7 +57,7 @@ func (h *FavoriteHandler) GetFavorites(c *gin.Context) {
 	common.V2Success(c, favorites)
 }
 
-// UpdateFavorites handles PUT /api/v1/members/me/favorites
+// UpdateFavorites handles PUT /api/v1/my/favorites
 func (h *FavoriteHandler) UpdateFavorites(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	if userID == "" {

--- a/internal/handler/v2/favorite_handler.go
+++ b/internal/handler/v2/favorite_handler.go
@@ -1,0 +1,94 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// FavoriteHandler handles board favorites (bookmark slots) endpoints
+type FavoriteHandler struct {
+	db *gorm.DB
+}
+
+// NewFavoriteHandler creates a new favorite handler
+func NewFavoriteHandler(db *gorm.DB) *FavoriteHandler {
+	return &FavoriteHandler{db: db}
+}
+
+// FavoriteEntry represents a single board favorite slot
+type FavoriteEntry struct {
+	BoardID string `json:"boardId"`
+	Title   string `json:"title"`
+}
+
+// GetFavorites handles GET /api/v1/members/me/favorites
+func (h *FavoriteHandler) GetFavorites(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	key := fmt.Sprintf("favorites:%s", userID)
+
+	var result struct {
+		ValueText string `gorm:"column:value_text"`
+	}
+	err := h.db.Raw("SELECT value_text FROM g5_kv_store WHERE `key` = ? LIMIT 1", key).Scan(&result).Error
+	if err != nil || result.ValueText == "" {
+		// 데이터 없음 — 빈 객체 반환
+		common.V2Success(c, map[string]FavoriteEntry{})
+		return
+	}
+
+	var favorites map[string]FavoriteEntry
+	if err := json.Unmarshal([]byte(result.ValueText), &favorites); err != nil {
+		common.V2Success(c, map[string]FavoriteEntry{})
+		return
+	}
+
+	common.V2Success(c, favorites)
+}
+
+// UpdateFavorites handles PUT /api/v1/members/me/favorites
+func (h *FavoriteHandler) UpdateFavorites(c *gin.Context) {
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	var favorites map[string]FavoriteEntry
+	if err := c.ShouldBindJSON(&favorites); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "유효하지 않은 요청입니다", err)
+		return
+	}
+
+	jsonBytes, err := json.Marshal(favorites)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "데이터 직렬화 실패", err)
+		return
+	}
+
+	key := fmt.Sprintf("favorites:%s", userID)
+	now := int(time.Now().Unix())
+
+	result := h.db.Exec(`
+		INSERT INTO g5_kv_store (`+"`key`"+`, value_type, value_text, updated_at)
+		VALUES (?, 'TEXT', ?, ?)
+		ON DUPLICATE KEY UPDATE value_text = VALUES(value_text), updated_at = VALUES(updated_at)
+	`, key, string(jsonBytes), now)
+	if result.Error != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "즐겨찾기 저장 실패", result.Error)
+		return
+	}
+
+	common.V2Success(c, gin.H{"success": true})
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -270,9 +270,10 @@ func SetupLicense(router *gin.Engine, h *v2handler.LicenseHandler) {
 func SetupFavorite(router *gin.Engine, h *v2handler.FavoriteHandler, jwtManager *jwt.Manager) {
 	auth := middleware.JWTAuth(jwtManager)
 
-	me := router.Group("/api/v1/members/me", auth)
-	me.GET("/favorites", h.GetFavorites)
-	me.PUT("/favorites", h.UpdateFavorites)
+	// /api/v1/my/* 패턴 — 기존 my/point, my/posts 등과 일관성 유지
+	my := router.Group("/api/v1/my", auth)
+	my.GET("/favorites", h.GetFavorites)
+	my.PUT("/favorites", h.UpdateFavorites)
 }
 
 // SetupContent configures content page routes (admin + public)

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -266,6 +266,15 @@ func SetupLicense(router *gin.Engine, h *v2handler.LicenseHandler) {
 	router.POST("/api/v2/licenses/verify", h.Verify)
 }
 
+// SetupFavorite configures board favorites routes
+func SetupFavorite(router *gin.Engine, h *v2handler.FavoriteHandler, jwtManager *jwt.Manager) {
+	auth := middleware.JWTAuth(jwtManager)
+
+	me := router.Group("/api/v1/members/me", auth)
+	me.GET("/favorites", h.GetFavorites)
+	me.PUT("/favorites", h.UpdateFavorites)
+}
+
 // SetupContent configures content page routes (admin + public)
 func SetupContent(router *gin.Engine, h *v2handler.ContentHandler, jwtManager *jwt.Manager) {
 	// Admin routes (requires authentication + admin)


### PR DESCRIPTION
## Summary
- GET/PUT `/api/v1/my/favorites` 엔드포인트 추가
- `g5_kv_store` 테이블에 `favorites:{mb_id}` 키로 JSON 저장 (UPSERT)
- JWT 인증 미들웨어 적용, SvelteKit 내부 인증 헤더 지원

Closes damoang/angple#603

## Related
- 프론트엔드 PR: damoang/angple (별도 PR)

## Test plan
- [ ] `GET /api/v1/my/favorites` — 빈 객체 반환 (초기)
- [ ] `PUT /api/v1/my/favorites` — JSON 저장 후 GET으로 확인
- [ ] 인증 없이 요청 시 401 반환
- [ ] `go build ./cmd/api/` 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)