### PR TITLE
perf: move legacy write after-work to worker

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -975,6 +974,7 @@ func main() {
 		// v1 notifications (g5_na_noti)
 		notiRepo := gnurepo.NewNotiRepository(db)
 		notiPrefRepo := gnurepo.NewNotiPreferenceRepository(db)
+		memberActivitySync := service.NewMemberActivitySyncService(db)
 		notiHandler := handler.NewNotiHandler(notiRepo, notiPrefRepo)
 		notiGroup := router.Group("/api/v1/notifications", middleware.JWTAuth(jwtManager))
 		notiGroup.GET("/unread-count", notiHandler.GetUnreadCount)
@@ -1378,6 +1378,17 @@ func main() {
 			}
 			return ids
 		}
+		writeAfterWorker := worker.NewWriteAfterWorker(
+			db,
+			cacheService,
+			notiRepo,
+			notiPrefRepo,
+			memberActivitySync,
+			getBlockedIDs,
+			worker.ClearPostMemCache(&postMemCache),
+		)
+		writeAfterWorker.Start(4)
+		defer writeAfterWorker.Stop()
 
 		// v1 block routes
 		v1Members := router.Group("/api/v1/members")
@@ -2294,72 +2305,14 @@ func main() {
 				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoWritePoint, "글쓰기", tableName, fmt.Sprintf("%d", post.WrID), "@write", pc) //nolint:errcheck
 			}
 
