### PR TITLE
feat: add member activity read model sync tools

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2846,7 +2846,7 @@ func main() {
 				replyCount = 0
 			}
 
-			delayMinutes := gnuboard.CalculateDelay(int(replyCount))
+			delayMinutes := gnuboard.CalculateDelay(common.SafeInt64ToInt(replyCount))
 
 			if delayMinutes == 0 {
 				// 답글 없으면 즉시 삭제
@@ -2880,7 +2880,7 @@ func main() {
 				BoTable:      slug,
 				WrID:         commentID,
 				WrIsComment:  1,
-				ReplyCount:   int(replyCount),
+				ReplyCount:   common.SafeInt64ToInt(replyCount),
 				DelayMinutes: delayMinutes,
 				ScheduledAt:  now.Add(time.Duration(delayMinutes) * time.Minute),
 				RequestedBy:  userID,

--- a/cmd/member-activity/main.go
+++ b/cmd/member-activity/main.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/damoang/angple-backend/internal/config"
+	"github.com/damoang/angple-backend/internal/service"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func main() {
+	configPath := flag.String("config", "configs/config.prod.yaml", "config file path")
+	mode := flag.String("mode", "verify", "mode: verify, backfill, or repair")
+	board := flag.String("board", "", "single legacy board slug to process")
+	scope := flag.String("scope", "legacy", "scope: legacy, v2, all")
+	batchSize := flag.Int("batch-size", 500, "batch size for backfill")
+	verbose := flag.Bool("verbose", false, "verbose SQL logging")
+	flag.Parse()
+
+	loaded := config.LoadDotEnv()
+	if len(loaded) > 0 {
+		log.Printf("Loaded env files: %v", loaded)
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	logLevel := gormlogger.Warn
+	if *verbose {
+		logLevel = gormlogger.Info
+	}
+
+	db, err := gorm.Open(mysql.Open(cfg.Database.GetDSN()), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(logLevel),
+	})
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("failed to get underlying DB: %v", err)
+	}
+	defer sqlDB.Close()
+
+	svc := service.NewMemberActivitySyncService(db)
+
+	switch *mode {
+	case "backfill":
+		runBackfill(db, svc, *scope, *board, *batchSize)
+	case "verify":
+		runVerifyOrExit(db, svc, *scope, *board)
+	case "repair":
+		runRepair(db, svc, *scope, *board, *batchSize)
+	default:
+		log.Fatalf("unsupported mode: %s", *mode)
+	}
+}
+
+func runBackfill(db *gorm.DB, svc *service.MemberActivitySyncService, scope, board string, batchSize int) {
+	if scope == "all" || scope == "legacy" {
+		boardIDs, err := getBoardIDs(db, board)
+		if err != nil {
+			log.Fatalf("failed to load board ids: %v", err)
+		}
+		for _, boardID := range boardIDs {
+			report, err := svc.BackfillLegacyBoard(boardID, batchSize)
+			if err != nil {
+				log.Fatalf("legacy backfill failed for %s: %v", boardID, err)
+			}
+			log.Printf("[backfill][legacy] board=%s source_posts=%d source_comments=%d synced_posts=%d synced_comments=%d",
+				report.BoardSlug, report.PostCount, report.CommentCount, report.ProcessedPosts, report.ProcessedComments)
+		}
+	}
+
+	if scope == "all" || scope == "v2" {
+		report, err := svc.BackfillV2(batchSize)
+		if err != nil {
+			log.Fatalf("v2 backfill failed: %v", err)
+		}
+		log.Printf("[backfill][v2] source_posts=%d source_comments=%d synced_posts=%d synced_comments=%d",
+			report.PostCount, report.CommentCount, report.ProcessedPosts, report.ProcessedComments)
+	}
+}
+
+func runRepair(db *gorm.DB, svc *service.MemberActivitySyncService, scope, board string, batchSize int) {
+	log.Printf("[repair] pre-check verify start scope=%s board=%s", scope, board)
+	if !runVerify(db, svc, scope, board) {
+		log.Printf("[repair] mismatch detected, running backfill")
+		runBackfill(db, svc, scope, board, batchSize)
+		log.Printf("[repair] post-backfill verify start")
+		if !runVerify(db, svc, scope, board) {
+			fmt.Fprintln(os.Stderr, "member activity repair completed with remaining mismatches")
+			os.Exit(1)
+		}
+		log.Printf("[repair] verify passed after backfill")
+		return
+	}
+	log.Printf("[repair] verify already clean; backfill skipped")
+}
+
+func runVerifyOrExit(db *gorm.DB, svc *service.MemberActivitySyncService, scope, board string) {
+	if !runVerify(db, svc, scope, board) {
+		fmt.Fprintln(os.Stderr, "member activity verification found mismatches")
+		os.Exit(1)
+	}
+}
+
+func runVerify(db *gorm.DB, svc *service.MemberActivitySyncService, scope, board string) bool {
+	hasMismatch := false
+
+	if scope == "all" || scope == "legacy" {
+		boardIDs, err := getBoardIDs(db, board)
+		if err != nil {
+			log.Fatalf("failed to load board ids: %v", err)
+		}
+		for _, boardID := range boardIDs {
+			report, err := svc.VerifyLegacyBoard(boardID)
+			if err != nil {
+				log.Fatalf("legacy verify failed for %s: %v", boardID, err)
+			}
+			mismatch := report.SourcePosts != report.FeedPosts ||
+				report.SourceComments != report.FeedComments ||
+				report.SourceDeletedPosts != report.FeedDeletedPosts ||
+				report.SourceDeletedComments != report.FeedDeletedComments
+			if mismatch {
+				hasMismatch = true
+			}
+			log.Printf("[verify][legacy] board=%s posts=%d/%d comments=%d/%d deleted_posts=%d/%d deleted_comments=%d/%d mismatch=%v",
+				report.BoardSlug,
+				report.SourcePosts, report.FeedPosts,
+				report.SourceComments, report.FeedComments,
+				report.SourceDeletedPosts, report.FeedDeletedPosts,
+				report.SourceDeletedComments, report.FeedDeletedComments,
+				mismatch)
+		}
+	}
+
+	if scope == "all" || scope == "v2" {
+		report, err := svc.VerifyV2()
+		if err != nil {
+			log.Fatalf("v2 verify failed: %v", err)
+		}
+		mismatch := report.SourcePosts != report.FeedPosts ||
+			report.SourceComments != report.FeedComments ||
+			report.SourceDeletedPosts != report.FeedDeletedPosts ||
+			report.SourceDeletedComments != report.FeedDeletedComments
+		if mismatch {
+			hasMismatch = true
+		}
+		log.Printf("[verify][v2] posts=%d/%d comments=%d/%d deleted_posts=%d/%d deleted_comments=%d/%d mismatch=%v",
+			report.SourcePosts, report.FeedPosts,
+			report.SourceComments, report.FeedComments,
+			report.SourceDeletedPosts, report.FeedDeletedPosts,
+			report.SourceDeletedComments, report.FeedDeletedComments,
+			mismatch)
+	}
+
+	if hasMismatch {
+		return false
+	}
+	return true
+}
+
+func getBoardIDs(db *gorm.DB, onlyBoard string) ([]string, error) {
+	if onlyBoard != "" {
+		return []string{onlyBoard}, nil
+	}
+
+	var boardIDs []string
+	if err := db.Table("g5_board").
+		Where("bo_table <> ''").
+		Order("bo_table ASC").
+		Pluck("bo_table", &boardIDs).Error; err != nil {
+		return nil, err
+	}
+	return boardIDs, nil
+}

--- a/internal/common/numeric.go
+++ b/internal/common/numeric.go
@@ -1,0 +1,22 @@
+package common
+
+import "math"
+
+// SafeInt64ToInt converts int64 to int without overflow.
+func SafeInt64ToInt(v int64) int {
+	if v > int64(math.MaxInt) {
+		return math.MaxInt
+	}
+	if v < int64(math.MinInt) {
+		return math.MinInt
+	}
+	return int(v)
+}
+
+// SafeUint64ToInt converts uint64 to int without overflow.
+func SafeUint64ToInt(v uint64) int {
+	if v > uint64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(v)
+}

--- a/internal/cron/member_levels.go
+++ b/internal/cron/member_levels.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	"gorm.io/gorm"
 )
 
@@ -86,13 +87,13 @@ func runUpdateMemberLevels(db *gorm.DB) (*MemberLevelsResult, error) {
 		if isExpired {
 			affected := updatePostVisibility(db, promo.MemberID, true)
 			if affected > 0 {
-				result.VisibilityCount += int(affected)
+				result.VisibilityCount += common.SafeInt64ToInt(affected)
 				result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): %d개 게시글 비공개 처리", promo.AdvertiserName, promo.MemberID, affected))
 			}
 		} else if isActive {
 			affected := updatePostVisibility(db, promo.MemberID, false)
 			if affected > 0 {
-				result.VisibilityCount += int(affected)
+				result.VisibilityCount += common.SafeInt64ToInt(affected)
 				result.Messages = append(result.Messages, fmt.Sprintf("%s(%s): %d개 게시글 공개 전환", promo.AdvertiserName, promo.MemberID, affected))
 			}
 		}

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	"gorm.io/gorm"
 )
 
