### PR TITLE
fix: add idempotent write handling

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -92,6 +92,11 @@ type memCachedPosts struct {
 	expiresAt time.Time
 }
 
+type idempotencyCachedResponse struct {
+	Status int             `json:"status"`
+	Body   json.RawMessage `json:"body"`
+}
+
 var postMemCache sync.Map // key: "posts:{boardID}:{page}:{limit}"
 
 func makePostDedupKey(boardID, memberID, title string) string {
@@ -147,6 +152,88 @@ func getNextWrNumFast(ctx context.Context, db *gorm.DB, redisClient *redis.Clien
 		return minNum - 1, nil
 	}
 	return int(next), nil
+}
+
+func getIdempotencyBaseKey(c *gin.Context, memberID string) string {
+	idempotencyKey := strings.TrimSpace(c.GetHeader("X-Idempotency-Key"))
+	if idempotencyKey == "" {
+		return ""
+	}
+	return fmt.Sprintf("idempotency:%s:%s:%s:%s", memberID, c.Request.Method, c.FullPath(), idempotencyKey)
+}
+
+func getIdempotencyRespKey(baseKey string) string {
+	return baseKey + ":resp"
+}
+
+func getIdempotencyLockKey(baseKey string) string {
+	return baseKey + ":lock"
+}
+
+func loadIdempotencyCachedResponse(ctx context.Context, redisClient *redis.Client, baseKey string) (*idempotencyCachedResponse, error) {
+	if redisClient == nil || baseKey == "" {
+		return nil, nil
+	}
+	raw, err := redisClient.Get(ctx, getIdempotencyRespKey(baseKey)).Bytes()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var cached idempotencyCachedResponse
+	if err := json.Unmarshal(raw, &cached); err != nil {
+		return nil, err
+	}
+	return &cached, nil
+}
+
+func beginIdempotentWrite(ctx context.Context, redisClient *redis.Client, baseKey string) (string, *idempotencyCachedResponse) {
+	if redisClient == nil || baseKey == "" {
+		return "proceed", nil
+	}
+	if cached, err := loadIdempotencyCachedResponse(ctx, redisClient, baseKey); err == nil && cached != nil {
+		return "cached", cached
+	}
+	locked, err := redisClient.SetNX(ctx, getIdempotencyLockKey(baseKey), "1", 60*time.Second).Result()
+	if err != nil {
+		return "proceed", nil
+	}
+	if locked {
+		return "proceed", nil
+	}
+	if cached, err := loadIdempotencyCachedResponse(ctx, redisClient, baseKey); err == nil && cached != nil {
+		return "cached", cached
+	}
+	return "processing", nil
+}
+
+func storeIdempotentWriteResponse(ctx context.Context, redisClient *redis.Client, baseKey string, status int, payload interface{}) {
+	if redisClient == nil || baseKey == "" {
+		return
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		redisClient.Del(ctx, getIdempotencyLockKey(baseKey)) //nolint:errcheck
+		return
+	}
+	cachedBody, err := json.Marshal(idempotencyCachedResponse{
+		Status: status,
+		Body:   body,
+	})
+	if err != nil {
+		redisClient.Del(ctx, getIdempotencyLockKey(baseKey)) //nolint:errcheck
+		return
+	}
+	redisClient.Set(ctx, getIdempotencyRespKey(baseKey), cachedBody, 5*time.Minute) //nolint:errcheck
+	redisClient.Del(ctx, getIdempotencyLockKey(baseKey))                            //nolint:errcheck
+}
+
+func releaseIdempotentWrite(ctx context.Context, redisClient *redis.Client, baseKey string) {
+	if redisClient == nil || baseKey == "" {
+		return
+	}
+	redisClient.Del(ctx, getIdempotencyLockKey(baseKey)) //nolint:errcheck
 }
 
 // filterItems filters blocked users' posts from parsed items slice, preserving notice posts.
@@ -2033,8 +2120,18 @@ func main() {
 			}
 
 			tableName := fmt.Sprintf("g5_write_%s", slug)
+			idempotencyBaseKey := getIdempotencyBaseKey(c, mbID)
+			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
+			case "cached":
+				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
+				return
+			case "processing":
+				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
+				return
+			}
 			dedupKey, reserved := reservePostDedup(c.Request.Context(), redisClient, slug, mbID, req.Title)
 			if !reserved {
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": "같은 제목의 글이 방금 작성되었습니다."})
 				return
 			}
@@ -2043,6 +2140,7 @@ func main() {
 			nextWrNum, wrNumErr := getNextWrNumFast(c.Request.Context(), db, redisClient, slug)
 			if wrNumErr != nil {
 				releasePostDedup(c.Request.Context(), redisClient, dedupKey)
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "wr_num 생성 실패"})
 				return
 			}
