### PR TITLE
fix: 검색+카테고리 조합 및 Sphinx 부분일치 검색

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1386,7 +1386,9 @@ func main() {
 
 			var posts []*gnuboard.G5Write
 			var total int64
-			if isSearching {
+			if isSearching && category != "" {
+				posts, total, err = gnuWriteRepo.SearchPostsByCategory(slug, sfl, stx, category, page, limit)
+			} else if isSearching {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
 			} else if useCursor {
 				posts, total, err = gnuWriteRepo.FindPostsAfter(slug, limit, cursorWrNum, cursorWrReply)

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -59,6 +59,7 @@ type WriteRepository interface {
 	FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsFiltered(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
 	SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error)
+	SearchPostsByCategory(boardID string, searchField, searchQuery, category string, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	SearchPostsFiltered(boardID string, searchField, searchQuery string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
 	FindPostByID(boardID string, wrID int) (*gnuboard.G5Write, error)
 	FindPostByIDIncludeDeleted(boardID string, wrID int) (*gnuboard.G5Write, error)
@@ -413,6 +414,46 @@ func (r *writeRepository) SearchPosts(boardID string, searchField, searchQuery s
 		}
 	}
 	return ordered, result.TotalFound, nil
+}
+
+// SearchPostsByCategory retrieves posts matching search criteria filtered by ca_name (category).
+// Uses Sphinx for full-text search, then filters by category in MySQL.
+func (r *writeRepository) SearchPostsByCategory(boardID string, searchField, searchQuery, category string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
+	if r.sphinx == nil {
+		return nil, 0, fmt.Errorf("검색 서비스를 일시적으로 사용할 수 없습니다")
+	}
+
+	// Fetch extra results from Sphinx since category filter will reduce count
+	result, err := r.sphinx.Search(boardID, searchField, searchQuery, 1, limit*page*3)
+	if err != nil {
+		return nil, 0, fmt.Errorf("검색 서비스 오류: %w", err)
+	}
+	if result == nil || len(result.IDs) == 0 {
+		return nil, 0, nil
+	}
+
+	// Fetch from MySQL with category filter and count
+	var total int64
+	table := tableName(boardID)
+	if err := r.db.Table(table).
+		Where("wr_id IN ? AND ca_name = ? AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", result.IDs, category).
+		Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var posts []*gnuboard.G5Write
+	offset := (page - 1) * limit
+	if err := r.db.Table(table).
+		Select(coreColumns).
+		Where("wr_id IN ? AND ca_name = ? AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", result.IDs, category).
+		Order("wr_id DESC").
+		Offset(offset).
+		Limit(limit).
+		Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return posts, total, nil
 }
 
 // FindPostByID retrieves a single post by ID (excludes soft deleted)

--- a/pkg/sphinx/sphinx.go
+++ b/pkg/sphinx/sphinx.go
@@ -35,21 +35,33 @@ func New(host string, port int) (*Client, error) {
 	return &Client{db: db}, nil
 }
 
+// addInfixWildcards wraps each whitespace-separated token with * for partial matching.
+// Requires min_infix_len to be set in the Sphinx index configuration.
+func addInfixWildcards(escaped string) string {
+	tokens := strings.Fields(escaped)
+	for i, t := range tokens {
+		tokens[i] = "*" + t + "*"
+	}
+	return strings.Join(tokens, " ")
+}
+
 // buildMatchExpr builds a Sphinx MATCH expression from search field and query.
 func buildMatchExpr(searchField, searchQuery string) string {
 	// Escape special Sphinx characters
 	escaped := escapeSphinx(searchQuery)
+	// Add infix wildcards for partial matching (author uses exact match)
+	wildcarded := addInfixWildcards(escaped)
 	switch searchField {
 	case "title":
-		return fmt.Sprintf("@wr_subject %s", escaped)
+		return fmt.Sprintf("@wr_subject %s", wildcarded)
 	case "content":
-		return fmt.Sprintf("@wr_content %s", escaped)
+		return fmt.Sprintf("@wr_content %s", wildcarded)
 	case "title_content":
-		return fmt.Sprintf("@(wr_subject,wr_content) %s", escaped)
+		return fmt.Sprintf("@(wr_subject,wr_content) %s", wildcarded)
 	case "author":
 		return fmt.Sprintf("@(wr_name,mb_id) %s", escaped)
 	default:
-		return fmt.Sprintf("@(wr_subject,wr_content) %s", escaped)
+		return fmt.Sprintf("@(wr_subject,wr_content) %s", wildcarded)
 	}
 }
 


### PR DESCRIPTION
## Summary
- 검색과 카테고리 필터 동시 사용 시 결과가 비어있던 문제 수정 (#8052)
- Sphinx 검색에 infix 와일드카드 적용하여 부분일치 검색 지원 (#7986)

## Changes
- `SearchPostsByCategory()` 메서드 추가 (Sphinx 검색 후 MySQL ca_name 필터)
- `buildMatchExpr()`에서 각 토큰을 `*토큰*`으로 감싸 부분일치 활성화
- author 필드는 정확 매칭 유지

## Test plan
- [ ] `?sfl=title&stx=할인&category=의류` 조합 검색 확인
- [ ] `?category=의류` 단독 필터 기존대로 동작 확인
- [ ] Sphinx 부분일치: "다모"로 검색 시 "다모앙" 포함 글 반환 확인
- [ ] author 검색은 정확 매칭 유지 확인