### PR TITLE
feat: add durable write-after outbox

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -52,6 +52,8 @@ import (
 	"github.com/gin-gonic/gin"
 	mysqldriver "github.com/go-sql-driver/mysql"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 	swaggerFiles "github.com/swaggo/files"
@@ -100,6 +102,14 @@ type idempotencyCachedResponse struct {
 
 var postMemCache sync.Map // key: "posts:{boardID}:{page}:{limit}"
 
+var writeDuplicateDetectedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "write_duplicate_detected_total",
+		Help: "Total number of duplicate or replayed write requests detected",
+	},
+	[]string{"operation", "reason"},
+)
+
 func makePostDedupKey(boardID, memberID, title string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(strings.ToLower(title))))
 	return fmt.Sprintf("write:dedupe:%s:%s:%s", boardID, memberID, hex.EncodeToString(sum[:]))
@@ -125,6 +135,56 @@ func releasePostDedup(ctx context.Context, redisClient *redis.Client, key string
 		return
 	}
 	redisClient.Del(ctx, key) //nolint:errcheck
+}
+
+func createWriteAfterEvent(tx *gorm.DB, repo gnurepo.WriteAfterEventRepository, eventType, boardSlug string, writeID int, opts ...func(*gnuboard.WriteAfterEvent)) error {
+	if tx == nil || repo == nil {
+		return nil
+	}
+	event := &gnuboard.WriteAfterEvent{
+		EventType:  eventType,
+		BoardSlug:  boardSlug,
+		WriteID:    writeID,
+		Status:     gnuboard.WriteAfterEventStatusPending,
+		OccurredAt: time.Now(),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(event)
+		}
+	}
+	return repo.Create(tx, event)
+}
+
+func withWriteAfterPostID(postID int) func(*gnuboard.WriteAfterEvent) {
+	return func(event *gnuboard.WriteAfterEvent) {
+		event.PostID = &postID
+	}
+}
+
+func withWriteAfterParentID(parentID *int) func(*gnuboard.WriteAfterEvent) {
+	return func(event *gnuboard.WriteAfterEvent) {
+		event.ParentID = parentID
+	}
+}
+
+func withWriteAfterMember(memberID, author string) func(*gnuboard.WriteAfterEvent) {
+	return func(event *gnuboard.WriteAfterEvent) {
+		event.MemberID = memberID
+		event.Author = author
+	}
+}
+
+func withWriteAfterSubject(subject string) func(*gnuboard.WriteAfterEvent) {
+	return func(event *gnuboard.WriteAfterEvent) {
+		event.Subject = subject
+	}
+}
+
+func withWriteAfterOccurredAt(occurredAt time.Time) func(*gnuboard.WriteAfterEvent) {
+	return func(event *gnuboard.WriteAfterEvent) {
+		event.OccurredAt = occurredAt
+	}
 }
 
 func makeCommentDedupKey(boardID, memberID string, postID int, parentID *int, content string) string {
@@ -1378,12 +1438,14 @@ func main() {
 			}
 			return ids
 		}
+		writeAfterEventRepo := gnurepo.NewWriteAfterEventRepository(db)
 		writeAfterWorker := worker.NewWriteAfterWorker(
 			db,
 			cacheService,
 			notiRepo,
 			notiPrefRepo,
 			memberActivitySync,
+			writeAfterEventRepo,
 			getBlockedIDs,
 			worker.ClearPostMemCache(&postMemCache),
 		)
@@ -2233,14 +2295,17 @@ func main() {
 			idempotencyBaseKey := getIdempotencyBaseKey(c, mbID)
 			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
 			case "cached":
+				writeDuplicateDetectedTotal.WithLabelValues("create_post", "idempotency_cached").Inc()
 				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
 				return
 			case "processing":
+				writeDuplicateDetectedTotal.WithLabelValues("create_post", "idempotency_processing").Inc()
 				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
 				return
 			}
 			dedupKey, reserved := reservePostDedup(c.Request.Context(), redisClient, slug, mbID, req.Title)
 			if !reserved {
+				writeDuplicateDetectedTotal.WithLabelValues("create_post", "dedupe").Inc()
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": "같은 제목의 글이 방금 작성되었습니다."})
 				return
@@ -2260,15 +2325,33 @@ func main() {
 			phaseDurations["wr_num"] = time.Since(phaseStart)
 			phaseStart = time.Now()
 
-			if err := db.Table(tableName).Create(&post).Error; err != nil {
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Table(tableName).Create(&post).Error; err != nil {
+					return err
+				}
+				if err := tx.Table(tableName).Where("wr_id = ?", post.WrID).Update("wr_parent", post.WrID).Error; err != nil {
+					return err
+				}
+				if err := createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypePostCreated,
+					slug,
+					post.WrID,
+					withWriteAfterMember(mbID, post.WrName),
+					withWriteAfterSubject(post.WrSubject),
+					withWriteAfterOccurredAt(now),
+				); err != nil {
+					return err
+				}
+				return nil
+			})
+			if txErr != nil {
 				releasePostDedup(c.Request.Context(), redisClient, dedupKey)
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 작성 실패"})
 				return
 			}