@@ -2050,6 +2148,7 @@ func main() {
 
 			if err := db.Table(tableName).Create(&post).Error; err != nil {
 				releasePostDedup(c.Request.Context(), redisClient, dedupKey)
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 작성 실패"})
 				return
 			}
@@ -2154,10 +2253,12 @@ func main() {
 				}
 			}()
 
-			c.JSON(http.StatusCreated, gin.H{
+			payload := gin.H{
 				"success": true,
 				"data":    v1handler.TransformToV1PostDetail(&post, false),
-			})
+			}
+			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusCreated, payload)
+			c.JSON(http.StatusCreated, payload)
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/comments - Create comment in g5_write_{slug}
@@ -2224,12 +2325,22 @@ func main() {
 			now := time.Now()
 			nowStr := now.Format("2006-01-02 15:04:05")
 			tableName := fmt.Sprintf("g5_write_%s", slug)
+			idempotencyBaseKey := getIdempotencyBaseKey(c, mbID)
+			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
+			case "cached":
+				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
+				return
+			case "processing":
+				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
+				return
+			}
 
 			// 중복 댓글 방지: 10초 이내 같은 내용의 댓글이 있으면 거부
 			var dupCommentCount int64
 			db.Table(tableName).Where("mb_id = ? AND wr_content = ? AND wr_is_comment = 1 AND wr_parent = ? AND wr_datetime > ?",
 				mbID, req.Content, postID, time.Now().Add(-10*time.Second)).Count(&dupCommentCount)
 			if dupCommentCount > 0 {
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": "같은 내용의 댓글이 방금 작성되었습니다."})
 				return
 			}
@@ -2322,6 +2433,7 @@ func main() {
 			})
 
 			if txErr != nil {
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				switch txErr.Error() {
 				case "PARENT_NOT_FOUND":
 					c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "부모 댓글을 찾을 수 없습니다"})
@@ -2423,7 +2535,7 @@ func main() {
 				}
 			}()
 
-			c.JSON(http.StatusCreated, gin.H{
+			payload := gin.H{
 				"success": true,
 				"data": gin.H{
 					"id":         comment.WrID,
@@ -2438,7 +2550,9 @@ func main() {
 					"created_at": now.Format(time.RFC3339),
 					"is_secret":  false,
 				},
-			})
+			}
+			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusCreated, payload)
+			c.JSON(http.StatusCreated, payload)
 		})
 
 		// PUT /api/v1/boards/:slug/posts/:id - Update post
@@ -2548,8 +2662,19 @@ func main() {
 				return
 			}
 
+			idempotencyBaseKey := getIdempotencyBaseKey(c, userID)
+			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
+			case "cached":
+				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
+				return
+			case "processing":
+				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
+				return
+			}
+
 			tableName := fmt.Sprintf("g5_write_%s", slug)
 			if err := db.Table(tableName).Where("wr_id = ?", postID).Updates(updates).Error; err != nil {
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 수정 실패"})
 				return
 			}
@@ -2573,7 +2698,9 @@ func main() {
 				return true
 			})
 
-			c.JSON(http.StatusOK, gin.H{"success": true, "message": "수정 완료"})
+			payload := gin.H{"success": true, "message": "수정 완료"}
+			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusOK, payload)
+			c.JSON(http.StatusOK, payload)
 		})
 
 		// PUT /api/v1/boards/:slug/posts/:id/comments/:comment_id - Update comment
@@ -2609,6 +2736,16 @@ func main() {
 				return
 			}
 
+			idempotencyBaseKey := getIdempotencyBaseKey(c, userID)
+			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
+			case "cached":
+				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
+				return
+			case "processing":
+				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
+				return
+			}
+
 			// 수정 전 내용을 리비전에 저장
 			var nextVersion int
 			db.Raw("SELECT COALESCE(MAX(version), 0) + 1 FROM g5_write_revisions WHERE board_id = ? AND wr_id = ?",
@@ -2637,6 +2774,7 @@ func main() {
 				"wr_content": req.Content,
 				"wr_last":    now,
 			}).Error; err != nil {
+				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 수정 실패"})
 				return
 			}
@@ -2647,7 +2785,9 @@ func main() {
 				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
 			}
 
