### PR TITLE
fix: 이용제한 목록 API에 penalty_date_to 필드 추가

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -113,6 +113,7 @@ type DisciplineLogListItem struct {
 	MemberNickname  string   `json:"member_nickname"`
 	PenaltyPeriod   int      `json:"penalty_period"`
 	PenaltyDateFrom string   `json:"penalty_date_from"`
+	PenaltyDateTo   *string  `json:"penalty_date_to,omitempty"`
 	ViolationTypes  []int    `json:"violation_types"`
 	ViolationTitles []string `json:"violation_titles"`
 	Memo            string   `json:"memo,omitempty"`
@@ -255,12 +256,24 @@ func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 			dateFrom = dateFrom[:10]
 		}
 
+		// Calculate penalty_date_to for time-limited penalties
+		var penaltyDateTo *string
+		if data.PenaltyPeriod > 0 {
+			df, err := time.Parse("2006-01-02 15:04:05", data.PenaltyDateFrom)
+			if err != nil {
+				df, _ = time.Parse("2006-01-02", data.PenaltyDateFrom)
+			}
+			dt := df.AddDate(0, 0, data.PenaltyPeriod).Format("2006-01-02 15:04:05")
+			penaltyDateTo = &dt
+		}
+
 		items = append(items, DisciplineLogListItem{
 			ID:              post.WrID,
 			MemberID:        data.PenaltyMbID,
 			MemberNickname:  getMemberNickFromTitle(post.WrSubject),
 			PenaltyPeriod:   data.PenaltyPeriod,
 			PenaltyDateFrom: dateFrom,
+			PenaltyDateTo:   penaltyDateTo,
 			ViolationTypes:  data.SgTypes,
 			ViolationTitles: titles,
 			Memo:            data.Content,


### PR DESCRIPTION
## Summary
- 이용제한 목록 API(`DisciplineLogListItem`)에 `penalty_date_to` 필드 추가
- `penalty_date_from + penalty_period` 일수로 계산
- 프론트엔드에서 "해제됨" 상태 판별 및 기간 구분 가능

## Fixes
- #8415 이용제한기간 중복등재 문제

## Test plan
- [ ] 이용제한 목록 API 응답에 `penalty_date_to` 포함 확인
- [ ] 영구정지(period=0)는 `penalty_date_to` null
- [ ] 기간제(period>0)는 `penalty_date_to` 날짜 표시