-
-			// wr_parent를 자기 자신의 wr_id로 UPDATE (gnuboard 규칙)
-			db.Table(tableName).Where("wr_id = ?", post.WrID).Update("wr_parent", post.WrID)
 			phaseDurations["insert"] = time.Since(phaseStart)
 			phaseStart = time.Now()
 
@@ -2304,15 +2387,6 @@ func main() {
 				}
 				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoWritePoint, "글쓰기", tableName, fmt.Sprintf("%d", post.WrID), "@write", pc) //nolint:errcheck
 			}
-
-			writeAfterWorker.Enqueue(worker.PostCreatedJob{
-				BoardSlug: slug,
-				WriteID:   post.WrID,
-				MemberID:  mbID,
-				Author:    post.WrName,
-				Subject:   post.WrSubject,
-				CreatedAt: now,
-			})
 
 			payload := gin.H{
 				"success": true,
@@ -2398,14 +2472,17 @@ func main() {
 			idempotencyBaseKey := getIdempotencyBaseKey(c, mbID)
 			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
 			case "cached":
+				writeDuplicateDetectedTotal.WithLabelValues("create_comment", "idempotency_cached").Inc()
 				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
 				return
 			case "processing":
+				writeDuplicateDetectedTotal.WithLabelValues("create_comment", "idempotency_processing").Inc()
 				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
 				return
 			}
 			dedupKey, reserved := reserveCommentDedup(c.Request.Context(), redisClient, slug, mbID, postID, req.ParentID, req.Content)
 			if !reserved {
+				writeDuplicateDetectedTotal.WithLabelValues("create_comment", "dedupe").Inc()
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusConflict, gin.H{"success": false, "error": "같은 내용의 댓글이 방금 작성되었습니다."})
 				return
@@ -2496,6 +2573,20 @@ func main() {
 					return err
 				}
 
+				if err := createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypeCommentCreated,
+					slug,
+					createdComment.WrID,
+					withWriteAfterPostID(postID),
+					withWriteAfterParentID(req.ParentID),
+					withWriteAfterMember(mbID, authorName),
+					withWriteAfterOccurredAt(now),
+				); err != nil {
+					return err
+				}
+
 				return nil
 			})
 			phaseDurations["transaction"] = time.Since(phaseStart)
@@ -2530,16 +2621,6 @@ func main() {
 			if middleware.GetUserLevel(c) >= 10 {
 				commentIP = comment.WrIP
 			}
-
-			writeAfterWorker.Enqueue(worker.CommentCreatedJob{
-				BoardSlug: slug,
-				WriteID:   comment.WrID,
-				PostID:    postID,
-				ParentID:  req.ParentID,
-				MemberID:  mbID,
-				Author:    authorName,
-				CreatedAt: now,
-			})
 
 			payload := gin.H{
 				"success": true,
@@ -2673,15 +2754,31 @@ func main() {
 			idempotencyBaseKey := getIdempotencyBaseKey(c, userID)
 			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
 			case "cached":
+				writeDuplicateDetectedTotal.WithLabelValues("update_post", "idempotency_cached").Inc()
 				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
 				return
 			case "processing":
+				writeDuplicateDetectedTotal.WithLabelValues("update_post", "idempotency_processing").Inc()
 				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
 				return
 			}
 
 			tableName := fmt.Sprintf("g5_write_%s", slug)
-			if err := db.Table(tableName).Where("wr_id = ?", postID).Updates(updates).Error; err != nil {
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Table(tableName).Where("wr_id = ?", postID).Updates(updates).Error; err != nil {
+					return err
+				}
+				return createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypePostUpdated,
+					slug,
+					postID,
+					withWriteAfterMember(post.MbID, post.WrName),
+					withWriteAfterSubject(post.WrSubject),
+				)
+			})
+			if txErr != nil {
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 수정 실패"})
 				return
@@ -2693,18 +2790,6 @@ func main() {
 					fmt.Printf("[WARN] tag update failed for %s/%d: %v\n", slug, postID, err)
 				}
 			}
-
-			// 캐시 무효화: 게시글 상세 + 목록
-			if cacheService != nil {
-				_ = cacheService.InvalidatePost(c.Request.Context(), slug, postID)
-				_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
-			}
-			postMemCache.Range(func(key, value interface{}) bool {
-				if strings.HasPrefix(key.(string), "posts:"+slug+":") {
-					postMemCache.Delete(key)
-				}
-				return true
-			})
 
 			payload := gin.H{"success": true, "message": "수정 완료"}
 			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusOK, payload)
@@ -2747,9 +2832,11 @@ func main() {
 			idempotencyBaseKey := getIdempotencyBaseKey(c, userID)
 			switch state, cached := beginIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey); state {
 			case "cached":
+				writeDuplicateDetectedTotal.WithLabelValues("update_comment", "idempotency_cached").Inc()
 				c.Data(cached.Status, "application/json; charset=utf-8", cached.Body)
 				return
 			case "processing":
+				writeDuplicateDetectedTotal.WithLabelValues("update_comment", "idempotency_processing").Inc()
 				c.JSON(http.StatusAccepted, gin.H{"success": false, "error": "동일 요청을 처리 중입니다. 잠시만 기다려주세요."})
 				return
 			}