@@ -763,7 +764,7 @@ func autoLockPost(tx *gorm.DB, boTable string, postID, threshold int) {
 		WHERE sg_table = ? AND (sg_id = ? OR sg_parent = ?) AND admin_approved = 1
 	`, boTable, postID, postID).Scan(&approvedCount)
 
-	if int(approvedCount) < threshold {
+	if common.SafeInt64ToInt(approvedCount) < threshold {
 		return
 	}
 
@@ -891,7 +892,7 @@ func autoLockComment(tx *gorm.DB, boTable string, commentID, parentID, threshold
 		WHERE sg_table = ? AND sg_id = ? AND sg_parent = ? AND admin_approved = 1
 	`, boTable, commentID, parentID).Scan(&approvedCount)
 
-	if int(approvedCount) < threshold {
+	if common.SafeInt64ToInt(approvedCount) < threshold {
 		return
 	}
 

--- a/internal/domain/gnuboard/member_activity.go
+++ b/internal/domain/gnuboard/member_activity.go
@@ -1,0 +1,46 @@
+package gnuboard
+
+import "time"
+
+// MemberActivityFeed represents a read-side activity entry from member_activity_feed.
+// This denormalized model exists to avoid repeated fan-out scans across g5_write_* tables.
+type MemberActivityFeed struct {
+	ID              uint64     `gorm:"column:id;primaryKey" json:"id"`
+	MemberID        string     `gorm:"column:member_id" json:"member_id"`
+	BoardID         string     `gorm:"column:board_id" json:"board_id"`
+	WriteTable      string     `gorm:"column:write_table" json:"write_table"`
+	WriteID         int        `gorm:"column:write_id" json:"write_id"`
+	ParentWriteID   *int       `gorm:"column:parent_write_id" json:"parent_write_id,omitempty"`
+	ActivityType    int8       `gorm:"column:activity_type" json:"activity_type"`
+	IsPublic        bool       `gorm:"column:is_public" json:"is_public"`
+	IsDeleted       bool       `gorm:"column:is_deleted" json:"is_deleted"`
+	Title           string     `gorm:"column:title" json:"title"`
+	ContentPreview  string     `gorm:"column:content_preview" json:"content_preview"`
+	ParentTitle     string     `gorm:"column:parent_title" json:"parent_title,omitempty"`
+	AuthorName      string     `gorm:"column:author_name" json:"author_name"`
+	WrOption        string     `gorm:"column:wr_option" json:"wr_option"`
+	ViewCount       int        `gorm:"column:view_count" json:"view_count"`
+	LikeCount       int        `gorm:"column:like_count" json:"like_count"`
+	DislikeCount    int        `gorm:"column:dislike_count" json:"dislike_count"`
+	CommentCount    int        `gorm:"column:comment_count" json:"comment_count"`
+	HasFile         bool       `gorm:"column:has_file" json:"has_file"`
+	SourceCreatedAt time.Time  `gorm:"column:source_created_at" json:"source_created_at"`
+	SourceUpdatedAt *time.Time `gorm:"column:source_updated_at" json:"source_updated_at,omitempty"`
+}
+
+func (MemberActivityFeed) TableName() string {
+	return "member_activity_feed"
+}
+
+type MemberActivityStatsRow struct {
+	MemberID           string `gorm:"column:member_id" json:"member_id"`
+	BoardID            string `gorm:"column:board_id" json:"board_id"`
+	PostCount          int64  `gorm:"column:post_count" json:"post_count"`
+	CommentCount       int64  `gorm:"column:comment_count" json:"comment_count"`
+	PublicPostCount    int64  `gorm:"column:public_post_count" json:"public_post_count"`
+	PublicCommentCount int64  `gorm:"column:public_comment_count" json:"public_comment_count"`
+}
+
+func (MemberActivityStatsRow) TableName() string {
+	return "member_activity_stats"
+}

--- a/internal/handler/v2/admin_settings_handler.go
+++ b/internal/handler/v2/admin_settings_handler.go
@@ -42,7 +42,7 @@ func (h *AdminSettingsHandler) UpdateReportLockThreshold(c *gin.Context) {
 		return
 	}
 
-	now := int(time.Now().Unix())
+	now := common.SafeInt64ToInt(time.Now().Unix())
 
 	// UPSERT into g5_kv_store
 	result := h.db.Exec(`

--- a/internal/handler/v2/exp_handler.go
+++ b/internal/handler/v2/exp_handler.go
@@ -104,7 +104,7 @@ func (h *ExpHandler) GetExpHistory(c *gin.Context) {
 	// Get summary as well
 	summary, _ := h.expRepo.GetSummary(mbID)
 
-	totalPages := (int(total) + limit - 1) / limit
+	totalPages := (common.SafeInt64ToInt(total) + limit - 1) / limit
 
 	common.V2Success(c, gin.H{
 		"summary": summary,
@@ -141,7 +141,7 @@ func (h *ExpHandler) AdminListMemberXP(c *gin.Context) {
 		return
 	}
 
-	totalPages := (int(total) + limit - 1) / limit
+	totalPages := (common.SafeInt64ToInt(total) + limit - 1) / limit
 
 	common.V2Success(c, gin.H{
 		"members": members,
@@ -180,7 +180,7 @@ func (h *ExpHandler) AdminGetMemberXPHistory(c *gin.Context) {
 
 	summary, _ := h.expRepo.GetSummary(mbID)
 
-	totalPages := (int(total) + limit - 1) / limit
+	totalPages := (common.SafeInt64ToInt(total) + limit - 1) / limit
 
 	common.V2Success(c, gin.H{
 		"summary": summary,

--- a/internal/handler/v2/favorite_handler.go
+++ b/internal/handler/v2/favorite_handler.go
@@ -78,7 +78,7 @@ func (h *FavoriteHandler) UpdateFavorites(c *gin.Context) {
 	}
 
 	key := fmt.Sprintf("favorites:%s", userID)
-	now := int(time.Now().Unix())
+	now := common.SafeInt64ToInt(time.Now().Unix())
 
 	result := h.db.Exec(`
 		INSERT INTO g5_kv_store (`+"`key`"+`, value_type, value_text, updated_at)

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -3,7 +3,6 @@ package v2
 import (
 	"fmt"
 	"log"
-	"math"
 	"net/http"
 	"slices"
 	"strconv"
@@ -1008,10 +1007,7 @@ func parsePagination(c *gin.Context) (int, int) {
 
 // safeUint64ToInt converts uint64 to int with overflow protection
 func safeUint64ToInt(v uint64) int {
-	if v > uint64(math.MaxInt) {
-		return math.MaxInt
-	}
-	return int(v)
+	return common.SafeUint64ToInt(v)
 }
 
 // createCommentNotification creates a notification for the post author when a comment is posted

--- a/internal/handler/v2/point_handler.go
+++ b/internal/handler/v2/point_handler.go
@@ -66,7 +66,7 @@ func (h *PointHandler) GetPointHistory(c *gin.Context) {
 	// Get summary as well
 	summary, _ := h.gnuPointRepo.GetSummary(mbID)
 
-	totalPages := (int(total) + limit - 1) / limit
+	totalPages := (common.SafeInt64ToInt(total) + limit - 1) / limit
 
 	common.V2Success(c, gin.H{
 		"summary": summary,

--- a/internal/migration/member_activity.go
+++ b/internal/migration/member_activity.go
@@ -1,0 +1,89 @@
+package migration
+
+import "gorm.io/gorm"
+
+// CreateMemberActivityTables creates the read-model tables used by member activity queries.
+// These tables are append/update targets for denormalized activity reads and must exist
+// before handlers rely on member_activity_feed as the primary read path.
+func CreateMemberActivityTables(db *gorm.DB) error {
+	feedDDL := `
+CREATE TABLE IF NOT EXISTS member_activity_feed (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  member_id VARCHAR(64) NOT NULL,
+  board_id VARCHAR(64) NOT NULL,
+  write_table VARCHAR(128) NOT NULL,
+  write_id BIGINT UNSIGNED NOT NULL,
+  parent_write_id BIGINT UNSIGNED DEFAULT NULL,
+  activity_type TINYINT UNSIGNED NOT NULL COMMENT '1=post, 2=comment',
+  is_public TINYINT(1) NOT NULL DEFAULT 1,
+  is_deleted TINYINT(1) NOT NULL DEFAULT 0,
+  title VARCHAR(255) DEFAULT NULL,
+  content_preview VARCHAR(255) DEFAULT NULL,
+  parent_title VARCHAR(255) DEFAULT NULL,
+  author_name VARCHAR(255) DEFAULT NULL,
+  wr_option VARCHAR(255) DEFAULT NULL,
+  view_count INT NOT NULL DEFAULT 0,
+  like_count INT NOT NULL DEFAULT 0,
+  dislike_count INT NOT NULL DEFAULT 0,
+  comment_count INT NOT NULL DEFAULT 0,
+  has_file TINYINT(1) NOT NULL DEFAULT 0,
+  source_created_at DATETIME NOT NULL,
+  source_updated_at DATETIME DEFAULT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_table_write_type (write_table, write_id, activity_type),
+  KEY idx_member_type_deleted_created (member_id, activity_type, is_deleted, source_created_at DESC, id DESC),
+  KEY idx_member_public_deleted_created (member_id, is_public, is_deleted, source_created_at DESC, id DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+
+	statsDDL := `
+CREATE TABLE IF NOT EXISTS member_activity_stats (
+  member_id VARCHAR(64) NOT NULL,
+  board_id VARCHAR(64) NOT NULL DEFAULT '',
+  post_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  comment_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  public_post_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  public_comment_count BIGINT UNSIGNED NOT NULL DEFAULT 0,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (member_id, board_id),
+  KEY idx_member (member_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+
+	if err := db.Exec(feedDDL).Error; err != nil {
+		return err
+	}
+	alterDDLs := map[string]string{
+		"view_count":    "ALTER TABLE member_activity_feed ADD COLUMN view_count INT NOT NULL DEFAULT 0",
+		"like_count":    "ALTER TABLE member_activity_feed ADD COLUMN like_count INT NOT NULL DEFAULT 0",
+		"dislike_count": "ALTER TABLE member_activity_feed ADD COLUMN dislike_count INT NOT NULL DEFAULT 0",
+		"comment_count": "ALTER TABLE member_activity_feed ADD COLUMN comment_count INT NOT NULL DEFAULT 0",
+		"has_file":      "ALTER TABLE member_activity_feed ADD COLUMN has_file TINYINT(1) NOT NULL DEFAULT 0",
+	}
+	for columnName, ddl := range alterDDLs {
+		exists, err := tableColumnExists(db, "member_activity_feed", columnName)
+		if err != nil {
+			return err
+		}
+		if exists {
+			continue
+		}
+		if err := db.Exec(ddl).Error; err != nil {
+			return err
+		}
+	}
+	return db.Exec(statsDDL).Error
+}
+
+func tableColumnExists(db *gorm.DB, tableName, columnName string) (bool, error) {
+	var count int64
+	err := db.Raw(`
+		SELECT COUNT(*)
+		  FROM information_schema.columns
+		 WHERE table_schema = DATABASE()
+		   AND table_name = ?
+		   AND column_name = ?`,
+		tableName, columnName,
+	).Scan(&count).Error
+	return count > 0, err
+}

--- a/internal/plugin/ratelimiter.go
+++ b/internal/plugin/ratelimiter.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 )
@@ -138,7 +139,7 @@ func (rl *RateLimiter) check(key string, cfg *RateLimitConfig) (bool, int, error
 		return false, 0, err
 	}
 
-	count := int(countCmd.Val())
+	count := common.SafeInt64ToInt(countCmd.Val())
 	remaining := cfg.Requests - count
 	if remaining < 0 {
 		remaining = 0

--- a/internal/repository/gnuboard/activity_repo.go
+++ b/internal/repository/gnuboard/activity_repo.go
@@ -1,0 +1,286 @@
+package gnuboard
+
+import (
+	"sync"
+	"time"
+
+	domain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+)
+
+const (
+	activityTypePost    int8 = 1
+	activityTypeComment int8 = 2
+)
+
+type activityCommentRef struct {
+	BoardID       string `gorm:"column:board_id"`
+	WriteID       int    `gorm:"column:write_id"`
+	ParentWriteID int    `gorm:"column:parent_write_id"`
+	ParentTitle   string `gorm:"column:parent_title"`
+}
+
+type activityPostRef struct {
+	BoardID string `gorm:"column:board_id"`
+	WriteID int    `gorm:"column:write_id"`
+}
+
+// MemberActivityRepository provides read access to the member_activity_feed read model.
+type MemberActivityRepository interface {
+	IsEnabled() bool
+	CountByMemberBoardType(mbID, boardID string, activityType int8) (int64, error)
+	CountByMemberType(mbID string, activityType int8) (int64, error)
+	ListWriteIDsByMemberBoardType(mbID, boardID string, activityType int8, limit int) ([]int, error)
+	ListPostRefsByMember(mbID string, offset, limit int) ([]activityPostRef, error)
+	ListCommentRefsByMember(mbID string, offset, limit int) ([]activityCommentRef, error)
+	ListPostsByMember(mbID string, offset, limit int) ([]gnudomain.MyPost, error)
+	ListCommentsByMember(mbID string, offset, limit int) ([]gnudomain.MyCommentRow, error)
+	ListCommentRefsByMemberBoardType(mbID, boardID string, limit int) ([]activityCommentRef, error)
+	ListBoardStatsByMember(mbID string) ([]domain.MemberActivityStatsRow, error)
+	ListPublicPostsByMember(mbID string, limit int) ([]domain.ActivityPost, error)
+	ListPublicCommentsByMember(mbID string, limit int) ([]domain.ActivityComment, error)
+}
+
+type memberActivityRepository struct {
+	db *gorm.DB
+}
+
+var memberActivityTableCache struct {
+	sync.RWMutex
+	exists    bool
+	checked   bool
+	expiresAt time.Time
+}
+
+const memberActivityTableCacheTTL = time.Minute
+
+func NewMemberActivityRepository(db *gorm.DB) MemberActivityRepository {
+	return &memberActivityRepository{db: db}
+}
+
+func (r *memberActivityRepository) IsEnabled() bool {
+	return r.hasFeedTable()
+}
+
+func (r *memberActivityRepository) CountByMemberBoardType(mbID, boardID string, activityType int8) (int64, error) {
+	if !r.hasFeedTable() {
+		return 0, gorm.ErrRecordNotFound
+	}
+
+	var count int64
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityType).
+		Count(&count).Error
+	return count, err
+}
+
+func (r *memberActivityRepository) CountByMemberType(mbID string, activityType int8) (int64, error) {
+	if !r.hasFeedTable() {
+		return 0, gorm.ErrRecordNotFound
+	}
+
+	var count int64
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityType).
+		Count(&count).Error
+	return count, err
+}
+
+func (r *memberActivityRepository) ListWriteIDsByMemberBoardType(mbID, boardID string, activityType int8, limit int) ([]int, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var rows []struct {
+		WriteID int `gorm:"column:write_id"`
+	}
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("write_id").
+		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityType).
+		Order("source_created_at DESC, id DESC").
+		Limit(limit).
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	writeIDs := make([]int, len(rows))
+	for i, row := range rows {
+		writeIDs[i] = row.WriteID
+	}
+	return writeIDs, nil
+}
+
+func (r *memberActivityRepository) ListCommentRefsByMemberBoardType(mbID, boardID string, limit int) ([]activityCommentRef, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var refs []activityCommentRef
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("write_id, COALESCE(parent_title, '') AS parent_title").
+		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityTypeComment).
+		Order("source_created_at DESC, id DESC").
+		Limit(limit).
+		Scan(&refs).Error
+	return refs, err
+}
+
+func (r *memberActivityRepository) ListPostRefsByMember(mbID string, offset, limit int) ([]activityPostRef, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var refs []activityPostRef
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("board_id, write_id").
+		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypePost).
+		Order("source_created_at DESC, id DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&refs).Error
+	return refs, err
+}
+
+func (r *memberActivityRepository) ListCommentRefsByMember(mbID string, offset, limit int) ([]activityCommentRef, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var refs []activityCommentRef
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("board_id, write_id, COALESCE(parent_write_id, 0) AS parent_write_id, COALESCE(parent_title, '') AS parent_title").
+		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypeComment).
+		Order("source_created_at DESC, id DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&refs).Error
+	return refs, err
+}
+
+func (r *memberActivityRepository) ListPostsByMember(mbID string, offset, limit int) ([]gnudomain.MyPost, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var posts []gnudomain.MyPost
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select(`
+			write_id AS wr_id,
+			COALESCE(title, '') AS wr_subject,
+			COALESCE(content_preview, '') AS wr_content,
+			view_count AS wr_hit,
+			like_count AS wr_good,
+			dislike_count AS wr_nogood,
+			comment_count AS wr_comment,
+			source_created_at AS wr_datetime,
+			member_id AS mb_id,
+			COALESCE(author_name, '') AS wr_name,
+			COALESCE(wr_option, '') AS wr_option,
+			CASE WHEN has_file = 1 THEN 1 ELSE 0 END AS wr_file,
+			board_id`).
+		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypePost).
+		Order("source_created_at DESC, id DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&posts).Error
+	return posts, err
+}
+
+func (r *memberActivityRepository) ListCommentsByMember(mbID string, offset, limit int) ([]gnudomain.MyCommentRow, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var comments []gnudomain.MyCommentRow
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select(`
+			write_id AS wr_id,
+			COALESCE(content_preview, '') AS wr_content,
+			source_created_at AS wr_datetime,
+			member_id AS mb_id,
+			COALESCE(author_name, '') AS wr_name,
+			COALESCE(parent_write_id, 0) AS wr_parent,
+			like_count AS wr_good,
+			dislike_count AS wr_nogood,
+			COALESCE(wr_option, '') AS wr_option,
+			COALESCE(parent_title, '') AS post_title,
+			board_id`).
+		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypeComment).
+		Order("source_created_at DESC, id DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&comments).Error
+	return comments, err
+}
+
+func (r *memberActivityRepository) ListBoardStatsByMember(mbID string) ([]domain.MemberActivityStatsRow, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var stats []domain.MemberActivityStatsRow
+	err := r.db.Model(&domain.MemberActivityStatsRow{}).
+		Where("member_id = ? AND board_id != '' AND (post_count > 0 OR comment_count > 0)", mbID).
+		Order("post_count + comment_count DESC, board_id ASC").
+		Find(&stats).Error
+	return stats, err
+}
+
+func (r *memberActivityRepository) ListPublicPostsByMember(mbID string, limit int) ([]domain.ActivityPost, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var posts []domain.ActivityPost
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("write_id AS wr_id, COALESCE(title, '') AS wr_subject, source_created_at AS wr_datetime, board_id").
+		Where("member_id = ? AND activity_type = ? AND is_public = 1 AND is_deleted = 0", mbID, activityTypePost).
+		Order("source_created_at DESC, id DESC").
+		Limit(limit).
+		Scan(&posts).Error
+	return posts, err
+}
+
+func (r *memberActivityRepository) ListPublicCommentsByMember(mbID string, limit int) ([]domain.ActivityComment, error) {
+	if !r.hasFeedTable() {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var comments []domain.ActivityComment
+	err := r.db.Model(&domain.MemberActivityFeed{}).
+		Select("write_id AS wr_id, COALESCE(content_preview, '') AS wr_content, COALESCE(parent_write_id, 0) AS wr_parent, source_created_at AS wr_datetime, board_id").
+		Where("member_id = ? AND activity_type = ? AND is_public = 1 AND is_deleted = 0", mbID, activityTypeComment).
+		Order("source_created_at DESC, id DESC").
+		Limit(limit).
+		Scan(&comments).Error
+	return comments, err
+}
+
+func (r *memberActivityRepository) hasFeedTable() bool {
+	now := time.Now()
+
+	memberActivityTableCache.RLock()
+	if memberActivityTableCache.checked && now.Before(memberActivityTableCache.expiresAt) {
+		exists := memberActivityTableCache.exists
+		memberActivityTableCache.RUnlock()
+		return exists
+	}
+	memberActivityTableCache.RUnlock()
+
+	var count int64
+	err := r.db.Raw(
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?",
+		"member_activity_feed",
+	).Scan(&count).Error
+	exists := err == nil && count > 0
+
+	memberActivityTableCache.Lock()
+	memberActivityTableCache.exists = exists
+	memberActivityTableCache.checked = true
+	memberActivityTableCache.expiresAt = now.Add(memberActivityTableCacheTTL)
+	memberActivityTableCache.Unlock()
+
+	return exists
+}

--- a/internal/repository/gnuboard/activity_repo.go
+++ b/internal/repository/gnuboard/activity_repo.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	domain "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
 )
@@ -37,9 +36,9 @@ type MemberActivityRepository interface {
 	ListPostsByMember(mbID string, offset, limit int) ([]gnudomain.MyPost, error)
 	ListCommentsByMember(mbID string, offset, limit int) ([]gnudomain.MyCommentRow, error)
 	ListCommentRefsByMemberBoardType(mbID, boardID string, limit int) ([]activityCommentRef, error)
-	ListBoardStatsByMember(mbID string) ([]domain.MemberActivityStatsRow, error)
-	ListPublicPostsByMember(mbID string, limit int) ([]domain.ActivityPost, error)
-	ListPublicCommentsByMember(mbID string, limit int) ([]domain.ActivityComment, error)
+	ListBoardStatsByMember(mbID string) ([]gnudomain.MemberActivityStatsRow, error)
+	ListPublicPostsByMember(mbID string, limit int) ([]gnudomain.ActivityPost, error)
+	ListPublicCommentsByMember(mbID string, limit int) ([]gnudomain.ActivityComment, error)
 }
 
 type memberActivityRepository struct {
@@ -69,7 +68,7 @@ func (r *memberActivityRepository) CountByMemberBoardType(mbID, boardID string, 
 	}
 
 	var count int64
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityType).
 		Count(&count).Error
 	return count, err
@@ -81,7 +80,7 @@ func (r *memberActivityRepository) CountByMemberType(mbID string, activityType i
 	}
 
 	var count int64
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityType).
 		Count(&count).Error
 	return count, err
@@ -95,7 +94,7 @@ func (r *memberActivityRepository) ListWriteIDsByMemberBoardType(mbID, boardID s
 	var rows []struct {
 		WriteID int `gorm:"column:write_id"`
 	}
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("write_id").
 		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityType).
 		Order("source_created_at DESC, id DESC").
@@ -118,7 +117,7 @@ func (r *memberActivityRepository) ListCommentRefsByMemberBoardType(mbID, boardI
 	}
 
 	var refs []activityCommentRef
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("write_id, COALESCE(parent_title, '') AS parent_title").
 		Where("member_id = ? AND board_id = ? AND activity_type = ? AND is_deleted = 0", mbID, boardID, activityTypeComment).
 		Order("source_created_at DESC, id DESC").
@@ -133,7 +132,7 @@ func (r *memberActivityRepository) ListPostRefsByMember(mbID string, offset, lim
 	}
 
 	var refs []activityPostRef
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("board_id, write_id").
 		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypePost).
 		Order("source_created_at DESC, id DESC").
@@ -149,7 +148,7 @@ func (r *memberActivityRepository) ListCommentRefsByMember(mbID string, offset, 
 	}
 
 	var refs []activityCommentRef
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("board_id, write_id, COALESCE(parent_write_id, 0) AS parent_write_id, COALESCE(parent_title, '') AS parent_title").
 		Where("member_id = ? AND activity_type = ? AND is_deleted = 0", mbID, activityTypeComment).
 		Order("source_created_at DESC, id DESC").
@@ -165,7 +164,7 @@ func (r *memberActivityRepository) ListPostsByMember(mbID string, offset, limit 
 	}
 
 	var posts []gnudomain.MyPost
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select(`
 			write_id AS wr_id,
 			COALESCE(title, '') AS wr_subject,
@@ -194,7 +193,7 @@ func (r *memberActivityRepository) ListCommentsByMember(mbID string, offset, lim
 	}
 
 	var comments []gnudomain.MyCommentRow
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select(`
 			write_id AS wr_id,
 			COALESCE(content_preview, '') AS wr_content,
@@ -215,26 +214,26 @@ func (r *memberActivityRepository) ListCommentsByMember(mbID string, offset, lim
 	return comments, err
 }
 
-func (r *memberActivityRepository) ListBoardStatsByMember(mbID string) ([]domain.MemberActivityStatsRow, error) {
+func (r *memberActivityRepository) ListBoardStatsByMember(mbID string) ([]gnudomain.MemberActivityStatsRow, error) {
 	if !r.hasFeedTable() {
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	var stats []domain.MemberActivityStatsRow
-	err := r.db.Model(&domain.MemberActivityStatsRow{}).
+	var stats []gnudomain.MemberActivityStatsRow
+	err := r.db.Model(&gnudomain.MemberActivityStatsRow{}).
 		Where("member_id = ? AND board_id != '' AND (post_count > 0 OR comment_count > 0)", mbID).
 		Order("post_count + comment_count DESC, board_id ASC").
 		Find(&stats).Error
 	return stats, err
 }
 
-func (r *memberActivityRepository) ListPublicPostsByMember(mbID string, limit int) ([]domain.ActivityPost, error) {
+func (r *memberActivityRepository) ListPublicPostsByMember(mbID string, limit int) ([]gnudomain.ActivityPost, error) {
 	if !r.hasFeedTable() {
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	var posts []domain.ActivityPost
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	var posts []gnudomain.ActivityPost
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("write_id AS wr_id, COALESCE(title, '') AS wr_subject, source_created_at AS wr_datetime, board_id").
 		Where("member_id = ? AND activity_type = ? AND is_public = 1 AND is_deleted = 0", mbID, activityTypePost).
 		Order("source_created_at DESC, id DESC").
@@ -243,13 +242,13 @@ func (r *memberActivityRepository) ListPublicPostsByMember(mbID string, limit in
 	return posts, err
 }
 
-func (r *memberActivityRepository) ListPublicCommentsByMember(mbID string, limit int) ([]domain.ActivityComment, error) {
+func (r *memberActivityRepository) ListPublicCommentsByMember(mbID string, limit int) ([]gnudomain.ActivityComment, error) {
 	if !r.hasFeedTable() {
 		return nil, gorm.ErrRecordNotFound
 	}
 
-	var comments []domain.ActivityComment
-	err := r.db.Model(&domain.MemberActivityFeed{}).
+	var comments []gnudomain.ActivityComment
+	err := r.db.Model(&gnudomain.MemberActivityFeed{}).
 		Select("write_id AS wr_id, COALESCE(content_preview, '') AS wr_content, COALESCE(parent_write_id, 0) AS wr_parent, source_created_at AS wr_datetime, board_id").
 		Where("member_id = ? AND activity_type = ? AND is_public = 1 AND is_deleted = 0", mbID, activityTypeComment).
 		Order("source_created_at DESC, id DESC").

--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
 
@@ -187,7 +188,7 @@ func (s *BoardWriteRestrictionService) countTodayPosts(boardSlug, memberID strin
 	if err != nil {
 		return 0, err
 	}
-	return int(count), nil
+	return common.SafeInt64ToInt(count), nil
 }
 
 // countTotalPosts counts all non-comment posts ever written by the member in the board.
@@ -201,7 +202,7 @@ func (s *BoardWriteRestrictionService) countTotalPosts(boardSlug, memberID strin
 	if err != nil {
 		return 0, err
 	}
-	return int(count), nil
+	return common.SafeInt64ToInt(count), nil
 }
 
 // parseWritingSettings extracts WritingSettings from the extended settings JSON.

--- a/internal/service/member_activity_sync.go
+++ b/internal/service/member_activity_sync.go
@@ -1,0 +1,852 @@
+package service
+
+import (
+	"fmt"
+	"html"
+	"regexp"
+	"strings"
+	"time"
+
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	memberActivityHTMLTagRe = regexp.MustCompile(`<[^>]*>`)
+	memberActivityEmoRe     = regexp.MustCompile(`\{emo:[^}]+\}`)
+	memberActivityWSRe      = regexp.MustCompile(`\s+`)
+	memberActivitySlugRe    = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+)
+
+type MemberActivitySyncService struct {
+	db *gorm.DB
+}
+
+type MemberActivityBackfillReport struct {
+	Scope             string
+	BoardSlug         string
+	PostCount         int64
+	CommentCount      int64
+	ProcessedPosts    int64
+	ProcessedComments int64
+}
+
+type MemberActivityVerifyReport struct {
+	Scope                 string
+	BoardSlug             string
+	SourcePosts           int64
+	FeedPosts             int64
+	SourceComments        int64
+	FeedComments          int64
+	SourceDeletedPosts    int64
+	FeedDeletedPosts      int64
+	SourceDeletedComments int64
+	FeedDeletedComments   int64
+}
+
+func NewMemberActivitySyncService(db *gorm.DB) *MemberActivitySyncService {
+	return &MemberActivitySyncService{db: db}
+}
+
+func (s *MemberActivitySyncService) SyncPost(postID uint64) error {
+	return s.syncPost(postID, true)
+}
+
+func (s *MemberActivitySyncService) syncPost(postID uint64, rebuildStats bool) error {
+	type postRow struct {
+		ID           uint64    `gorm:"column:id"`
+		BoardSlug    string    `gorm:"column:board_slug"`
+		MemberID     string    `gorm:"column:member_id"`
+		Author       string    `gorm:"column:author_name"`
+		Title        string    `gorm:"column:title"`
+		Content      string    `gorm:"column:content"`
+		ViewCount    int       `gorm:"column:view_count"`
+		LikeCount    int       `gorm:"column:like_count"`
+		DislikeCount int       `gorm:"column:dislike_count"`
+		CommentCount int       `gorm:"column:comment_count"`
+		IsSecret     bool      `gorm:"column:is_secret"`
+		Status       string    `gorm:"column:status"`
+		CreatedAt    time.Time `gorm:"column:created_at"`
+		UpdatedAt    time.Time `gorm:"column:updated_at"`
+	}
+
+	var row postRow
+	if err := s.db.Raw(`
+		SELECT p.id, b.slug AS board_slug, COALESCE(m.mb_id, '') AS member_id,
+		       COALESCE(m.mb_nick, '') AS author_name, p.title, p.content,
+		       p.view_count, p.like_count, p.dislike_count, p.comment_count,
+		       p.is_secret, p.status, p.created_at, p.updated_at
+		  FROM v2_posts p
+		  JOIN v2_boards b ON b.id = p.board_id
+		  LEFT JOIN g5_member m ON m.mb_no = p.user_id
+		 WHERE p.id = ?
+		 LIMIT 1`, postID).Scan(&row).Error; err != nil {
+		return err
+	}
+	if row.ID == 0 || row.MemberID == "" || row.BoardSlug == "" {
+		return nil
+	}
+
+	isPublic := !row.IsSecret && row.Status != "deleted" && s.isBoardSearchable(row.BoardSlug)
+	updatedAt := row.UpdatedAt
+	affectedMembers := []string{row.MemberID}
+	feed := &gnudomain.MemberActivityFeed{
+		MemberID:        row.MemberID,
+		BoardID:         row.BoardSlug,
+		WriteTable:      "v2_posts",
+		WriteID:         int(row.ID),
+		ActivityType:    1,
+		IsPublic:        isPublic,
+		IsDeleted:       row.Status == "deleted",
+		Title:           truncateForFeed(row.Title, 255),
+		ContentPreview:  buildContentPreview(row.Content, 200),
+		AuthorName:      row.Author,
+		WrOption:        wrOptionFromSecret(row.IsSecret),
+		ViewCount:       row.ViewCount,
+		LikeCount:       row.LikeCount,
+		DislikeCount:    row.DislikeCount,
+		CommentCount:    row.CommentCount,
+		SourceCreatedAt: row.CreatedAt,
+		SourceUpdatedAt: &updatedAt,
+	}
+	if err := s.upsertFeed(feed); err != nil {
+		return err
+	}
+
+	// Parent title/public visibility changes cascade to comment activity rows.
+	if err := s.db.Table("member_activity_feed").
+		Where("write_table = ? AND parent_write_id = ? AND activity_type = 2", "v2_comments", postID).
+		Updates(map[string]interface{}{
+			"parent_title":      truncateForFeed(row.Title, 255),
+			"is_public":         boolToInt(isPublic),
+			"source_updated_at": updatedAt,
+		}).Error; err != nil {
+		return err
+	}
+	if members, err := s.memberIDsForParent("v2_comments", int(postID)); err == nil {
+		affectedMembers = append(affectedMembers, members...)
+	}
+
+	if !rebuildStats {
+		return nil
+	}
+	return s.rebuildMemberBoardStats(row.BoardSlug, uniqueNonEmptyStrings(affectedMembers))
+}
+
+func (s *MemberActivitySyncService) SyncComment(commentID uint64) error {
+	return s.syncComment(commentID, true)
+}
+
+func (s *MemberActivitySyncService) syncComment(commentID uint64, rebuildStats bool) error {
+	type commentRow struct {
+		ID           uint64    `gorm:"column:id"`
+		PostID       uint64    `gorm:"column:post_id"`
+		BoardSlug    string    `gorm:"column:board_slug"`
+		MemberID     string    `gorm:"column:member_id"`
+		Author       string    `gorm:"column:author_name"`
+		Content      string    `gorm:"column:content"`
+		PostTitle    string    `gorm:"column:post_title"`
+		LikeCount    int       `gorm:"column:like_count"`
+		DislikeCount int       `gorm:"column:dislike_count"`
+		PostSecret   bool      `gorm:"column:post_secret"`
+		PostStatus   string    `gorm:"column:post_status"`
+		Status       string    `gorm:"column:status"`
+		CreatedAt    time.Time `gorm:"column:created_at"`
+		UpdatedAt    time.Time `gorm:"column:updated_at"`
+	}
+
+	var row commentRow
+	if err := s.db.Raw(`
+		SELECT c.id, c.post_id, b.slug AS board_slug, COALESCE(m.mb_id, '') AS member_id,
+		       COALESCE(m.mb_nick, '') AS author_name, c.content,
+		       c.like_count, c.dislike_count,
+		       COALESCE(p.title, '') AS post_title, p.is_secret AS post_secret,
+		       p.status AS post_status, c.status, c.created_at, c.updated_at
+		  FROM v2_comments c
+		  JOIN v2_posts p ON p.id = c.post_id
+		  JOIN v2_boards b ON b.id = p.board_id
+		  LEFT JOIN g5_member m ON m.mb_no = c.user_id
+		 WHERE c.id = ?
+		 LIMIT 1`, commentID).Scan(&row).Error; err != nil {
+		return err
+	}
+	if row.ID == 0 || row.MemberID == "" || row.BoardSlug == "" {
+		return nil
+	}
+
+	isPublic := row.Status != "deleted" &&
+		row.PostStatus != "deleted" &&
+		!row.PostSecret &&
+		s.isBoardSearchable(row.BoardSlug)
+	updatedAt := row.UpdatedAt
+	parentID := int(row.PostID)
+	feed := &gnudomain.MemberActivityFeed{
+		MemberID:        row.MemberID,
+		BoardID:         row.BoardSlug,
+		WriteTable:      "v2_comments",
+		WriteID:         int(row.ID),
+		ParentWriteID:   &parentID,
+		ActivityType:    2,
+		IsPublic:        isPublic,
+		IsDeleted:       row.Status == "deleted",
+		ContentPreview:  buildContentPreview(row.Content, 200),
+		ParentTitle:     truncateForFeed(row.PostTitle, 255),
+		AuthorName:      row.Author,
+		LikeCount:       row.LikeCount,
+		DislikeCount:    row.DislikeCount,
+		SourceCreatedAt: row.CreatedAt,
+		SourceUpdatedAt: &updatedAt,
+	}
+	if err := s.upsertFeed(feed); err != nil {
+		return err
+	}
+
+	if !rebuildStats {
+		return nil
+	}
+	return s.rebuildMemberBoardStats(row.BoardSlug, []string{row.MemberID})
+}
+
+func (s *MemberActivitySyncService) SyncLegacyPost(boardSlug string, wrID int) error {
+	return s.syncLegacyPost(boardSlug, wrID, true)
+}
+
+func (s *MemberActivitySyncService) syncLegacyPost(boardSlug string, wrID int, rebuildStats bool) error {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return err
+	}
+
+	type postRow struct {
+		ID           int       `gorm:"column:id"`
+		MemberID     string    `gorm:"column:member_id"`
+		Author       string    `gorm:"column:author_name"`
+		Title        string    `gorm:"column:title"`
+		Content      string    `gorm:"column:content"`
+		WrOption     string    `gorm:"column:wr_option"`
+		ViewCount    int       `gorm:"column:view_count"`
+		LikeCount    int       `gorm:"column:like_count"`
+		DislikeCount int       `gorm:"column:dislike_count"`
+		CommentCount int       `gorm:"column:comment_count"`
+		HasFile      bool      `gorm:"column:has_file"`
+		IsDeleted    bool      `gorm:"column:is_deleted"`
+		CreatedAt    time.Time `gorm:"column:created_at"`
+		UpdatedAt    time.Time `gorm:"column:updated_at"`
+	}
+
+	var row postRow
+	query := fmt.Sprintf(`
+		SELECT p.wr_id AS id,
+		       COALESCE(p.mb_id, '') AS member_id,
+		       COALESCE(p.wr_name, '') AS author_name,
+		       COALESCE(p.wr_subject, '') AS title,
+		       COALESCE(p.wr_content, '') AS content,
+		       COALESCE(p.wr_option, '') AS wr_option,
+		       COALESCE(p.wr_hit, 0) AS view_count,
+		       COALESCE(p.wr_good, 0) AS like_count,
+		       COALESCE(p.wr_nogood, 0) AS dislike_count,
+		       COALESCE(p.wr_comment, 0) AS comment_count,
+		       (COALESCE(p.wr_file, 0) > 0) AS has_file,
+		       (p.wr_deleted_at IS NOT NULL) AS is_deleted,
+		       p.wr_datetime AS created_at,
+		       CASE
+		           WHEN p.wr_last IS NULL OR p.wr_last = '' OR p.wr_last = '0000-00-00 00:00:00' THEN p.wr_datetime
+		           ELSE p.wr_last
+		       END AS updated_at
+		  FROM %s p
+		 WHERE p.wr_id = ?
+		   AND p.wr_is_comment = 0
+		 LIMIT 1`, tableName)
+	if err := s.db.Raw(query, wrID).Scan(&row).Error; err != nil {
+		return err
+	}
+	if row.ID == 0 || row.MemberID == "" {
+		return nil
+	}
+
+	isPublic := !row.IsDeleted &&
+		!strings.Contains(strings.ToLower(row.WrOption), "secret") &&
+		s.isBoardSearchable(boardSlug)
+	updatedAt := row.UpdatedAt
+	affectedMembers := []string{row.MemberID}
+	feed := &gnudomain.MemberActivityFeed{
+		MemberID:        row.MemberID,
+		BoardID:         boardSlug,
+		WriteTable:      tableName,
+		WriteID:         row.ID,
+		ActivityType:    1,
+		IsPublic:        isPublic,
+		IsDeleted:       row.IsDeleted,
+		Title:           truncateForFeed(row.Title, 255),
+		ContentPreview:  buildContentPreview(row.Content, 200),
+		AuthorName:      row.Author,
+		WrOption:        truncateForFeed(row.WrOption, 255),
+		ViewCount:       row.ViewCount,
+		LikeCount:       row.LikeCount,
+		DislikeCount:    row.DislikeCount,
+		CommentCount:    row.CommentCount,
+		HasFile:         row.HasFile,
+		SourceCreatedAt: row.CreatedAt,
+		SourceUpdatedAt: &updatedAt,
+	}
+	if err := s.upsertFeed(feed); err != nil {
+		return err
+	}
+
+	if err := s.db.Table("member_activity_feed").
+		Where("write_table = ? AND parent_write_id = ? AND activity_type = 2", tableName, wrID).
+		Updates(map[string]interface{}{
+			"parent_title":      truncateForFeed(row.Title, 255),
+			"is_public":         boolToInt(isPublic),
+			"source_updated_at": updatedAt,
+		}).Error; err != nil {
+		return err
+	}
+	if members, err := s.memberIDsForParent(tableName, wrID); err == nil {
+		affectedMembers = append(affectedMembers, members...)
+	}
+
+	if !rebuildStats {
+		return nil
+	}
+	return s.rebuildMemberBoardStats(boardSlug, uniqueNonEmptyStrings(affectedMembers))
+}
+
+func (s *MemberActivitySyncService) SyncLegacyComment(boardSlug string, wrID int) error {
+	return s.syncLegacyComment(boardSlug, wrID, true)
+}
+
+func (s *MemberActivitySyncService) syncLegacyComment(boardSlug string, wrID int, rebuildStats bool) error {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return err
+	}
+
+	type commentRow struct {
+		ID           int       `gorm:"column:id"`
+		ParentID     int       `gorm:"column:parent_id"`
+		MemberID     string    `gorm:"column:member_id"`
+		Author       string    `gorm:"column:author_name"`
+		Content      string    `gorm:"column:content"`
+		ParentTitle  string    `gorm:"column:parent_title"`
+		ParentOpt    string    `gorm:"column:parent_option"`
+		LikeCount    int       `gorm:"column:like_count"`
+		DislikeCount int       `gorm:"column:dislike_count"`
+		IsDeleted    bool      `gorm:"column:is_deleted"`
+		ParentGone   bool      `gorm:"column:parent_deleted"`
+		CreatedAt    time.Time `gorm:"column:created_at"`
+		UpdatedAt    time.Time `gorm:"column:updated_at"`
+	}
+
+	var row commentRow
+	query := fmt.Sprintf(`
+		SELECT c.wr_id AS id,
+		       c.wr_parent AS parent_id,
+		       COALESCE(c.mb_id, '') AS member_id,
+		       COALESCE(c.wr_name, '') AS author_name,
+		       COALESCE(c.wr_content, '') AS content,
+		       COALESCE(p.wr_subject, '') AS parent_title,
+		       COALESCE(p.wr_option, '') AS parent_option,
+		       COALESCE(c.wr_good, 0) AS like_count,
+		       COALESCE(c.wr_nogood, 0) AS dislike_count,
+		       (c.wr_deleted_at IS NOT NULL) AS is_deleted,
+		       (p.wr_deleted_at IS NOT NULL) AS parent_deleted,
+		       c.wr_datetime AS created_at,
+		       CASE
+		           WHEN c.wr_last IS NULL OR c.wr_last = '' OR c.wr_last = '0000-00-00 00:00:00' THEN c.wr_datetime
+		           ELSE c.wr_last
+		       END AS updated_at
+		  FROM %s c
+		  JOIN %s p ON p.wr_id = c.wr_parent AND p.wr_is_comment = 0
+		 WHERE c.wr_id = ?
+		   AND c.wr_is_comment = 1
+		 LIMIT 1`, tableName, tableName)
+	if err := s.db.Raw(query, wrID).Scan(&row).Error; err != nil {
+		return err
+	}
+	if row.ID == 0 || row.MemberID == "" {
+		return nil
+	}
+
+	isPublic := !row.IsDeleted &&
+		!row.ParentGone &&
+		!strings.Contains(strings.ToLower(row.ParentOpt), "secret") &&
+		s.isBoardSearchable(boardSlug)
+	updatedAt := row.UpdatedAt
+	parentID := row.ParentID
+	feed := &gnudomain.MemberActivityFeed{
+		MemberID:        row.MemberID,
+		BoardID:         boardSlug,
+		WriteTable:      tableName,
+		WriteID:         row.ID,
+		ParentWriteID:   &parentID,
+		ActivityType:    2,
+		IsPublic:        isPublic,
+		IsDeleted:       row.IsDeleted,
+		ContentPreview:  buildContentPreview(row.Content, 200),
+		ParentTitle:     truncateForFeed(row.ParentTitle, 255),
+		AuthorName:      row.Author,
+		LikeCount:       row.LikeCount,
+		DislikeCount:    row.DislikeCount,
+		SourceCreatedAt: row.CreatedAt,
+		SourceUpdatedAt: &updatedAt,
+	}
+	if err := s.upsertFeed(feed); err != nil {
+		return err
+	}
+
+	if !rebuildStats {
+		return nil
+	}
+	return s.rebuildMemberBoardStats(boardSlug, []string{row.MemberID})
+}
+
+func (s *MemberActivitySyncService) RemoveLegacyPost(boardSlug string, wrID int) error {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return err
+	}
+	memberIDs, err := s.memberIDsForWriteOrParent(tableName, wrID)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Where("write_table = ? AND (write_id = ? OR parent_write_id = ?)", tableName, wrID, wrID).
+		Delete(&gnudomain.MemberActivityFeed{}).Error; err != nil {
+		return err
+	}
+	return s.rebuildMemberBoardStats(boardSlug, memberIDs)
+}
+
+func (s *MemberActivitySyncService) RemoveLegacyComment(boardSlug string, wrID int) error {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return err
+	}
+	memberIDs, err := s.memberIDsForWriteOrParent(tableName, wrID)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Where("write_table = ? AND write_id = ? AND activity_type = 2", tableName, wrID).
+		Delete(&gnudomain.MemberActivityFeed{}).Error; err != nil {
+		return err
+	}
+	return s.rebuildMemberBoardStats(boardSlug, memberIDs)
+}
+
+func (s *MemberActivitySyncService) BackfillLegacyBoard(boardSlug string, batchSize int) (*MemberActivityBackfillReport, error) {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return nil, err
+	}
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+
+	report := &MemberActivityBackfillReport{Scope: "legacy", BoardSlug: boardSlug}
+	if err := s.db.Table(tableName).Where("wr_is_comment = 0 AND mb_id <> ''").Count(&report.PostCount).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table(tableName).Where("wr_is_comment = 1 AND mb_id <> ''").Count(&report.CommentCount).Error; err != nil {
+		return nil, err
+	}
+
+	var lastID int
+	for {
+		var postIDs []int
+		if err := s.db.Table(tableName).
+			Select("wr_id").
+			Where("wr_is_comment = 0 AND mb_id <> '' AND wr_id > ?", lastID).
+			Order("wr_id ASC").
+			Limit(batchSize).
+			Scan(&postIDs).Error; err != nil {
+			return nil, err
+		}
+		if len(postIDs) == 0 {
+			break
+		}
+		for _, id := range postIDs {
+			if err := s.syncLegacyPost(boardSlug, id, false); err != nil {
+				return nil, err
+			}
+			report.ProcessedPosts++
+			lastID = id
+		}
+	}
+
+	lastID = 0
+	for {
+		var commentIDs []int
+		if err := s.db.Table(tableName).
+			Select("wr_id").
+			Where("wr_is_comment = 1 AND mb_id <> '' AND wr_id > ?", lastID).
+			Order("wr_id ASC").
+			Limit(batchSize).
+			Scan(&commentIDs).Error; err != nil {
+			return nil, err
+		}
+		if len(commentIDs) == 0 {
+			break
+		}
+		for _, id := range commentIDs {
+			if err := s.syncLegacyComment(boardSlug, id, false); err != nil {
+				return nil, err
+			}
+			report.ProcessedComments++
+			lastID = id
+		}
+	}
+
+	return report, s.rebuildBoardStats(boardSlug)
+}
+
+func (s *MemberActivitySyncService) BackfillV2(batchSize int) (*MemberActivityBackfillReport, error) {
+	if batchSize <= 0 {
+		batchSize = 500
+	}
+	report := &MemberActivityBackfillReport{Scope: "v2"}
+
+	if err := s.db.Table("v2_posts p").
+		Joins("JOIN g5_member m ON m.mb_no = p.user_id").
+		Where("COALESCE(m.mb_id, '') <> ''").
+		Count(&report.PostCount).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("v2_comments c").
+		Joins("JOIN g5_member m ON m.mb_no = c.user_id").
+		Where("COALESCE(m.mb_id, '') <> ''").
+		Count(&report.CommentCount).Error; err != nil {
+		return nil, err
+	}
+
+	boardTouched := map[string]struct{}{}
+	var lastID uint64
+	for {
+		var postIDs []uint64
+		if err := s.db.Table("v2_posts").
+			Select("id").
+			Where("id > ?", lastID).
+			Order("id ASC").
+			Limit(batchSize).
+			Scan(&postIDs).Error; err != nil {
+			return nil, err
+		}
+		if len(postIDs) == 0 {
+			break
+		}
+		for _, id := range postIDs {
+			boardSlug, err := s.syncPostWithoutStats(id)
+			if err != nil {
+				return nil, err
+			}
+			if boardSlug != "" {
+				boardTouched[boardSlug] = struct{}{}
+				report.ProcessedPosts++
+			}
+			lastID = id
+		}
+	}
+
+	lastID = 0
+	for {
+		var commentIDs []uint64
+		if err := s.db.Table("v2_comments").
+			Select("id").
+			Where("id > ?", lastID).
+			Order("id ASC").
+			Limit(batchSize).
+			Scan(&commentIDs).Error; err != nil {
+			return nil, err
+		}
+		if len(commentIDs) == 0 {
+			break
+		}
+		for _, id := range commentIDs {
+			boardSlug, err := s.syncCommentWithoutStats(id)
+			if err != nil {
+				return nil, err
+			}
+			if boardSlug != "" {
+				boardTouched[boardSlug] = struct{}{}
+				report.ProcessedComments++
+			}
+			lastID = id
+		}
+	}
+
+	for boardSlug := range boardTouched {
+		if err := s.rebuildBoardStats(boardSlug); err != nil {
+			return nil, err
+		}
+	}
+
+	return report, nil
+}
+
+func (s *MemberActivitySyncService) VerifyLegacyBoard(boardSlug string) (*MemberActivityVerifyReport, error) {
+	tableName, err := legacyWriteTableName(boardSlug)
+	if err != nil {
+		return nil, err
+	}
+	report := &MemberActivityVerifyReport{Scope: "legacy", BoardSlug: boardSlug}
+
+	if err := s.db.Table(tableName).Where("wr_is_comment = 0 AND mb_id <> ''").Count(&report.SourcePosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table(tableName).Where("wr_is_comment = 1 AND mb_id <> ''").Count(&report.SourceComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table(tableName).Where("wr_is_comment = 0 AND mb_id <> '' AND wr_deleted_at IS NOT NULL").Count(&report.SourceDeletedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table(tableName).Where("wr_is_comment = 1 AND mb_id <> '' AND wr_deleted_at IS NOT NULL").Count(&report.SourceDeletedComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND board_id = ? AND activity_type = 1", tableName, boardSlug).Count(&report.FeedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND board_id = ? AND activity_type = 2", tableName, boardSlug).Count(&report.FeedComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND board_id = ? AND activity_type = 1 AND is_deleted = 1", tableName, boardSlug).Count(&report.FeedDeletedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND board_id = ? AND activity_type = 2 AND is_deleted = 1", tableName, boardSlug).Count(&report.FeedDeletedComments).Error; err != nil {
+		return nil, err
+	}
+
+	return report, nil
+}
+
+func (s *MemberActivitySyncService) VerifyV2() (*MemberActivityVerifyReport, error) {
+	report := &MemberActivityVerifyReport{Scope: "v2"}
+	if err := s.db.Table("v2_posts p").
+		Joins("JOIN g5_member m ON m.mb_no = p.user_id").
+		Where("COALESCE(m.mb_id, '') <> ''").
+		Count(&report.SourcePosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("v2_comments c").
+		Joins("JOIN g5_member m ON m.mb_no = c.user_id").
+		Where("COALESCE(m.mb_id, '') <> ''").
+		Count(&report.SourceComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("v2_posts p").
+		Joins("JOIN g5_member m ON m.mb_no = p.user_id").
+		Where("COALESCE(m.mb_id, '') <> '' AND p.status = ?", "deleted").
+		Count(&report.SourceDeletedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("v2_comments c").
+		Joins("JOIN g5_member m ON m.mb_no = c.user_id").
+		Where("COALESCE(m.mb_id, '') <> '' AND c.status = ?", "deleted").
+		Count(&report.SourceDeletedComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND activity_type = 1", "v2_posts").Count(&report.FeedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND activity_type = 2", "v2_comments").Count(&report.FeedComments).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND activity_type = 1 AND is_deleted = 1", "v2_posts").Count(&report.FeedDeletedPosts).Error; err != nil {
+		return nil, err
+	}
+	if err := s.db.Table("member_activity_feed").Where("write_table = ? AND activity_type = 2 AND is_deleted = 1", "v2_comments").Count(&report.FeedDeletedComments).Error; err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+func (s *MemberActivitySyncService) upsertFeed(feed *gnudomain.MemberActivityFeed) error {
+	return s.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "write_table"}, {Name: "write_id"}, {Name: "activity_type"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"member_id",
+			"board_id",
+			"parent_write_id",
+			"is_public",
+			"is_deleted",
+			"title",
+			"content_preview",
+			"parent_title",
+			"author_name",
+			"wr_option",
+			"view_count",
+			"like_count",
+			"dislike_count",
+			"comment_count",
+			"has_file",
+			"source_created_at",
+			"source_updated_at",
+			"updated_at",
+		}),
+	}).Create(feed).Error
+}
+
+func (s *MemberActivitySyncService) rebuildBoardStats(boardSlug string) error {
+	if err := s.db.Exec("DELETE FROM member_activity_stats WHERE board_id = ?", boardSlug).Error; err != nil {
+		return err
+	}
+
+	return s.db.Exec(`
+		INSERT INTO member_activity_stats
+		    (member_id, board_id, post_count, comment_count, public_post_count, public_comment_count)
+		SELECT
+		    member_id,
+		    board_id,
+		    SUM(CASE WHEN activity_type = 1 AND is_deleted = 0 THEN 1 ELSE 0 END) AS post_count,
+		    SUM(CASE WHEN activity_type = 2 AND is_deleted = 0 THEN 1 ELSE 0 END) AS comment_count,
+		    SUM(CASE WHEN activity_type = 1 AND is_deleted = 0 AND is_public = 1 THEN 1 ELSE 0 END) AS public_post_count,
+		    SUM(CASE WHEN activity_type = 2 AND is_deleted = 0 AND is_public = 1 THEN 1 ELSE 0 END) AS public_comment_count
+		  FROM member_activity_feed
+		 WHERE board_id = ?
+		 GROUP BY member_id, board_id`, boardSlug).Error
+}
+
+func (s *MemberActivitySyncService) rebuildMemberBoardStats(boardSlug string, memberIDs []string) error {
+	memberIDs = uniqueNonEmptyStrings(memberIDs)
+	if len(memberIDs) == 0 {
+		return nil
+	}
+	if err := s.db.Where("board_id = ? AND member_id IN ?", boardSlug, memberIDs).
+		Delete(&gnudomain.MemberActivityStatsRow{}).Error; err != nil {
+		return err
+	}
+	return s.db.Exec(`
+		INSERT INTO member_activity_stats
+		    (member_id, board_id, post_count, comment_count, public_post_count, public_comment_count)
+		SELECT
+		    member_id,
+		    board_id,
+		    SUM(CASE WHEN activity_type = 1 AND is_deleted = 0 THEN 1 ELSE 0 END) AS post_count,
+		    SUM(CASE WHEN activity_type = 2 AND is_deleted = 0 THEN 1 ELSE 0 END) AS comment_count,
+		    SUM(CASE WHEN activity_type = 1 AND is_deleted = 0 AND is_public = 1 THEN 1 ELSE 0 END) AS public_post_count,
+		    SUM(CASE WHEN activity_type = 2 AND is_deleted = 0 AND is_public = 1 THEN 1 ELSE 0 END) AS public_comment_count
+		  FROM member_activity_feed
+		 WHERE board_id = ?
+		   AND member_id IN ?
+		 GROUP BY member_id, board_id`, boardSlug, memberIDs).Error
+}
+
+func (s *MemberActivitySyncService) isBoardSearchable(boardSlug string) bool {
+	var boUseSearch int
+	if err := s.db.Table("g5_board").
+		Select("bo_use_search").
+		Where("bo_table = ?", boardSlug).
+		Scan(&boUseSearch).Error; err != nil {
+		return false
+	}
+	return boUseSearch == 1
+}
+
+func buildContentPreview(content string, maxLen int) string {
+	s := memberActivityHTMLTagRe.ReplaceAllString(content, "")
+	s = memberActivityEmoRe.ReplaceAllString(s, "")
+	s = html.UnescapeString(s)
+	s = memberActivityWSRe.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+	return truncateForFeed(s, maxLen)
+}
+
+func truncateForFeed(s string, maxLen int) string {
+	runes := []rune(strings.TrimSpace(s))
+	if len(runes) <= maxLen {
+		return string(runes)
+	}
+	return string(runes[:maxLen])
+}
+
+func wrOptionFromSecret(secret bool) string {
+	if secret {
+		return "secret"
+	}
+	return ""
+}
+
+func boolToInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func (s *MemberActivitySyncService) syncPostWithoutStats(postID uint64) (string, error) {
+	boardSlug, err := s.boardSlugForV2Post(postID)
+	if err != nil || boardSlug == "" {
+		return boardSlug, err
+	}
+	return boardSlug, s.syncPost(postID, false)
+}
+
+func (s *MemberActivitySyncService) syncCommentWithoutStats(commentID uint64) (string, error) {
+	boardSlug, err := s.boardSlugForV2Comment(commentID)
+	if err != nil || boardSlug == "" {
+		return boardSlug, err
+	}
+	return boardSlug, s.syncComment(commentID, false)
+}
+
+func (s *MemberActivitySyncService) boardSlugForV2Post(postID uint64) (string, error) {
+	var boardSlug string
+	err := s.db.Raw(`
+		SELECT b.slug
+		  FROM v2_posts p
+		  JOIN v2_boards b ON b.id = p.board_id
+		 WHERE p.id = ?
+		 LIMIT 1`, postID).Scan(&boardSlug).Error
+	return boardSlug, err
+}
+
+func (s *MemberActivitySyncService) boardSlugForV2Comment(commentID uint64) (string, error) {
+	var boardSlug string
+	err := s.db.Raw(`
+		SELECT b.slug
+		  FROM v2_comments c
+		  JOIN v2_posts p ON p.id = c.post_id
+		  JOIN v2_boards b ON b.id = p.board_id
+		 WHERE c.id = ?
+		 LIMIT 1`, commentID).Scan(&boardSlug).Error
+	return boardSlug, err
+}
+
+func legacyWriteTableName(boardSlug string) (string, error) {
+	if !memberActivitySlugRe.MatchString(boardSlug) {
+		return "", fmt.Errorf("invalid board slug: %q", boardSlug)
+	}
+	return "g5_write_" + boardSlug, nil
+}
+
+func (s *MemberActivitySyncService) memberIDsForParent(writeTable string, parentWriteID int) ([]string, error) {
+	return s.memberIDsByFeedWhere("write_table = ? AND parent_write_id = ? AND activity_type = 2", writeTable, parentWriteID)
+}
+
+func (s *MemberActivitySyncService) memberIDsForWriteOrParent(writeTable string, writeID int) ([]string, error) {
+	return s.memberIDsByFeedWhere("write_table = ? AND (write_id = ? OR parent_write_id = ?)", writeTable, writeID, writeID)
+}
+
+func (s *MemberActivitySyncService) memberIDsByFeedWhere(where string, args ...interface{}) ([]string, error) {
+	var memberIDs []string
+	err := s.db.Model(&gnudomain.MemberActivityFeed{}).
+		Distinct("member_id").
+		Where(where, args...).
+		Pluck("member_id", &memberIDs).Error
+	return uniqueNonEmptyStrings(memberIDs), err
+}
+
+func uniqueNonEmptyStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	return out
+}

--- a/internal/service/member_activity_sync.go
+++ b/internal/service/member_activity_sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/damoang/angple-backend/internal/common"
 	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -95,7 +96,7 @@ func (s *MemberActivitySyncService) syncPost(postID uint64, rebuildStats bool) e
 		MemberID:        row.MemberID,
 		BoardID:         row.BoardSlug,
 		WriteTable:      "v2_posts",
-		WriteID:         int(row.ID),
+		WriteID:         common.SafeUint64ToInt(row.ID),
 		ActivityType:    1,
 		IsPublic:        isPublic,
 		IsDeleted:       row.Status == "deleted",
@@ -124,7 +125,7 @@ func (s *MemberActivitySyncService) syncPost(postID uint64, rebuildStats bool) e
 		}).Error; err != nil {
 		return err
 	}
-	if members, err := s.memberIDsForParent("v2_comments", int(postID)); err == nil {
+	if members, err := s.memberIDsForParent("v2_comments", common.SafeUint64ToInt(postID)); err == nil {
 		affectedMembers = append(affectedMembers, members...)
 	}
 
@@ -180,12 +181,12 @@ func (s *MemberActivitySyncService) syncComment(commentID uint64, rebuildStats b
 		!row.PostSecret &&
 		s.isBoardSearchable(row.BoardSlug)
 	updatedAt := row.UpdatedAt
-	parentID := int(row.PostID)
+	parentID := common.SafeUint64ToInt(row.PostID)
 	feed := &gnudomain.MemberActivityFeed{
 		MemberID:        row.MemberID,
 		BoardID:         row.BoardSlug,
 		WriteTable:      "v2_comments",
-		WriteID:         int(row.ID),
+		WriteID:         common.SafeUint64ToInt(row.ID),
 		ParentWriteID:   &parentID,
 		ActivityType:    2,
 		IsPublic:        isPublic,


### PR DESCRIPTION
## Summary
- add member activity read model domain, repository, migration, and sync service
- add member-activity repair/backfill/verify CLI
- prepare feed-based read model workflows for safer activity reads

## Verification
- go test ./internal/repository/gnuboard/... ./internal/handler/... ./internal/service/... ./cmd/api ./internal/worker/...