### PR TITLE
fix: 이용제한 사용자 소명게시판(claim) 글쓰기 허용

### DIFF
--- a/internal/domain/v2/advertiser_board_policy.go
+++ b/internal/domain/v2/advertiser_board_policy.go
@@ -1,0 +1,20 @@
+package v2
+
+// V2AdvertiserBoardPolicy represents board-specific advertiser policy settings.
+type V2AdvertiserBoardPolicy struct {
+	ID                           uint    `gorm:"primaryKey" json:"id"`
+	BoardID                      string  `gorm:"column:board_id;uniqueIndex" json:"board_id"`
+	Mode                         string  `gorm:"column:mode;default:shadow" json:"mode"`
+	Enabled                      bool    `gorm:"column:enabled;default:false" json:"enabled"`
+	AllowActiveAdvertiserRead    bool    `gorm:"column:allow_active_advertiser_read;default:true" json:"allow_active_advertiser_read"`
+	AllowActiveAdvertiserWrite   bool    `gorm:"column:allow_active_advertiser_write;default:true" json:"allow_active_advertiser_write"`
+	AllowActiveAdvertiserComment bool    `gorm:"column:allow_active_advertiser_comment;default:true" json:"allow_active_advertiser_comment"`
+	RequireCertification         bool    `gorm:"column:require_certification;default:false" json:"require_certification"`
+	DailyPostLimit               int     `gorm:"column:daily_post_limit;default:0" json:"daily_post_limit"`
+	AllowedRoutesJSON            *string `gorm:"column:allowed_routes_json;type:text" json:"allowed_routes_json"`
+}
+
+// TableName returns the table name for GORM.
+func (V2AdvertiserBoardPolicy) TableName() string {
+	return "v2_advertiser_board_policies"
+}

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -15,6 +15,7 @@ const (
 	interceptDateDashFormat  = "2006-01-02"
 	interceptDateShortFormat = "20060102"
 	promotionBoardSlug       = "promotion"
+	claimBoardSlug           = "claim"
 )
 
 // BanCheck checks if the authenticated user is banned (mb_intercept_date).
@@ -75,9 +76,9 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		// User is currently banned — only promotion board is allowed
+		// User is currently banned — only promotion and claim boards are allowed
 		slug := c.Param("slug")
-		if slug == promotionBoardSlug {
+		if slug == promotionBoardSlug || slug == claimBoardSlug {
 			c.Next()
 			return
 		}

--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -174,6 +174,27 @@ func (s *BoardWriteRestrictionService) Check(boardSlug, memberID string, memberL
 	return &WriteRestrictionResult{CanWrite: true, Remaining: -1, DailyLimit: 0}, nil
 }
 
+// PolicyComparison holds the base and candidate restriction results for dry-run comparison.
+type PolicyComparison struct {
+	Base      *WriteRestrictionResult `json:"base"`
+	Policy    interface{}             `json:"policy"`
+	Candidate *WriteRestrictionResult `json:"candidate"`
+}
+
+// CompareWithAdvertiserPolicy performs a dry-run comparison of base write restriction
+// versus advertiser-policy-adjusted restriction.
+func (s *BoardWriteRestrictionService) CompareWithAdvertiserPolicy(boardSlug, memberID string, memberLevel int) (*PolicyComparison, error) {
+	base, err := s.Check(boardSlug, memberID, memberLevel)
+	if err != nil {
+		return nil, err
+	}
+	// Currently returns base as both base and candidate (shadow mode only).
+	return &PolicyComparison{
+		Base:      base,
+		Candidate: base,
+	}, nil
+}
+
 // countTodayPosts counts the number of non-comment posts written today (KST) by the member.
 // wr_datetime is stored in KST by legacy PHP (Gnuboard).
 func (s *BoardWriteRestrictionService) countTodayPosts(boardSlug, memberID string) (int, error) {


### PR DESCRIPTION
## Summary
- 이용제한 사용자가 소명글 작성 시 403 에러 발생하는 버그 수정
- BanCheck 미들웨어에서 `claim` 게시판을 `promotion`과 함께 예외 처리
- V2AdvertiserBoardPolicy 도메인 모델 누락으로 인한 빌드 에러 함께 수정

## Test plan
- [ ] 이용제한 사용자로 `/claim/write` 접근 → 글쓰기 가능 확인
- [ ] 이용제한 사용자로 다른 게시판 글쓰기 → 여전히 차단 확인