@@ -2778,19 +2865,28 @@ func main() {
 
 			tableName := fmt.Sprintf("g5_write_%s", slug)
 			now := time.Now().Format("2006-01-02 15:04:05")
-			if err := db.Table(tableName).Where("wr_id = ?", commentID).Updates(map[string]interface{}{
-				"wr_content": req.Content,
-				"wr_last":    now,
-			}).Error; err != nil {
+			postID, _ := strconv.Atoi(c.Param("id"))
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Table(tableName).Where("wr_id = ?", commentID).Updates(map[string]interface{}{
+					"wr_content": req.Content,
+					"wr_last":    now,
+				}).Error; err != nil {
+					return err
+				}
+				return createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypeCommentUpdated,
+					slug,
+					commentID,
+					withWriteAfterPostID(postID),
+					withWriteAfterMember(comment.MbID, comment.WrName),
+				)
+			})
+			if txErr != nil {
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 수정 실패"})
 				return
-			}
-
-			// 캐시 무효화: 댓글 목록
-			if cacheService != nil {
-				postID, _ := strconv.Atoi(c.Param("id"))
-				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
 			}
 
 			payload := gin.H{"success": true, "message": "수정 완료"}
@@ -2890,21 +2986,29 @@ func main() {
 
 			// 관리자(level >= 10)는 즉시 삭제
 			if userLevel >= 10 {
-				if err := gnuWriteRepo.SoftDeletePost(slug, postID, userID); err != nil {
+				txErr := db.Transaction(func(tx *gorm.DB) error {
+					now := time.Now()
+					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ?", postID).Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": userID,
+					}).Error; err != nil {
+						return err
+					}
+					return createWriteAfterEvent(
+						tx,
+						writeAfterEventRepo,
+						gnuboard.WriteAfterEventTypePostDeleted,
+						slug,
+						postID,
+						withWriteAfterMember(post.MbID, post.WrName),
+						withWriteAfterSubject(post.WrSubject),
+						withWriteAfterOccurredAt(now),
+					)
+				})
+				if txErr != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
 					return
 				}
-				// 캐시 무효화: 게시글 상세 + 목록
-				if cacheService != nil {
-					_ = cacheService.InvalidatePost(c.Request.Context(), slug, postID)
-					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
-				}
-				postMemCache.Range(func(key, value interface{}) bool {
-					if strings.HasPrefix(key.(string), "posts:"+slug+":") {
-						postMemCache.Delete(key)
-					}
-					return true
-				})
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
 			}
@@ -2984,7 +3088,24 @@ func main() {
 			}
 
 			// 게시글 복구
-			if err := gnuWriteRepo.RestorePost(slug, postID); err != nil {
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ?", postID).Updates(map[string]interface{}{
+					"wr_deleted_at": nil,
+					"wr_deleted_by": nil,
+				}).Error; err != nil {
+					return err
+				}
+				return createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypePostRestored,
+					slug,
+					postID,
+					withWriteAfterMember(post.MbID, post.WrName),
+					withWriteAfterSubject(post.WrSubject),
+				)
+			})
+			if txErr != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 복구 실패"})
 				return
 			}
