### PR TITLE
fix: guard write-after activity sync timestamps

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2537,11 +2537,14 @@ func main() {
 					}
 				} else {
 					// 루트 댓글: FOR UPDATE로 게시글 행 잠금 후 MAX(wr_comment) + 1
+					var lockedPost struct {
+						WrID int `gorm:"column:wr_id"`
+					}
 					tx.Table(tableName).
 						Clauses(clause.Locking{Strength: "UPDATE"}).
 						Select("wr_id").
 						Where("wr_id = ? AND wr_is_comment = 0", postID).
-						Scan(&struct{}{})
+						Scan(&lockedPost)
 
 					var maxComment int
 					tx.Table(tableName).

--- a/internal/service/member_activity_sync.go
+++ b/internal/service/member_activity_sync.go
@@ -233,7 +233,8 @@ func (s *MemberActivitySyncService) syncLegacyPost(boardSlug string, wrID int, r
 		HasFile      bool      `gorm:"column:has_file"`
 		IsDeleted    bool      `gorm:"column:is_deleted"`
 		CreatedAt    time.Time `gorm:"column:created_at"`
-		UpdatedAt    time.Time `gorm:"column:updated_at"`
+		UpdatedAt    time.Time `gorm:"-"`
+		UpdatedAtRaw string    `gorm:"column:updated_at"`
 	}
 
 	var row postRow
@@ -253,7 +254,7 @@ func (s *MemberActivitySyncService) syncLegacyPost(boardSlug string, wrID int, r
 		       p.wr_datetime AS created_at,
 		       CASE
 		           WHEN p.wr_last IS NULL OR p.wr_last = '' OR p.wr_last = '0000-00-00 00:00:00' THEN p.wr_datetime
-		           ELSE p.wr_last
+		           ELSE DATE_FORMAT(p.wr_last, '%%Y-%%m-%%d %%H:%%i:%%s')
 		       END AS updated_at
 		  FROM %s p
 		 WHERE p.wr_id = ?
@@ -265,6 +266,7 @@ func (s *MemberActivitySyncService) syncLegacyPost(boardSlug string, wrID int, r
 	if row.ID == 0 || row.MemberID == "" {
 		return nil
 	}
+	row.UpdatedAt = parseLegacyFeedTime(row.UpdatedAtRaw, row.CreatedAt)
 
 	isPublic := !row.IsDeleted &&
 		!strings.Contains(strings.ToLower(row.WrOption), "secret") &&
@@ -337,7 +339,8 @@ func (s *MemberActivitySyncService) syncLegacyComment(boardSlug string, wrID int
 		IsDeleted    bool      `gorm:"column:is_deleted"`
 		ParentGone   bool      `gorm:"column:parent_deleted"`
 		CreatedAt    time.Time `gorm:"column:created_at"`
-		UpdatedAt    time.Time `gorm:"column:updated_at"`
+		UpdatedAt    time.Time `gorm:"-"`
+		UpdatedAtRaw string    `gorm:"column:updated_at"`
 	}
 
 	var row commentRow
@@ -356,7 +359,7 @@ func (s *MemberActivitySyncService) syncLegacyComment(boardSlug string, wrID int
 		       c.wr_datetime AS created_at,
 		       CASE
 		           WHEN c.wr_last IS NULL OR c.wr_last = '' OR c.wr_last = '0000-00-00 00:00:00' THEN c.wr_datetime
-		           ELSE c.wr_last
+		           ELSE DATE_FORMAT(c.wr_last, '%%Y-%%m-%%d %%H:%%i:%%s')
 		       END AS updated_at
 		  FROM %s c
 		  JOIN %s p ON p.wr_id = c.wr_parent AND p.wr_is_comment = 0
@@ -369,6 +372,7 @@ func (s *MemberActivitySyncService) syncLegacyComment(boardSlug string, wrID int
 	if row.ID == 0 || row.MemberID == "" {
 		return nil
 	}
+	row.UpdatedAt = parseLegacyFeedTime(row.UpdatedAtRaw, row.CreatedAt)
 
 	isPublic := !row.IsDeleted &&
 		!row.ParentGone &&
@@ -817,6 +821,18 @@ func legacyWriteTableName(boardSlug string) (string, error) {
 		return "", fmt.Errorf("invalid board slug: %q", boardSlug)
 	}
 	return "g5_write_" + boardSlug, nil
+}
+
+func parseLegacyFeedTime(raw string, fallback time.Time) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "0000-00-00 00:00:00" {
+		return fallback
+	}
+	parsed, err := time.ParseInLocation("2006-01-02 15:04:05", raw, time.Local)
+	if err != nil {
+		return fallback
+	}
+	return parsed
 }
 
 func (s *MemberActivitySyncService) memberIDsForParent(writeTable string, parentWriteID int) ([]string, error) {

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -51,6 +51,13 @@ var (
 		},
 		[]string{"event_type"},
 	)
+	writeAfterActivitySyncFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "write_after_activity_sync_failures_total",
+			Help: "Total number of member activity sync failures inside write-after processing",
+		},
+		[]string{"event_type"},
+	)
 )
 
 type WriteAfterWorker struct {
@@ -221,6 +228,7 @@ func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 	}
 	if w.activitySync != nil {
 		if err := w.activitySync.SyncLegacyPost(job.BoardSlug, job.WriteID); err != nil {
+			writeAfterActivitySyncFailuresTotal.WithLabelValues(gnudomain.WriteAfterEventTypePostCreated).Inc()
 			log.Printf("[WriteAfterWorker] activity sync failed for post %s/%d: %v", job.BoardSlug, job.WriteID, err)
 		}
 	}
@@ -289,6 +297,7 @@ func (w *WriteAfterWorker) handleCommentCreated(job CommentCreatedJob) {
 	}
 	if w.activitySync != nil {
 		if err := w.activitySync.SyncLegacyComment(job.BoardSlug, job.WriteID); err != nil {
+			writeAfterActivitySyncFailuresTotal.WithLabelValues(gnudomain.WriteAfterEventTypeCommentCreated).Inc()
 			log.Printf("[WriteAfterWorker] activity sync failed for comment %s/%d: %v", job.BoardSlug, job.WriteID, err)
 		}
 	}
@@ -364,6 +373,7 @@ func (w *WriteAfterWorker) handlePostChanged(event gnudomain.WriteAfterEvent) {
 	}
 	if w.activitySync != nil {
 		if err := w.activitySync.SyncLegacyPost(event.BoardSlug, event.WriteID); err != nil {
+			writeAfterActivitySyncFailuresTotal.WithLabelValues(event.EventType).Inc()
 			log.Printf("[WriteAfterWorker] activity sync failed for post %s/%d: %v", event.BoardSlug, event.WriteID, err)
 		}
 	}
@@ -384,6 +394,7 @@ func (w *WriteAfterWorker) handleCommentChanged(event gnudomain.WriteAfterEvent)
 	}
 	if w.activitySync != nil {
 		if err := w.activitySync.SyncLegacyComment(event.BoardSlug, event.WriteID); err != nil {
+			writeAfterActivitySyncFailuresTotal.WithLabelValues(event.EventType).Inc()
 			log.Printf("[WriteAfterWorker] activity sync failed for comment %s/%d: %v", event.BoardSlug, event.WriteID, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- fix legacy member activity sync timestamp scanning for g5_write rows by parsing formatted strings safely
- remove noisy root-comment lock scan error in comment creation
- add a Prometheus counter for write-after activity sync failures so future regressions are visible

## Test plan
- [x] go test ./cmd/api ./internal/service/... ./internal/worker/...