-			c.JSON(http.StatusOK, gin.H{"success": true, "message": "수정 완료"})
+			payload := gin.H{"success": true, "message": "수정 완료"}
+			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusOK, payload)
+			c.JSON(http.StatusOK, payload)
 		})
 
 		// GET /api/v1/boards/:slug/posts/:id/comments/:comment_id/revisions - Get comment revision history

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -50,6 +52,7 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/redis/go-redis/v9"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"gorm.io/driver/mysql"
@@ -90,6 +93,61 @@ type memCachedPosts struct {
 }
 
 var postMemCache sync.Map // key: "posts:{boardID}:{page}:{limit}"
+
+func makePostDedupKey(boardID, memberID, title string) string {
+	sum := sha1.Sum([]byte(strings.TrimSpace(strings.ToLower(title))))
+	return fmt.Sprintf("write:dedupe:%s:%s:%s", boardID, memberID, hex.EncodeToString(sum[:]))
+}
+
+func reservePostDedup(ctx context.Context, redisClient *redis.Client, boardID, memberID, title string) (string, bool) {
+	if redisClient == nil {
+		return "", true
+	}
+	key := makePostDedupKey(boardID, memberID, title)
+	ok, err := redisClient.SetNX(ctx, key, "1", 30*time.Second).Result()
+	if err != nil {
+		return "", true
+	}
+	return key, ok
+}
+
+func releasePostDedup(ctx context.Context, redisClient *redis.Client, key string) {
+	if redisClient == nil || key == "" {
+		return
+	}
+	redisClient.Del(ctx, key) //nolint:errcheck
+}
+
+func getNextWrNumFast(ctx context.Context, db *gorm.DB, redisClient *redis.Client, boardID string) (int, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardID)
+	if redisClient == nil {
+		var minNum int
+		if err := db.Table(tableName).Select("COALESCE(MIN(wr_num), 0)").Scan(&minNum).Error; err != nil {
+			return 0, err
+		}
+		return minNum - 1, nil
+	}
+
+	key := fmt.Sprintf("board:wr_num:%s", boardID)
+	exists, err := redisClient.Exists(ctx, key).Result()
+	if err == nil && exists == 0 {
+		var minNum int64
+		if scanErr := db.Table(tableName).Select("COALESCE(MIN(wr_num), 0)").Scan(&minNum).Error; scanErr != nil {
+			return 0, scanErr
+		}
+		redisClient.SetNX(ctx, key, minNum, 0) //nolint:errcheck
+	}
+
+	next, err := redisClient.Decr(ctx, key).Result()
+	if err != nil {
+		var minNum int
+		if scanErr := db.Table(tableName).Select("COALESCE(MIN(wr_num), 0)").Scan(&minNum).Error; scanErr != nil {
+			return 0, scanErr
+		}
+		return minNum - 1, nil
+	}
+	return int(next), nil
+}
 
 // filterItems filters blocked users' posts from parsed items slice, preserving notice posts.
 func filterItems(items []map[string]any, blockedIDs []string) []map[string]any {
@@ -1975,22 +2033,23 @@ func main() {
 			}
 
 			tableName := fmt.Sprintf("g5_write_%s", slug)
-
-			// 중복 작성 방지: 30초 이내 같은 제목의 글이 있으면 거부
-			var dupPostCount int64
-			db.Table(tableName).Where("mb_id = ? AND wr_subject = ? AND wr_is_comment = 0 AND wr_datetime > ?",
-				mbID, req.Title, time.Now().Add(-30*time.Second)).Count(&dupPostCount)
-			if dupPostCount > 0 {
+			dedupKey, reserved := reservePostDedup(c.Request.Context(), redisClient, slug, mbID, req.Title)
+			if !reserved {
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": "같은 제목의 글이 방금 작성되었습니다."})
 				return
 			}
 
 			// wr_num 값 계산 (가장 작은 음수값 - 1, gnuboard 정렬 규칙)
-			var minNum int
-			db.Table(tableName).Select("COALESCE(MIN(wr_num), 0)").Scan(&minNum)
-			post.WrNum = minNum - 1
+			nextWrNum, wrNumErr := getNextWrNumFast(c.Request.Context(), db, redisClient, slug)
+			if wrNumErr != nil {
+				releasePostDedup(c.Request.Context(), redisClient, dedupKey)
+				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "wr_num 생성 실패"})
+				return
+			}
+			post.WrNum = nextWrNum
 
 			if err := db.Table(tableName).Create(&post).Error; err != nil {
+				releasePostDedup(c.Request.Context(), redisClient, dedupKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 작성 실패"})
 				return
 			}


### PR DESCRIPTION
## Summary
- add Redis-backed idempotency handling for post/comment create and update endpoints
- cache successful write responses and replay them for duplicate requests
- reject concurrent duplicate writes while the first request is still processing

## Validation
- go test ./cmd/api