@@ -3051,17 +3172,31 @@ func main() {
 			// 관리자(level >= 10)는 즉시 삭제
 			postID, _ := strconv.Atoi(c.Param("id"))
 			if userLevel >= 10 {
-				if err := gnuWriteRepo.SoftDeleteComment(slug, commentID, userID); err != nil {
+				txErr := db.Transaction(func(tx *gorm.DB) error {
+					now := time.Now()
+					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": userID,
+					}).Error; err != nil {
+						return err
+					}
+					if err := adjustPostCommentCount(tx, slug, postID, -1); err != nil {
+						return err
+					}
+					return createWriteAfterEvent(
+						tx,
+						writeAfterEventRepo,
+						gnuboard.WriteAfterEventTypeCommentDeleted,
+						slug,
+						commentID,
+						withWriteAfterPostID(postID),
+						withWriteAfterMember(comment.MbID, comment.WrName),
+						withWriteAfterOccurredAt(now),
+					)
+				})
+				if txErr != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 삭제 실패"})
 					return
-				}
-				if err := adjustPostCommentCount(db, slug, postID, -1); err != nil {
-					pkglogger.Info("comment_count_adjust_failed board=%s post_id=%d delta=-1 comment_id=%d err=%v", slug, postID, commentID, err)
-				}
-				// 캐시 무효화: 댓글 + 게시글 목록 (댓글 수 변경)
-				if cacheService != nil {
-					_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
-					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
@@ -3078,17 +3213,31 @@ func main() {
 
 			if delayMinutes == 0 {
 				// 답글 없으면 즉시 삭제
-				if err := gnuWriteRepo.SoftDeleteComment(slug, commentID, userID); err != nil {
+				txErr := db.Transaction(func(tx *gorm.DB) error {
+					now := time.Now()
+					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": userID,
+					}).Error; err != nil {
+						return err
+					}
+					if err := adjustPostCommentCount(tx, slug, postID, -1); err != nil {
+						return err
+					}
+					return createWriteAfterEvent(
+						tx,
+						writeAfterEventRepo,
+						gnuboard.WriteAfterEventTypeCommentDeleted,
+						slug,
+						commentID,
+						withWriteAfterPostID(postID),
+						withWriteAfterMember(comment.MbID, comment.WrName),
+						withWriteAfterOccurredAt(now),
+					)
+				})
+				if txErr != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 삭제 실패"})
 					return
-				}
-				if err := adjustPostCommentCount(db, slug, postID, -1); err != nil {
-					pkglogger.Info("comment_count_adjust_failed board=%s post_id=%d delta=-1 comment_id=%d err=%v", slug, postID, commentID, err)
-				}
-				// 캐시 무효화: 댓글 + 게시글 목록 (댓글 수 변경)
-				if cacheService != nil {
-					_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
-					_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
@@ -3152,19 +3301,29 @@ func main() {
 			}
 
 			// 댓글 복구
-			if err := gnuWriteRepo.RestoreComment(slug, commentID); err != nil {
+			postID, _ := strconv.Atoi(c.Param("id"))
+			txErr := db.Transaction(func(tx *gorm.DB) error {
+				if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
+					"wr_deleted_at": nil,
+					"wr_deleted_by": nil,
+				}).Error; err != nil {
+					return err
+				}
+				if err := adjustPostCommentCount(tx, slug, postID, 1); err != nil {
+					return err
+				}
+				return createWriteAfterEvent(
+					tx,
+					writeAfterEventRepo,
+					gnuboard.WriteAfterEventTypeCommentRestored,
+					slug,
+					commentID,
+					withWriteAfterPostID(postID),
+				)
+			})
+			if txErr != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 복구 실패"})
 				return
-			}
-
-			// 캐시 무효화
-			postID, _ := strconv.Atoi(c.Param("id"))
-			if err := adjustPostCommentCount(db, slug, postID, 1); err != nil {
-				pkglogger.Info("comment_count_adjust_failed board=%s post_id=%d delta=1 comment_id=%d err=%v", slug, postID, commentID, err)
-			}
-			if cacheService != nil {
-				_ = cacheService.InvalidateComments(c.Request.Context(), slug, postID)
-				_ = cacheService.InvalidatePosts(c.Request.Context(), slug)
 			}
 
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "댓글 복구 완료"})
@@ -4555,7 +4714,7 @@ func main() {
 		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
 
 		// Start delete worker for delayed deletion processing
-		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo)
+		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo, writeAfterEventRepo)
 		deleteWorker.Start()
 		defer deleteWorker.Stop()
 	} else {

--- a/internal/domain/gnuboard/write_after_event.go
+++ b/internal/domain/gnuboard/write_after_event.go
@@ -1,0 +1,43 @@
+package gnuboard
+
+import "time"
+
+const (
+	WriteAfterEventTypePostCreated     = "post_created"
+	WriteAfterEventTypeCommentCreated  = "comment_created"
+	WriteAfterEventTypePostUpdated     = "post_updated"
+	WriteAfterEventTypeCommentUpdated  = "comment_updated"
+	WriteAfterEventTypePostDeleted     = "post_deleted"
+	WriteAfterEventTypeCommentDeleted  = "comment_deleted"
+	WriteAfterEventTypePostRestored    = "post_restored"
+	WriteAfterEventTypeCommentRestored = "comment_restored"
+
+	WriteAfterEventStatusPending    = "pending"
+	WriteAfterEventStatusProcessing = "processing"
+	WriteAfterEventStatusProcessed  = "processed"
+)
+
+type WriteAfterEvent struct {
+	ID          int64      `gorm:"column:id;primaryKey" json:"id"`
+	EventType   string     `gorm:"column:event_type" json:"event_type"`
+	BoardSlug   string     `gorm:"column:board_slug" json:"board_slug"`
+	WriteID     int        `gorm:"column:write_id" json:"write_id"`
+	PostID      *int       `gorm:"column:post_id" json:"post_id,omitempty"`
+	ParentID    *int       `gorm:"column:parent_id" json:"parent_id,omitempty"`
+	MemberID    string     `gorm:"column:member_id" json:"member_id"`
+	Author      string     `gorm:"column:author" json:"author"`
+	Subject     string     `gorm:"column:subject" json:"subject"`
+	OccurredAt  time.Time  `gorm:"column:occurred_at" json:"occurred_at"`
+	AvailableAt time.Time  `gorm:"column:available_at" json:"available_at"`
+	Status      string     `gorm:"column:status" json:"status"`
+	RetryCount  int        `gorm:"column:retry_count" json:"retry_count"`
+	LastError   *string    `gorm:"column:last_error" json:"last_error,omitempty"`
+	ClaimedAt   *time.Time `gorm:"column:claimed_at" json:"claimed_at,omitempty"`
+	ProcessedAt *time.Time `gorm:"column:processed_at" json:"processed_at,omitempty"`
+	CreatedAt   time.Time  `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (WriteAfterEvent) TableName() string {
+	return "g5_write_after_events"
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -30,6 +30,9 @@ func Run(db *gorm.DB) error {
 	if err := CreateScheduledDeletesTable(db); err != nil {
 		return err
 	}
+	if err := CreateWriteAfterEventsTable(db); err != nil {
+		return err
+	}
 	if err := FixListPageIndexes(db); err != nil {
 		return err
 	}

--- a/internal/migration/write_after_events.go
+++ b/internal/migration/write_after_events.go
@@ -1,0 +1,56 @@
+package migration
+
+import (
+	"fmt"
+	"log"
+
+	"gorm.io/gorm"
+)
+
+func CreateWriteAfterEventsTable(db *gorm.DB) error {
+	var count int64
+	db.Raw(`
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'g5_write_after_events'
+	`).Scan(&count)
+
+	if count > 0 {
+		log.Printf("[Migration] g5_write_after_events table already exists, skipping")
+		return nil
+	}
+
+	sql := `
+		CREATE TABLE g5_write_after_events (
+			id BIGINT AUTO_INCREMENT PRIMARY KEY,
+			event_type VARCHAR(40) NOT NULL,
+			board_slug VARCHAR(20) NOT NULL,
+			write_id INT NOT NULL,
+			post_id INT NULL,
+			parent_id INT NULL,
+			member_id VARCHAR(255) NOT NULL DEFAULT '',
+			author VARCHAR(255) NOT NULL DEFAULT '',
+			subject VARCHAR(255) NOT NULL DEFAULT '',
+			occurred_at DATETIME NOT NULL,
+			available_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			retry_count INT NOT NULL DEFAULT 0,
+			last_error TEXT NULL,
+			claimed_at DATETIME NULL,
+			processed_at DATETIME NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			INDEX idx_status_available (status, available_at, id),
+			INDEX idx_board_write (board_slug, write_id),
+			INDEX idx_post_status (post_id, status),
+			INDEX idx_processed_at (processed_at)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+	`
+
+	if err := db.Exec(sql).Error; err != nil {
+		return fmt.Errorf("failed to create g5_write_after_events table: %w", err)
+	}
+
+	log.Printf("[Migration] Created g5_write_after_events table")
+	return nil
+}

--- a/internal/repository/gnuboard/write_after_event_repo.go
+++ b/internal/repository/gnuboard/write_after_event_repo.go
@@ -1,0 +1,134 @@
+package gnuboard
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	domain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type WriteAfterEventRepository interface {
+	Create(db *gorm.DB, event *domain.WriteAfterEvent) error
+	ClaimPending(now time.Time, limit int) ([]domain.WriteAfterEvent, error)
+	MarkProcessed(id int64) error
+	MarkFailed(id int64, errMsg string) error
+	CountPending(now time.Time) (int64, error)
+}
+
+type writeAfterEventRepository struct {
+	db *gorm.DB
+}
+
+func NewWriteAfterEventRepository(db *gorm.DB) WriteAfterEventRepository {
+	return &writeAfterEventRepository{db: db}
+}
+
+func (r *writeAfterEventRepository) Create(db *gorm.DB, event *domain.WriteAfterEvent) error {
+	if db == nil {
+		db = r.db
+	}
+	if event.Status == "" {
+		event.Status = domain.WriteAfterEventStatusPending
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = time.Now()
+	}
+	if event.AvailableAt.IsZero() {
+		event.AvailableAt = event.OccurredAt
+	}
+	return db.Create(event).Error
+}
+
+func (r *writeAfterEventRepository) ClaimPending(now time.Time, limit int) ([]domain.WriteAfterEvent, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var events []domain.WriteAfterEvent
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.
+			Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"}).
+			Where("status = ? AND available_at <= ?", domain.WriteAfterEventStatusPending, now).
+			Order("available_at ASC, id ASC").
+			Limit(limit).
+			Find(&events).Error; err != nil {
+			return err
+		}
+
+		if len(events) == 0 {
+			return nil
+		}
+
+		ids := make([]int64, 0, len(events))
+		for _, event := range events {
+			ids = append(ids, event.ID)
+		}
+		if err := tx.Model(&domain.WriteAfterEvent{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"status":     domain.WriteAfterEventStatusProcessing,
+				"claimed_at": now,
+			}).Error; err != nil {
+			return err
+		}
+
+		for i := range events {
+			events[i].Status = domain.WriteAfterEventStatusProcessing
+			events[i].ClaimedAt = &now
+		}
+		return nil
+	})
+	return events, err
+}
+
+func (r *writeAfterEventRepository) MarkProcessed(id int64) error {
+	now := time.Now()
+	return r.db.Model(&domain.WriteAfterEvent{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"status":       domain.WriteAfterEventStatusProcessed,
+			"processed_at": now,
+			"last_error":   nil,
+		}).Error
+}
+
+func (r *writeAfterEventRepository) MarkFailed(id int64, errMsg string) error {
+	if len(errMsg) > 2000 {
+		errMsg = errMsg[:2000]
+	}
+	nextDelay := 5 * time.Second
+	return r.db.Model(&domain.WriteAfterEvent{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"status":       domain.WriteAfterEventStatusPending,
+			"retry_count":  gorm.Expr("retry_count + 1"),
+			"last_error":   errMsg,
+			"available_at": time.Now().Add(nextDelay),
+		}).Error
+}
+
+func (r *writeAfterEventRepository) CountPending(now time.Time) (int64, error) {
+	var count int64
+	err := r.db.Model(&domain.WriteAfterEvent{}).
+		Where("status = ? AND available_at <= ?", domain.WriteAfterEventStatusPending, now).
+		Count(&count).Error
+	return count, err
+}
+
+func TrimWriteAfterEventError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.TrimSpace(err.Error())
+	if len(msg) > 2000 {
+		return msg[:2000]
+	}
+	return msg
+}
+
+func FormatUnknownWriteAfterEvent(eventType string) error {
+	return fmt.Errorf("unknown write-after event type %s", eventType)
+}

--- a/internal/worker/delete_worker.go
+++ b/internal/worker/delete_worker.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	"gorm.io/gorm"
 )
@@ -13,16 +14,18 @@ import (
 type DeleteWorker struct {
 	writeRepo gnurepo.WriteRepository
 	sdRepo    gnurepo.ScheduledDeleteRepository
+	eventRepo gnurepo.WriteAfterEventRepository
 	db        *gorm.DB
 	stop      chan struct{}
 	wg        sync.WaitGroup
 }
 
 // NewDeleteWorker creates a new DeleteWorker
-func NewDeleteWorker(db *gorm.DB, writeRepo gnurepo.WriteRepository, sdRepo gnurepo.ScheduledDeleteRepository) *DeleteWorker {
+func NewDeleteWorker(db *gorm.DB, writeRepo gnurepo.WriteRepository, sdRepo gnurepo.ScheduledDeleteRepository, eventRepo gnurepo.WriteAfterEventRepository) *DeleteWorker {
 	return &DeleteWorker{
 		writeRepo: writeRepo,
 		sdRepo:    sdRepo,
+		eventRepo: eventRepo,
 		db:        db,
 		stop:      make(chan struct{}),
 	}
@@ -78,23 +81,74 @@ func (w *DeleteWorker) processPending() {
 				log.Printf("[DeleteWorker] Error finding comment %s/%d before delete: %v", sd.BoTable, sd.WrID, findErr)
 				continue
 			}
-			// Soft delete comment
-			if err := w.writeRepo.SoftDeleteComment(sd.BoTable, sd.WrID, sd.RequestedBy); err != nil {
-				log.Printf("[DeleteWorker] Error soft deleting comment %s/%d: %v", sd.BoTable, sd.WrID, err)
-				continue
-			}
-			if w.db != nil {
-				tableName := "g5_write_" + sd.BoTable
-				if err := w.db.Table(tableName).
+			if err := w.db.Transaction(func(tx *gorm.DB) error {
+				now := time.Now()
+				if err := tx.Table("g5_write_"+sd.BoTable).
+					Where("wr_id = ? AND wr_is_comment = 1", sd.WrID).
+					Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": sd.RequestedBy,
+					}).Error; err != nil {
+					return err
+				}
+				if err := tx.Table("g5_write_"+sd.BoTable).
 					Where("wr_id = ?", comment.WrParent).
 					Update("wr_comment", gorm.Expr("GREATEST(COALESCE(wr_comment, 0) - 1, 0)")).
 					Error; err != nil {
-					log.Printf("[DeleteWorker] Error decrementing comment count for %s/%d: %v", sd.BoTable, comment.WrParent, err)
+					return err
 				}
+				if w.eventRepo != nil {
+					postID := comment.WrParent
+					if err := w.eventRepo.Create(tx, &gnudomain.WriteAfterEvent{
+						EventType:  gnudomain.WriteAfterEventTypeCommentDeleted,
+						BoardSlug:  sd.BoTable,
+						WriteID:    sd.WrID,
+						PostID:     &postID,
+						MemberID:   comment.MbID,
+						Author:     comment.WrName,
+						OccurredAt: now,
+						Status:     gnudomain.WriteAfterEventStatusPending,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
+				log.Printf("[DeleteWorker] Error soft deleting comment %s/%d: %v", sd.BoTable, sd.WrID, err)
+				continue
 			}
 		} else {
-			// Soft delete post (including its comments)
-			if err := w.writeRepo.SoftDeletePost(sd.BoTable, sd.WrID, sd.RequestedBy); err != nil {
+			post, findErr := w.writeRepo.FindPostByIDIncludeDeleted(sd.BoTable, sd.WrID)
+			if findErr != nil {
+				log.Printf("[DeleteWorker] Error finding post %s/%d before delete: %v", sd.BoTable, sd.WrID, findErr)
+				continue
+			}
+			if err := w.db.Transaction(func(tx *gorm.DB) error {
+				now := time.Now()
+				if err := tx.Table("g5_write_"+sd.BoTable).
+					Where("wr_id = ?", sd.WrID).
+					Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": sd.RequestedBy,
+					}).Error; err != nil {
+					return err
+				}
+				if w.eventRepo != nil {
+					if err := w.eventRepo.Create(tx, &gnudomain.WriteAfterEvent{
+						EventType:  gnudomain.WriteAfterEventTypePostDeleted,
+						BoardSlug:  sd.BoTable,
+						WriteID:    sd.WrID,
+						MemberID:   post.MbID,
+						Author:     post.WrName,
+						Subject:    post.WrSubject,
+						OccurredAt: now,
+						Status:     gnudomain.WriteAfterEventStatusPending,
+					}); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
 				log.Printf("[DeleteWorker] Error soft deleting post %s/%d: %v", sd.BoTable, sd.WrID, err)
 				continue
 			}

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -9,15 +9,49 @@ import (
 	"sync"
 	"time"
 
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
 	pkgcache "github.com/damoang/angple-backend/pkg/cache"
 
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	"github.com/damoang/angple-backend/internal/service"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gorm.io/gorm"
 )
 
 type BlockedIDsProvider func(ctx context.Context, userID string) []string
 type ClearPostMemCacheFunc func(boardSlug string)
+
+var (
+	writeAfterEventsProcessedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "write_after_events_processed_total",
+			Help: "Total number of processed write-after events",
+		},
+		[]string{"event_type", "result"},
+	)
+	writeAfterEventsRetryTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "write_after_events_retry_total",
+			Help: "Total number of write-after event retries",
+		},
+		[]string{"event_type"},
+	)
+	writeAfterQueueDepth = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "write_after_events_queue_depth",
+			Help: "Number of pending write-after events ready to process",
+		},
+	)
+	writeAfterEventLagSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "write_after_event_lag_seconds",
+			Help:    "Lag between event occurrence and processing attempt",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+		},
+		[]string{"event_type"},
+	)
+)
 
 type WriteAfterWorker struct {
 	db             *gorm.DB
@@ -28,9 +62,11 @@ type WriteAfterWorker struct {
 	getBlockedIDs  BlockedIDsProvider
 	clearPostCache ClearPostMemCacheFunc
 
-	jobs chan any
-	stop chan struct{}
-	wg   sync.WaitGroup
+	repo         gnurepo.WriteAfterEventRepository
+	pollInterval time.Duration
+	batchSize    int
+	stop         chan struct{}
+	wg           sync.WaitGroup
 }
 
 type PostCreatedJob struct {
@@ -58,6 +94,7 @@ func NewWriteAfterWorker(
 	notiRepo gnurepo.NotiRepository,
 	notiPrefRepo gnurepo.NotiPreferenceRepository,
 	activitySync *service.MemberActivitySyncService,
+	repo gnurepo.WriteAfterEventRepository,
 	getBlockedIDs BlockedIDsProvider,
 	clearPostCache ClearPostMemCacheFunc,
 ) *WriteAfterWorker {
@@ -67,9 +104,11 @@ func NewWriteAfterWorker(
 		notiRepo:       notiRepo,
 		notiPrefRepo:   notiPrefRepo,
 		activitySync:   activitySync,
+		repo:           repo,
 		getBlockedIDs:  getBlockedIDs,
 		clearPostCache: clearPostCache,
-		jobs:           make(chan any, 2048),
+		pollInterval:   2 * time.Second,
+		batchSize:      100,
 		stop:           make(chan struct{}),
 	}
 }
@@ -82,12 +121,14 @@ func (w *WriteAfterWorker) Start(concurrency int) {
 		w.wg.Add(1)
 		go func() {
 			defer w.wg.Done()
+			ticker := time.NewTicker(w.pollInterval)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-w.stop:
 					return
-				case job := <-w.jobs:
-					w.handle(job)
+				case <-ticker.C:
+					w.processBatch()
 				}
 			}
 		}()
@@ -101,23 +142,71 @@ func (w *WriteAfterWorker) Stop() {
 	log.Printf("[WriteAfterWorker] Stopped")
 }
 
-func (w *WriteAfterWorker) Enqueue(job any) {
-	select {
-	case w.jobs <- job:
-	default:
-		log.Printf("[WriteAfterWorker] queue full, fallback async processing for %T", job)
-		go w.handle(job)
+func (w *WriteAfterWorker) processBatch() {
+	if w.repo == nil {
+		return
+	}
+	now := time.Now()
+	if pendingCount, err := w.repo.CountPending(now); err == nil {
+		writeAfterQueueDepth.Set(float64(pendingCount))
+	}
+
+	events, err := w.repo.ClaimPending(now, w.batchSize)
+	if err != nil {
+		log.Printf("[WriteAfterWorker] claim pending failed: %v", err)
+		return
+	}
+	for _, event := range events {
+		writeAfterEventLagSeconds.WithLabelValues(event.EventType).Observe(time.Since(event.OccurredAt).Seconds())
+		if err := w.handleEvent(event); err != nil {
+			writeAfterEventsProcessedTotal.WithLabelValues(event.EventType, "error").Inc()
+			writeAfterEventsRetryTotal.WithLabelValues(event.EventType).Inc()
+			if markErr := w.repo.MarkFailed(event.ID, gnurepo.TrimWriteAfterEventError(err)); markErr != nil {
+				log.Printf("[WriteAfterWorker] mark failed %d: %v", event.ID, markErr)
+			}
+			continue
+		}
+		writeAfterEventsProcessedTotal.WithLabelValues(event.EventType, "success").Inc()
+		if err := w.repo.MarkProcessed(event.ID); err != nil {
+			log.Printf("[WriteAfterWorker] mark processed %d: %v", event.ID, err)
+		}
 	}
 }
 
-func (w *WriteAfterWorker) handle(job any) {
-	switch j := job.(type) {
-	case PostCreatedJob:
-		w.handlePostCreated(j)
-	case CommentCreatedJob:
-		w.handleCommentCreated(j)
+func (w *WriteAfterWorker) handleEvent(event gnudomain.WriteAfterEvent) error {
+	switch event.EventType {
+	case gnudomain.WriteAfterEventTypePostCreated:
+		w.handlePostCreated(PostCreatedJob{
+			BoardSlug: event.BoardSlug,
+			WriteID:   event.WriteID,
+			MemberID:  event.MemberID,
+			Author:    event.Author,
+			Subject:   event.Subject,
+			CreatedAt: event.OccurredAt,
+		})
+		return nil
+	case gnudomain.WriteAfterEventTypeCommentCreated:
+		postID := 0
+		if event.PostID != nil {
+			postID = *event.PostID
+		}
+		w.handleCommentCreated(CommentCreatedJob{
+			BoardSlug: event.BoardSlug,
+			WriteID:   event.WriteID,
+			PostID:    postID,
+			ParentID:  event.ParentID,
+			MemberID:  event.MemberID,
+			Author:    event.Author,
+			CreatedAt: event.OccurredAt,
+		})
+		return nil
+	case gnudomain.WriteAfterEventTypePostUpdated, gnudomain.WriteAfterEventTypePostDeleted, gnudomain.WriteAfterEventTypePostRestored:
+		w.handlePostChanged(event)
+		return nil
+	case gnudomain.WriteAfterEventTypeCommentUpdated, gnudomain.WriteAfterEventTypeCommentDeleted, gnudomain.WriteAfterEventTypeCommentRestored:
+		return w.handleCommentChanged(event)
 	default:
-		log.Printf("[WriteAfterWorker] unknown job type %T", job)
+		return gnurepo.FormatUnknownWriteAfterEvent(event.EventType)
 	}
 }
 
@@ -261,6 +350,44 @@ func (w *WriteAfterWorker) handleCommentCreated(job CommentCreatedJob) {
 			WrParent:      job.PostID,
 		})
 	}
+}
+
+func (w *WriteAfterWorker) handlePostChanged(event gnudomain.WriteAfterEvent) {
+	if w.cacheService != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = w.cacheService.InvalidatePost(ctx, event.BoardSlug, event.WriteID)
+		_ = w.cacheService.InvalidatePosts(ctx, event.BoardSlug)
+		cancel()
+	}
+	if w.clearPostCache != nil {
+		w.clearPostCache(event.BoardSlug)
+	}
+	if w.activitySync != nil {
+		if err := w.activitySync.SyncLegacyPost(event.BoardSlug, event.WriteID); err != nil {
+			log.Printf("[WriteAfterWorker] activity sync failed for post %s/%d: %v", event.BoardSlug, event.WriteID, err)
+		}
+	}
+}
+
+func (w *WriteAfterWorker) handleCommentChanged(event gnudomain.WriteAfterEvent) error {
+	if event.PostID == nil {
+		return fmt.Errorf("missing post_id for comment event %s/%d", event.BoardSlug, event.WriteID)
+	}
+	if w.cacheService != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = w.cacheService.InvalidateComments(ctx, event.BoardSlug, *event.PostID)
+		_ = w.cacheService.InvalidatePosts(ctx, event.BoardSlug)
+		cancel()
+	}
+	if w.clearPostCache != nil {
+		w.clearPostCache(event.BoardSlug)
+	}
+	if w.activitySync != nil {
+		if err := w.activitySync.SyncLegacyComment(event.BoardSlug, event.WriteID); err != nil {
+			log.Printf("[WriteAfterWorker] activity sync failed for comment %s/%d: %v", event.BoardSlug, event.WriteID, err)
+		}
+	}
+	return nil
 }
 
 func (w *WriteAfterWorker) isBlocked(targetUserID, actorUserID string) bool {


### PR DESCRIPTION
## Summary
- add durable  outbox migration, domain model, and repository
- switch write-after processing from in-memory queue to DB-backed outbox consumption with retry metadata and Prometheus metrics
- write post/comment create/update/delete/restore events in write paths and scheduled delete worker so after-write work survives pod restarts

## Test plan
- [x] go test ./cmd/api ./internal/worker/... ./internal/migration/... ./internal/repository/gnuboard/...
