### PR TITLE
fix: level 유형 제재 시 소명게시판 접근 차단 버그 수정

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -434,24 +434,29 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 		return fmt.Errorf("회원 조회 실패: %w", err)
 	}
 
-	// 제재 종료일 계산 (mb_intercept_date는 varchar(8)이므로 YYYYMMDD 형식)
-	var restrictionEndDate string
-	if disciplineDays == 9999 {
-		restrictionEndDate = "99991231"
-	} else {
-		restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
+	// disciplineType에 따라 적절한 필드만 업데이트
+	penaltyTypes := convertDisciplineType(disciplineType)
+
+	// "access" 유형에서만 mb_intercept_date 설정
+	// "level" 유형은 g5_member 변경 없음 (mb_level 강등도 하지 않음)
+	for _, pt := range penaltyTypes {
+		if pt == "access" {
+			var restrictionEndDate string
+			if disciplineDays == 9999 {
+				restrictionEndDate = "99991231"
+			} else {
+				restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
+			}
+			if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).
+				Update("mb_intercept_date", restrictionEndDate).Error; err != nil {
+				return err
+			}
+			break
+		}
 	}
 
-	// 제재 적용 (글쓰기 차단만, mb_level 강등 없음)
-	updates := map[string]interface{}{}
-	updates["mb_intercept_date"] = restrictionEndDate
-
-	if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).Updates(updates).Error; err != nil {
-		return err
-	}
-
-	// g5_da_member_discipline 테이블에 제재 정보 저장 (모든 타입을 intercept로 통일)
-	penaltyTypeValue := "intercept"
+	// g5_da_member_discipline 테이블에 제재 정보 저장 (올바른 penalty_type 사용)
+	penaltyTypeValue := derivePenaltyTypeValue(penaltyTypes)
 
 	penaltyPeriod := disciplineDays
 	if disciplineDays == 9999 {
@@ -654,6 +659,30 @@ func convertDisciplineType(disciplineType string) []string {
 	default:
 		return []string{}
 	}
+}
+
+// derivePenaltyTypeValue converts penalty type slice to DB value string
+func derivePenaltyTypeValue(penaltyTypes []string) string {
+	hasLevel := false
+	hasAccess := false
+	for _, pt := range penaltyTypes {
+		if pt == "level" {
+			hasLevel = true
+		}
+		if pt == "access" {
+			hasAccess = true
+		}
+	}
+	if hasLevel && hasAccess {
+		return "both"
+	}
+	if hasLevel {
+		return "level"
+	}
+	if hasAccess {
+		return "intercept"
+	}
+	return ""
 }
 
 // stripTags removes HTML tags from a string (simple implementation)

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -44,6 +44,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 					END
 				 FROM g5_da_member_discipline
 				 WHERE penalty_mb_id = ?
+				   AND penalty_type IN ('intercept', 'both', 'all')
 				   AND (
 						penalty_period = -1
 						OR (penalty_period > 0 AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW())


### PR DESCRIPTION
## Summary
- level 유형 이용제한 회원이 소명게시판(/claim) 글쓰기 불가한 버그 수정
- `applyUserRestriction()`: access 유형만 `mb_intercept_date` 설정, level 유형은 `g5_member` 미변경
- `BanCheck` fallback 쿼리에 `penalty_type IN (intercept, both, all)` 필터 추가
- `derivePenaltyTypeValue()` 함수 추가로 올바른 `penalty_type` 값 저장 (기존: 모든 타입을 intercept로 하드코딩)

## 근본 원인
1. Cron `applyUserRestriction()`이 disciplineType 무관하게 항상 `mb_intercept_date` 설정
2. BanCheck fallback 쿼리가 `penalty_type` 필터 없이 `g5_da_member_discipline` 레코드 조회 → level 유형도 접근 차단

## 수정 후 동작
| disciplineType | mb_intercept_date | BanCheck 차단 | 소명 가능 |
|---|---|---|---|
| level | 미설정 | X | O |
| access | 설정 | O | X (설계 의도) |
| both | 설정 | O | X (설계 의도) |

## Test plan
- [ ] go vet ./internal/cron/ 및 go vet ./internal/middleware/ 통과 확인
- [ ] level 유형 징계 회원의 mb_intercept_date 미설정 확인
- [ ] level 유형 징계 회원의 /claim 글쓰기 가능 확인
- [ ] access 유형 징계 회원의 접근 차단 정상 동작 확인