### PR TITLE
fix: 차단한 사용자의 댓글/답글 알림 차단

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2298,7 +2298,10 @@ func main() {
 				if req.ParentID != nil && *req.ParentID > 0 {
 					var parentAuthorMbID string
 					if err := db.Table(tableName).Select("mb_id").Where("wr_id = ?", *req.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != mbID {
-						if pref, _ := notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
+						// 수신자가 발신자를 차단한 경우 알림 생략
+						if blocked, _ := blockRepo.Exists(parentAuthorMbID, mbID); blocked {
+							// skip
+						} else if pref, _ := notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
 							_ = notiRepo.Create(&gnurepo.Notification{
 								PhToCase:      "comment_reply",
 								PhFromCase:    "comment",
@@ -2318,9 +2321,11 @@ func main() {
 					}
 				}
 
-				// 게시글 작성자에게 알림 (자기 댓글은 제외)
+				// 게시글 작성자에게 알림 (자기 댓글은 제외, 차단한 사용자 제외)
 				if postAuthor.MbID != mbID {
-					if pref, _ := notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
+					if blocked, _ := blockRepo.Exists(postAuthor.MbID, mbID); blocked {
+						// 게시글 작성자가 댓글 작성자를 차단한 경우 알림 생략
+					} else if pref, _ := notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
 						_ = notiRepo.Create(&gnurepo.Notification{
 							PhToCase:      "comment",
 							PhFromCase:    "comment",

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2298,8 +2299,8 @@ func main() {
 				if req.ParentID != nil && *req.ParentID > 0 {
 					var parentAuthorMbID string
 					if err := db.Table(tableName).Select("mb_id").Where("wr_id = ?", *req.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != mbID {
-						// 수신자가 발신자를 차단한 경우 알림 생략
-						if blocked, _ := blockRepo.Exists(parentAuthorMbID, mbID); blocked {
+						// 수신자가 발신자를 차단한 경우 알림 생략 (Redis 캐시 활용)
+						if slices.Contains(getBlockedIDs(context.Background(), parentAuthorMbID), mbID) {
 							// skip
 						} else if pref, _ := notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
 							_ = notiRepo.Create(&gnurepo.Notification{
@@ -2323,7 +2324,7 @@ func main() {
 
 				// 게시글 작성자에게 알림 (자기 댓글은 제외, 차단한 사용자 제외)
 				if postAuthor.MbID != mbID {
-					if blocked, _ := blockRepo.Exists(postAuthor.MbID, mbID); blocked {
+					if slices.Contains(getBlockedIDs(context.Background(), postAuthor.MbID), mbID) {
 						// 게시글 작성자가 댓글 작성자를 차단한 경우 알림 생략
 					} else if pref, _ := notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
 						_ = notiRepo.Create(&gnurepo.Notification{

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
@@ -1045,7 +1046,9 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 				// 수신자가 발신자를 차단했는지 확인
 				isBlockedByParent := false
 				if h.blockRepo != nil {
-					isBlockedByParent, _ = h.blockRepo.Exists(parentAuthorMbID, commenterMbID)
+					if blockedIDs, err := h.blockRepo.GetBlockedUserIDs(parentAuthorMbID); err == nil {
+						isBlockedByParent = slices.Contains(blockedIDs, commenterMbID)
+					}
 				}
 				// 답글 알림 설정 확인
 				sendReply := true
@@ -1083,7 +1086,7 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 
 	// 게시글 작성자가 댓글 작성자를 차단한 경우 알림 생략
 	if h.blockRepo != nil {
-		if blocked, _ := h.blockRepo.Exists(postAuthorMbID, commenterMbID); blocked {
+		if blockedIDs, err := h.blockRepo.GetBlockedUserIDs(postAuthorMbID); err == nil && slices.Contains(blockedIDs, commenterMbID) {
 			return
 		}
 	}

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -1042,9 +1042,16 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 		if err == nil {
 			var parentAuthorMbID string
 			if err := h.gnuDB.Table("g5_member").Select("mb_id").Where("mb_no = ?", parentComment.UserID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != commenterMbID {
+				// 수신자가 발신자를 차단했는지 확인
+				isBlockedByParent := false
+				if h.blockRepo != nil {
+					isBlockedByParent, _ = h.blockRepo.Exists(parentAuthorMbID, commenterMbID)
+				}
 				// 답글 알림 설정 확인
 				sendReply := true
-				if h.notiPrefRepo != nil {
+				if isBlockedByParent {
+					sendReply = false
+				} else if h.notiPrefRepo != nil {
 					if pref, err := h.notiPrefRepo.Get(parentAuthorMbID); err == nil && !pref.NotiReply {
 						sendReply = false
 					}
@@ -1071,6 +1078,13 @@ func (h *V2Handler) createCommentNotification(boardSlug string, postID uint64, c
 					}
 				}
 			}
+		}
+	}
+
+	// 게시글 작성자가 댓글 작성자를 차단한 경우 알림 생략
+	if h.blockRepo != nil {
+		if blocked, _ := h.blockRepo.Exists(postAuthorMbID, commenterMbID); blocked {
+			return
 		}
 	}
 


### PR DESCRIPTION
## Summary
- 수신자가 발신자를 차단한 경우 댓글/답글 알림을 생성하지 않도록 변경
- v1 (cmd/api/main.go) + v2 (handler.go) 모두 적용
- blockRepo.Exists(receiverID, senderID) 체크 추가

## Fixes
- #7964 차단한 사람의 댓글이 보임 + 알림이 옴

## Test plan
- [ ] A가 B를 차단 → B가 A의 글에 댓글 → A에게 알림 안 감 확인
- [ ] A가 B를 차단 → B가 A의 댓글에 답글 → A에게 알림 안 감 확인
- [ ] A가 B를 차단하지 않음 → B가 댓글 → A에게 알림 정상 도착 확인