-			// 응답 이후 처리: 캐시 무효화 + 알림
-			go func() {
-				if cacheService != nil {
-					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-					defer cancel()
-					_ = cacheService.InvalidatePosts(ctx, slug)
-				}
-				postMemCache.Range(func(key, value interface{}) bool {
-					if strings.HasPrefix(key.(string), "posts:"+slug+":") {
-						postMemCache.Delete(key)
-					}
-					return true
-				})
-
-				authorName := post.WrName
-				if authorName == "" {
-					authorName = mbID
-				}
-				subject := post.WrSubject
-				now := time.Now()
-
-				// 1. 팔로워 알림: 이 작성자를 팔로우한 사람들
-				var followerIDs []string
-				db.Table("g5_member_follow").Select("mb_id").Where("target_id = ?", mbID).Pluck("mb_id", &followerIDs)
-				for _, fid := range followerIDs {
-					if pref, _ := notiPrefRepo.Get(fid); !pref.NotiFollow {
-						continue
-					}
-					_ = notiRepo.Create(&gnurepo.Notification{
-						PhToCase: "follow", PhFromCase: "write", BoTable: slug,
-						WrID: post.WrID, MbID: fid, RelMbID: mbID,
-						RelMbNick:  authorName,
-						RelMsg:     fmt.Sprintf("%s님이 새 글을 작성했습니다: %s", authorName, subject),
-						RelURL:     fmt.Sprintf("/%s/%d", slug, post.WrID),
-						PhReaded:   "N",
-						PhDatetime: now,
-						WrParent:   post.WrID,
-					})
-				}
-
-				// 2. 게시판 구독자 알림: 이 게시판을 구독한 사람들 (작성자 제외, 팔로워 중복 제외)
-				var subscriberIDs []string
-				db.Table("g5_board_subscribe").Select("mb_id").Where("bo_table = ? AND mb_id != ?", slug, mbID).Pluck("mb_id", &subscriberIDs)
-				followerSet := make(map[string]bool, len(followerIDs))
-				for _, fid := range followerIDs {
-					followerSet[fid] = true
-				}
-				for _, sid := range subscriberIDs {
-					if followerSet[sid] {
-						continue // 이미 팔로워 알림 받음
-					}
-					if pref, _ := notiPrefRepo.Get(sid); !pref.NotiFollow {
-						continue
-					}
-					_ = notiRepo.Create(&gnurepo.Notification{
-						PhToCase: "subscribe", PhFromCase: "write", BoTable: slug,
-						WrID: post.WrID, MbID: sid, RelMbID: mbID,
-						RelMbNick:  authorName,
-						RelMsg:     fmt.Sprintf("%s 게시판에 새 글: %s", slug, subject),
-						RelURL:     fmt.Sprintf("/%s/%d", slug, post.WrID),
-						PhReaded:   "N",
-						PhDatetime: now,
-						WrParent:   post.WrID,
-					})
-				}
-			}()
+			writeAfterWorker.Enqueue(worker.PostCreatedJob{
+				BoardSlug: slug,
+				WriteID:   post.WrID,
+				MemberID:  mbID,
+				Author:    post.WrName,
+				Subject:   post.WrSubject,
+				CreatedAt: now,
+			})
 
 			payload := gin.H{
 				"success": true,
@@ -2578,80 +2531,15 @@ func main() {
 				commentIP = comment.WrIP
 			}
 
-			// 응답 이후 처리: 캐시 무효화 + 알림
-			go func() {
-				if cacheService != nil {
-					ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-					defer cancel()
-					_ = cacheService.InvalidateComments(ctx, slug, postID)
-					_ = cacheService.InvalidatePosts(ctx, slug)
-				}
-				postMemCache.Range(func(key, value interface{}) bool {
-					if strings.HasPrefix(key.(string), "posts:"+slug+":") {
-						postMemCache.Delete(key)
-					}
-					return true
-				})
-
-				// 게시글 작성자 조회
-				var postAuthor struct {
-					MbID      string `gorm:"column:mb_id"`
-					WrSubject string `gorm:"column:wr_subject"`
-				}
-				if err := db.Table(tableName).Select("mb_id, wr_subject").Where("wr_id = ? AND wr_is_comment = 0", postID).Scan(&postAuthor).Error; err != nil || postAuthor.MbID == "" {
-					return
-				}
-
-				// 대댓글인 경우: 부모 댓글 작성자에게 알림
-				if req.ParentID != nil && *req.ParentID > 0 {
-					var parentAuthorMbID string
-					if err := db.Table(tableName).Select("mb_id").Where("wr_id = ?", *req.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != mbID {
-						// 수신자가 발신자를 차단한 경우 알림 생략 (Redis 캐시 활용)
-						if slices.Contains(getBlockedIDs(context.Background(), parentAuthorMbID), mbID) {
-							// skip
-						} else if pref, _ := notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
-							_ = notiRepo.Create(&gnurepo.Notification{
-								PhToCase:      "comment_reply",
-								PhFromCase:    "comment",
-								BoTable:       slug,
-								WrID:          comment.WrID,
-								MbID:          parentAuthorMbID,
-								RelMbID:       mbID,
-								RelMbNick:     authorName,
-								RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", authorName),
-								RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
-								PhReaded:      "N",
-								PhDatetime:    now,
-								ParentSubject: postAuthor.WrSubject,
-								WrParent:      postID,
-							})
-						}
-					}
-				}
-
-				// 게시글 작성자에게 알림 (자기 댓글은 제외, 차단한 사용자 제외)
-				if postAuthor.MbID != mbID {
-					if slices.Contains(getBlockedIDs(context.Background(), postAuthor.MbID), mbID) {
-						// 게시글 작성자가 댓글 작성자를 차단한 경우 알림 생략
-					} else if pref, _ := notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
-						_ = notiRepo.Create(&gnurepo.Notification{
-							PhToCase:      "comment",
-							PhFromCase:    "comment",
-							BoTable:       slug,
-							WrID:          comment.WrID,
-							MbID:          postAuthor.MbID,
-							RelMbID:       mbID,
-							RelMbNick:     authorName,
-							RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", authorName),
-							RelURL:        fmt.Sprintf("/%s/%d#comment_%d", slug, postID, comment.WrID),
-							PhReaded:      "N",
-							PhDatetime:    now,
-							ParentSubject: postAuthor.WrSubject,
-							WrParent:      postID,
-						})
-					}
-				}
-			}()
+			writeAfterWorker.Enqueue(worker.CommentCreatedJob{
+				BoardSlug: slug,
+				WriteID:   comment.WrID,
+				PostID:    postID,
+				ParentID:  req.ParentID,
+				MemberID:  mbID,
+				Author:    authorName,
+				CreatedAt: now,
+			})
 
 			payload := gin.H{
 				"success": true,

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -1,0 +1,286 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	pkgcache "github.com/damoang/angple-backend/pkg/cache"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	"github.com/damoang/angple-backend/internal/service"
+	"gorm.io/gorm"
+)
+
+type BlockedIDsProvider func(ctx context.Context, userID string) []string
+type ClearPostMemCacheFunc func(boardSlug string)
+
+type WriteAfterWorker struct {
+	db             *gorm.DB
+	cacheService   pkgcache.Service
+	notiRepo       gnurepo.NotiRepository
+	notiPrefRepo   gnurepo.NotiPreferenceRepository
+	activitySync   *service.MemberActivitySyncService
+	getBlockedIDs  BlockedIDsProvider
+	clearPostCache ClearPostMemCacheFunc
+
+	jobs chan any
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+type PostCreatedJob struct {
+	BoardSlug string
+	WriteID   int
+	MemberID  string
+	Author    string
+	Subject   string
+	CreatedAt time.Time
+}
+
+type CommentCreatedJob struct {
+	BoardSlug string
+	WriteID   int
+	PostID    int
+	ParentID  *int
+	MemberID  string
+	Author    string
+	CreatedAt time.Time
+}
+
+func NewWriteAfterWorker(
+	db *gorm.DB,
+	cacheService pkgcache.Service,
+	notiRepo gnurepo.NotiRepository,
+	notiPrefRepo gnurepo.NotiPreferenceRepository,
+	activitySync *service.MemberActivitySyncService,
+	getBlockedIDs BlockedIDsProvider,
+	clearPostCache ClearPostMemCacheFunc,
+) *WriteAfterWorker {
+	return &WriteAfterWorker{
+		db:             db,
+		cacheService:   cacheService,
+		notiRepo:       notiRepo,
+		notiPrefRepo:   notiPrefRepo,
+		activitySync:   activitySync,
+		getBlockedIDs:  getBlockedIDs,
+		clearPostCache: clearPostCache,
+		jobs:           make(chan any, 2048),
+		stop:           make(chan struct{}),
+	}
+}
+
+func (w *WriteAfterWorker) Start(concurrency int) {
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	for i := 0; i < concurrency; i++ {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			for {
+				select {
+				case <-w.stop:
+					return
+				case job := <-w.jobs:
+					w.handle(job)
+				}
+			}
+		}()
+	}
+	log.Printf("[WriteAfterWorker] Started with %d workers", concurrency)
+}
+
+func (w *WriteAfterWorker) Stop() {
+	close(w.stop)
+	w.wg.Wait()
+	log.Printf("[WriteAfterWorker] Stopped")
+}
+
+func (w *WriteAfterWorker) Enqueue(job any) {
+	select {
+	case w.jobs <- job:
+	default:
+		log.Printf("[WriteAfterWorker] queue full, fallback async processing for %T", job)
+		go w.handle(job)
+	}
+}
+
+func (w *WriteAfterWorker) handle(job any) {
+	switch j := job.(type) {
+	case PostCreatedJob:
+		w.handlePostCreated(j)
+	case CommentCreatedJob:
+		w.handleCommentCreated(j)
+	default:
+		log.Printf("[WriteAfterWorker] unknown job type %T", job)
+	}
+}
+
+func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
+	if w.cacheService != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = w.cacheService.InvalidatePosts(ctx, job.BoardSlug)
+		cancel()
+	}
+	if w.clearPostCache != nil {
+		w.clearPostCache(job.BoardSlug)
+	}
+	if w.activitySync != nil {
+		if err := w.activitySync.SyncLegacyPost(job.BoardSlug, job.WriteID); err != nil {
+			log.Printf("[WriteAfterWorker] activity sync failed for post %s/%d: %v", job.BoardSlug, job.WriteID, err)
+		}
+	}
+	if w.db == nil || w.notiRepo == nil || w.notiPrefRepo == nil {
+		return
+	}
+
+	authorName := job.Author
+	if authorName == "" {
+		authorName = job.MemberID
+	}
+
+	var followerIDs []string
+	w.db.Table("g5_member_follow").Select("mb_id").Where("target_id = ?", job.MemberID).Pluck("mb_id", &followerIDs)
+	for _, fid := range followerIDs {
+		if pref, _ := w.notiPrefRepo.Get(fid); !pref.NotiFollow {
+			continue
+		}
+		_ = w.notiRepo.Create(&gnurepo.Notification{
+			PhToCase: "follow", PhFromCase: "write", BoTable: job.BoardSlug,
+			WrID: job.WriteID, MbID: fid, RelMbID: job.MemberID,
+			RelMbNick:  authorName,
+			RelMsg:     fmt.Sprintf("%s님이 새 글을 작성했습니다: %s", authorName, job.Subject),
+			RelURL:     fmt.Sprintf("/%s/%d", job.BoardSlug, job.WriteID),
+			PhReaded:   "N",
+			PhDatetime: job.CreatedAt,
+			WrParent:   job.WriteID,
+		})
+	}
+
+	var subscriberIDs []string
+	w.db.Table("g5_board_subscribe").Select("mb_id").Where("bo_table = ? AND mb_id != ?", job.BoardSlug, job.MemberID).Pluck("mb_id", &subscriberIDs)
+	followerSet := make(map[string]bool, len(followerIDs))
+	for _, fid := range followerIDs {
+		followerSet[fid] = true
+	}
+	for _, sid := range subscriberIDs {
+		if followerSet[sid] {
+			continue
+		}
+		if pref, _ := w.notiPrefRepo.Get(sid); !pref.NotiFollow {
+			continue
+		}
+		_ = w.notiRepo.Create(&gnurepo.Notification{
+			PhToCase: "subscribe", PhFromCase: "write", BoTable: job.BoardSlug,
+			WrID: job.WriteID, MbID: sid, RelMbID: job.MemberID,
+			RelMbNick:  authorName,
+			RelMsg:     fmt.Sprintf("%s 게시판에 새 글: %s", job.BoardSlug, job.Subject),
+			RelURL:     fmt.Sprintf("/%s/%d", job.BoardSlug, job.WriteID),
+			PhReaded:   "N",
+			PhDatetime: job.CreatedAt,
+			WrParent:   job.WriteID,
+		})
+	}
+}
+
+func (w *WriteAfterWorker) handleCommentCreated(job CommentCreatedJob) {
+	if w.cacheService != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = w.cacheService.InvalidateComments(ctx, job.BoardSlug, job.PostID)
+		_ = w.cacheService.InvalidatePosts(ctx, job.BoardSlug)
+		cancel()
+	}
+	if w.clearPostCache != nil {
+		w.clearPostCache(job.BoardSlug)
+	}
+	if w.activitySync != nil {
+		if err := w.activitySync.SyncLegacyComment(job.BoardSlug, job.WriteID); err != nil {
+			log.Printf("[WriteAfterWorker] activity sync failed for comment %s/%d: %v", job.BoardSlug, job.WriteID, err)
+		}
+	}
+	if w.db == nil || w.notiRepo == nil || w.notiPrefRepo == nil {
+		return
+	}
+
+	tableName := "g5_write_" + job.BoardSlug
+	var postAuthor struct {
+		MbID      string `gorm:"column:mb_id"`
+		WrSubject string `gorm:"column:wr_subject"`
+	}
+	if err := w.db.Table(tableName).Select("mb_id, wr_subject").Where("wr_id = ? AND wr_is_comment = 0", job.PostID).Scan(&postAuthor).Error; err != nil || postAuthor.MbID == "" {
+		return
+	}
+
+	if job.ParentID != nil && *job.ParentID > 0 {
+		var parentAuthorMbID string
+		if err := w.db.Table(tableName).Select("mb_id").Where("wr_id = ?", *job.ParentID).Scan(&parentAuthorMbID).Error; err == nil && parentAuthorMbID != "" && parentAuthorMbID != job.MemberID {
+			if !w.isBlocked(parentAuthorMbID, job.MemberID) {
+				if pref, _ := w.notiPrefRepo.Get(parentAuthorMbID); pref.NotiReply {
+					_ = w.notiRepo.Create(&gnurepo.Notification{
+						PhToCase:      "comment_reply",
+						PhFromCase:    "comment",
+						BoTable:       job.BoardSlug,
+						WrID:          job.WriteID,
+						MbID:          parentAuthorMbID,
+						RelMbID:       job.MemberID,
+						RelMbNick:     job.Author,
+						RelMsg:        fmt.Sprintf("%s님이 회원님의 댓글에 답글을 남겼습니다.", job.Author),
+						RelURL:        fmt.Sprintf("/%s/%d#comment_%d", job.BoardSlug, job.PostID, job.WriteID),
+						PhReaded:      "N",
+						PhDatetime:    job.CreatedAt,
+						ParentSubject: postAuthor.WrSubject,
+						WrParent:      job.PostID,
+					})
+				}
+			}
+		}
+	}
+
+	if postAuthor.MbID == job.MemberID || w.isBlocked(postAuthor.MbID, job.MemberID) {
+		return
+	}
+	if pref, _ := w.notiPrefRepo.Get(postAuthor.MbID); pref.NotiComment {
+		_ = w.notiRepo.Create(&gnurepo.Notification{
+			PhToCase:      "comment",
+			PhFromCase:    "comment",
+			BoTable:       job.BoardSlug,
+			WrID:          job.WriteID,
+			MbID:          postAuthor.MbID,
+			RelMbID:       job.MemberID,
+			RelMbNick:     job.Author,
+			RelMsg:        fmt.Sprintf("%s님이 회원님의 글에 댓글을 남겼습니다.", job.Author),
+			RelURL:        fmt.Sprintf("/%s/%d#comment_%d", job.BoardSlug, job.PostID, job.WriteID),
+			PhReaded:      "N",
+			PhDatetime:    job.CreatedAt,
+			ParentSubject: postAuthor.WrSubject,
+			WrParent:      job.PostID,
+		})
+	}
+}
+
+func (w *WriteAfterWorker) isBlocked(targetUserID, actorUserID string) bool {
+	if w.getBlockedIDs == nil || targetUserID == "" || actorUserID == "" {
+		return false
+	}
+	return slices.Contains(w.getBlockedIDs(context.Background(), targetUserID), actorUserID)
+}
+
+func ClearPostMemCache(postMemCache *sync.Map) func(string) {
+	return func(slug string) {
+		if postMemCache == nil {
+			return
+		}
+		postMemCache.Range(func(key, value interface{}) bool {
+			keyStr, ok := key.(string)
+			if ok && strings.HasPrefix(keyStr, "posts:"+slug+":") {
+				postMemCache.Delete(key)
+			}
+			return true
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- move legacy post/comment after_write cache invalidation, notifications, and activity sync into a background worker
- keep v1 create post/comment response path focused on transaction + response payload
- reuse a bounded worker queue instead of spawning ad-hoc goroutines per request

## Test Plan
- go test ./cmd/api ./internal/worker/...
