### PR TITLE
fix: scope login XP dedupe to login table

### DIFF
--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -259,8 +259,8 @@ func (r *expRepository) HasTodayAction(mbID, action string) (bool, error) {
 	tomorrowStart := todayStart.AddDate(0, 0, 1)
 	var count int64
 	err := r.db.Model(&gnuboard.G5NaXP{}).
-		Where("mb_id = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?",
-			mbID, action, todayStart, tomorrowStart).
+		Where("mb_id = ? AND xp_rel_table = ? AND xp_rel_action = ? AND xp_datetime >= ? AND xp_datetime < ?",
+			mbID, "@login", action, todayStart, tomorrowStart).
 		Count(&count).Error
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary
- restrict login XP dedupe to xp_rel_table='@login'
- avoid treating backfill rows as today's real login XP

## Verification
- go test ./internal/repository/v2/...
- production remediation applied for today's affected members
