### PR TITLE
perf: 이용제한 목록 조회 쿼리 최적화

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -96,14 +96,18 @@ var ViolationTypes = []ViolationType{
 	{40, "뉴스전문전재", "뉴스 전문을 허가 없이 전재하는 행위"},
 }
 
+// violationTypeMap is a pre-built lookup map for O(1) access by code
+var violationTypeMap = func() map[int]*ViolationType {
+	m := make(map[int]*ViolationType, len(ViolationTypes))
+	for i := range ViolationTypes {
+		m[ViolationTypes[i].Code] = &ViolationTypes[i]
+	}
+	return m
+}()
+
 // getViolationType returns the violation type by code
 func getViolationType(code int) *ViolationType {
-	for _, v := range ViolationTypes {
-		if v.Code == code {
-			return &v
-		}
-	}
-	return nil
+	return violationTypeMap[code]
 }
 
 // DisciplineLogListItem represents a discipline log item in list
@@ -219,9 +223,9 @@ func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 	var total int64
 
 	if memberID != "" {
-		// Filter by member_id using JSON_EXTRACT on wr_content
+		// Filter by member_id using generated column (indexed)
 		table := "g5_write_disciplinelog"
-		filter := "wr_is_comment = 0 AND wr_deleted_at IS NULL AND JSON_VALID(wr_content) AND JSON_UNQUOTE(JSON_EXTRACT(wr_content, '$.penalty_mb_id')) = ?"
+		filter := "wr_is_comment = 0 AND wr_deleted_at IS NULL AND penalty_mb_id = ?"
 
 		h.db.Table(table).Where(filter, memberID).Count(&total)
 		h.db.Table(table).Select(disciplineLogColumns).Where(filter, memberID).

--- a/internal/migration/discipline_log.go
+++ b/internal/migration/discipline_log.go
@@ -1,0 +1,44 @@
+package migration
+
+import (
+	"gorm.io/gorm"
+)
+
+// AddDisciplineLogPenaltyMbIDColumn adds a generated column and index for
+// penalty_mb_id extracted from JSON wr_content, replacing slow JSON_EXTRACT
+// full-table scans with an indexed column lookup.
+func AddDisciplineLogPenaltyMbIDColumn(db *gorm.DB) error {
+	// Check if column already exists
+	var count int64
+	db.Raw(`
+		SELECT COUNT(*) FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'g5_write_disciplinelog'
+		  AND COLUMN_NAME = 'penalty_mb_id'
+	`).Scan(&count)
+
+	if count > 0 {
+		return nil // already migrated
+	}
+
+	// Add generated column (STORED so it can be indexed)
+	if err := db.Exec(`
+		ALTER TABLE g5_write_disciplinelog
+		ADD COLUMN penalty_mb_id VARCHAR(100)
+		GENERATED ALWAYS AS (
+			CASE WHEN JSON_VALID(wr_content) THEN JSON_UNQUOTE(JSON_EXTRACT(wr_content, '$.penalty_mb_id')) ELSE NULL END
+		) STORED
+	`).Error; err != nil {
+		return err
+	}
+
+	// Add index for fast lookups
+	if err := db.Exec(`
+		ALTER TABLE g5_write_disciplinelog
+		ADD INDEX idx_penalty_mb_id (penalty_mb_id)
+	`).Error; err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -36,6 +36,9 @@ func Run(db *gorm.DB) error {
 	if err := AddListDeletedIndexes(db); err != nil {
 		return err
 	}
+	if err := AddDisciplineLogPenaltyMbIDColumn(db); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `JSON_EXTRACT` 풀 테이블 스캔 → Generated Column (`penalty_mb_id`) + 인덱스로 변경
- `getViolationType` 선형 탐색 O(n) → Map 기반 O(1) 조회로 변경

## Changes
- `discipline_log_handler.go`: Map 기반 violation type 조회, generated column 필터링
- `migration/discipline_log.go`: `penalty_mb_id` STORED generated column + 인덱스 추가
- `migration/migrate.go`: 마이그레이션 호출 추가

## Performance Impact
- member_id 필터: `JSON_EXTRACT` 풀 스캔 → 인덱스 스캔 (O(n) → O(log n))
- violation type 조회: 40개 항목 선형 탐색 → O(1) map lookup

## Test plan
- [ ] 서버 시작 시 마이그레이션 자동 실행 확인 (generated column + index 생성)
- [ ] `GET /api/v1/discipline-logs?member_id=xxx` 정상 응답 확인
- [ ] `GET /api/v1/discipline-logs` (member_id 없이) 기존과 동일 동작 확인
- [ ] `EXPLAIN` 쿼리로 인덱스 사용 확인