### PR TITLE
feat: HTML sanitization 방어 강화 (bluemonday)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
@@ -72,6 +73,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/gorilla/css v1.0.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -83,6 +85,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
+github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -118,6 +120,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/css v1.0.1 h1:ntNaBIghp6JmvWnxbZKANoLyuXTPZ4cAMlo6RyhlbO8=
+github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A3b0=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -157,6 +161,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
+github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/common/sanitize.go
+++ b/internal/common/sanitize.go
@@ -1,0 +1,150 @@
+package common
+
+import (
+	"regexp"
+
+	"github.com/microcosm-cc/bluemonday"
+)
+
+// safeCSSProperties는 style 속성에서 허용하는 CSS 속성 목록
+var safeCSSProperties = []string{
+	"font-size", "font-weight", "font-style", "font-family",
+	"color", "background-color",
+	"text-align", "text-decoration", "line-height", "letter-spacing",
+	"margin", "margin-top", "margin-bottom", "margin-left", "margin-right",
+	"padding", "padding-top", "padding-bottom", "padding-left", "padding-right",
+	"border", "border-radius",
+	"width", "max-width", "height", "max-height",
+}
+
+// allowedIframeSrcRegex는 허용하는 iframe src 도메인 정규식
+var allowedIframeSrcRegex = regexp.MustCompile(`^https://(www\.)?(` +
+	`youtube\.com|youtube-nocookie\.com|` + // YouTube
+	`platform\.twitter\.com|syndication\.twitter\.com|platform\.x\.com|` + // Twitter/X
+	`embed\.bsky\.app|` + // Bluesky
+	`instagram\.com|` + // Instagram
+	`player\.vimeo\.com|` + // Vimeo
+	`open\.spotify\.com|` + // Spotify
+	`codepen\.io|` + // CodePen
+	`tiktok\.com` + // TikTok
+	`)/`)
+
+// newPostPolicy는 게시글 본문용 bluemonday 정책을 생성한다.
+func newPostPolicy() *bluemonday.Policy {
+	p := bluemonday.NewPolicy()
+
+	// 허용 태그 및 속성
+	p.AllowElements("h1", "h2", "h3", "h4", "h5", "h6")
+	p.AllowElements("p", "br", "hr", "div", "span")
+	p.AllowElements("strong", "b", "em", "i", "u", "s", "del")
+	p.AllowElements("ul", "ol", "li")
+	p.AllowElements("blockquote", "code", "pre")
+	p.AllowElements("table", "thead", "tbody", "tr")
+	p.AllowElements("figure", "figcaption")
+	p.AllowElements("details", "summary")
+	p.AllowElements("a", "img", "iframe")
+	p.AllowElements("video", "audio", "source")
+
+	// th, td에 colspan, rowspan 허용
+	p.AllowAttrs("colspan", "rowspan").OnElements("th", "td")
+
+	// a 태그
+	p.AllowAttrs("href", "title", "target", "rel").OnElements("a")
+	p.AllowURLSchemes("https", "http", "mailto", "tel")
+
+	// img 태그
+	p.AllowAttrs("src", "alt", "title", "width", "height", "loading").OnElements("img")
+
+	// iframe — 허용 도메인만 통과 (후처리에서 검증)
+	p.AllowAttrs("src", "width", "height", "frameborder", "allow", "allowfullscreen",
+		"referrerpolicy", "loading", "scrolling", "allowtransparency").OnElements("iframe")
+	p.AllowAttrs("allowfullscreen").OnElements("iframe")
+
+	// video/audio/source 속성
+	p.AllowAttrs("src", "type", "controls", "autoplay", "muted", "loop",
+		"playsinline", "preload", "width", "height").OnElements("video", "audio", "source")
+
+	// 공통 속성
+	p.AllowAttrs("class").Globally()
+	p.AllowAttrs("alt", "title").Globally()
+
+	// data 속성 (에디터/임베드용)
+	p.AllowAttrs("data-youtube-video", "data-platform", "data-embed-height",
+		"data-tweet-id", "data-bluesky-uri", "data-bluesky-cid").Globally()
+
+	// details 태그의 open 속성
+	p.AllowAttrs("open").OnElements("details")
+
+	// start 속성 (ol)
+	p.AllowAttrs("start").OnElements("ol")
+
+	// style 속성 — 안전한 CSS만 허용
+	p.AllowStyles(safeCSSProperties...).Globally()
+
+	// target="_blank" 자동으로 rel 추가
+	p.RequireNoFollowOnLinks(false)
+
+	return p
+}
+
+// newCommentPolicy는 댓글용 bluemonday 정책을 생성한다.
+func newCommentPolicy() *bluemonday.Policy {
+	p := bluemonday.NewPolicy()
+
+	p.AllowElements("p", "br", "span")
+	p.AllowElements("strong", "b", "em", "i", "code", "s", "del")
+
+	// a 태그 — nofollow noopener 강제
+	p.AllowAttrs("href", "target", "rel").OnElements("a")
+	p.AllowURLSchemes("https", "http", "mailto", "tel")
+	p.RequireNoFollowOnLinks(true)
+	p.RequireNoFollowOnFullyQualifiedLinks(true)
+	p.AddTargetBlankToFullyQualifiedLinks(true)
+
+	return p
+}
+
+// 싱글톤 정책 (재사용)
+var (
+	postPolicy    = newPostPolicy()
+	commentPolicy = newCommentPolicy()
+	strictPolicy  = bluemonday.StrictPolicy()
+)
+
+// SanitizePostContent는 게시글 본문 HTML을 정제한다.
+// 안전한 태그/속성만 허용하고, iframe은 허용 도메인만 통과시킨다.
+func SanitizePostContent(html string) string {
+	sanitized := postPolicy.Sanitize(html)
+	// iframe src가 허용 도메인이 아닌 경우 제거
+	sanitized = removeDisallowedIframes(sanitized)
+	return sanitized
+}
+
+// SanitizeComment는 댓글 HTML을 정제한다.
+// 기본 서식만 허용하고, 모든 링크에 rel="nofollow noopener"를 강제한다.
+func SanitizeComment(html string) string {
+	return commentPolicy.Sanitize(html)
+}
+
+// SanitizeMessage는 메시지 텍스트에서 모든 HTML을 제거하고 텍스트만 반환한다.
+func SanitizeMessage(text string) string {
+	return strictPolicy.Sanitize(text)
+}
+
+// iframeRegex는 iframe 태그를 매칭하는 정규식
+var iframeRegex = regexp.MustCompile(`(?i)<iframe\s[^>]*src="([^"]*)"[^>]*>[\s\S]*?</iframe>`)
+
+// removeDisallowedIframes는 허용 도메인이 아닌 iframe을 제거한다.
+func removeDisallowedIframes(html string) string {
+	return iframeRegex.ReplaceAllStringFunc(html, func(match string) string {
+		submatch := iframeRegex.FindStringSubmatch(match)
+		if len(submatch) < 2 {
+			return ""
+		}
+		src := submatch[1]
+		if allowedIframeSrcRegex.MatchString(src) {
+			return match
+		}
+		return ""
+	})
+}

--- a/internal/common/sanitize_test.go
+++ b/internal/common/sanitize_test.go
@@ -1,0 +1,209 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizePostContent_RemovesScript(t *testing.T) {
+	input := `<p>Hello</p><script>alert('xss')</script><p>World</p>`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "<script") {
+		t.Errorf("script tag not removed: %s", result)
+	}
+	if !strings.Contains(result, "<p>Hello</p>") {
+		t.Errorf("safe p tag removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_PreservesSafeTags(t *testing.T) {
+	input := `<p>text</p><strong>bold</strong><em>italic</em><a href="https://example.com">link</a>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "<p>") {
+		t.Errorf("p tag removed: %s", result)
+	}
+	if !strings.Contains(result, "<strong>") {
+		t.Errorf("strong tag removed: %s", result)
+	}
+	if !strings.Contains(result, "<a ") {
+		t.Errorf("a tag removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_PreservesImg(t *testing.T) {
+	input := `<img src="https://example.com/photo.jpg" alt="photo" loading="lazy">`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "<img") {
+		t.Errorf("img tag removed: %s", result)
+	}
+	if !strings.Contains(result, `alt="photo"`) {
+		t.Errorf("alt attribute removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_YouTubeIframePreserved(t *testing.T) {
+	input := `<iframe src="https://www.youtube.com/embed/abc123" width="560" height="315" frameborder="0" allowfullscreen></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "youtube.com/embed/abc123") {
+		t.Errorf("YouTube iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_YouTubeNoCookiePreserved(t *testing.T) {
+	input := `<iframe src="https://www.youtube-nocookie.com/embed/abc123" width="560" height="315"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "youtube-nocookie.com") {
+		t.Errorf("YouTube nocookie iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_NonYoutubeIframeRemoved(t *testing.T) {
+	input := `<iframe src="https://evil.com/phish" width="100%" height="500"></iframe>`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "evil.com") {
+		t.Errorf("non-YouTube iframe not removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_DangerousCSSRemoved(t *testing.T) {
+	input := `<div style="position: fixed; z-index: 9999; top: 0; left: 0; width: 100vw;">overlay</div>`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "position") {
+		t.Errorf("dangerous CSS 'position' not removed: %s", result)
+	}
+	if strings.Contains(result, "z-index") {
+		t.Errorf("dangerous CSS 'z-index' not removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_SafeCSSPreserved(t *testing.T) {
+	input := `<p style="color: red; font-size: 16px;">styled</p>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "color") {
+		t.Errorf("safe CSS 'color' removed: %s", result)
+	}
+	if !strings.Contains(result, "font-size") {
+		t.Errorf("safe CSS 'font-size' removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_JavascriptHrefBlocked(t *testing.T) {
+	input := `<a href="javascript:alert('xss')">click</a>`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "javascript:") {
+		t.Errorf("javascript: href not blocked: %s", result)
+	}
+}
+
+func TestSanitizePostContent_OnEventHandlersRemoved(t *testing.T) {
+	input := `<img src="x" onerror="alert('xss')">`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "onerror") {
+		t.Errorf("onerror attribute not removed: %s", result)
+	}
+}
+
+func TestSanitizeComment_BasicFormatting(t *testing.T) {
+	input := `<p>Hello <strong>bold</strong> <em>italic</em></p>`
+	result := SanitizeComment(input)
+	if !strings.Contains(result, "<strong>") {
+		t.Errorf("strong tag removed from comment: %s", result)
+	}
+}
+
+func TestSanitizeComment_NoImgAllowed(t *testing.T) {
+	input := `<p>text</p><img src="https://example.com/img.jpg"><p>more</p>`
+	result := SanitizeComment(input)
+	if strings.Contains(result, "<img") {
+		t.Errorf("img tag should not be allowed in comments: %s", result)
+	}
+}
+
+func TestSanitizeComment_NoIframeAllowed(t *testing.T) {
+	input := `<iframe src="https://youtube.com/embed/abc"></iframe>`
+	result := SanitizeComment(input)
+	if strings.Contains(result, "<iframe") {
+		t.Errorf("iframe should not be allowed in comments: %s", result)
+	}
+}
+
+func TestSanitizeComment_NofollowAdded(t *testing.T) {
+	input := `<a href="https://example.com">link</a>`
+	result := SanitizeComment(input)
+	if !strings.Contains(result, "nofollow") {
+		t.Errorf("nofollow not added to comment link: %s", result)
+	}
+}
+
+func TestSanitizeMessage_StripsAllHTML(t *testing.T) {
+	input := `<p>Hello <strong>World</strong></p><script>alert('x')</script>`
+	result := SanitizeMessage(input)
+	if strings.Contains(result, "<") {
+		t.Errorf("HTML tags not stripped: %s", result)
+	}
+	if !strings.Contains(result, "Hello") || !strings.Contains(result, "World") {
+		t.Errorf("text content lost: %s", result)
+	}
+}
+
+func TestSanitizePostContent_DataAttributes(t *testing.T) {
+	input := `<div data-youtube-video="true" data-platform="youtube">embed</div>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "data-youtube-video") {
+		t.Errorf("data-youtube-video attribute removed: %s", result)
+	}
+	if !strings.Contains(result, "data-platform") {
+		t.Errorf("data-platform attribute removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_TwitterIframePreserved(t *testing.T) {
+	input := `<iframe src="https://platform.twitter.com/embed/Tweet.html?id=123" width="550" height="300" data-tweet-id="123"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "platform.twitter.com") {
+		t.Errorf("Twitter iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_BlueskyIframePreserved(t *testing.T) {
+	input := `<iframe src="https://embed.bsky.app/embed/post/abc" width="550" height="300"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "embed.bsky.app") {
+		t.Errorf("Bluesky iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_VimeoIframePreserved(t *testing.T) {
+	input := `<iframe src="https://player.vimeo.com/video/123456" width="640" height="360"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "player.vimeo.com") {
+		t.Errorf("Vimeo iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_SpotifyIframePreserved(t *testing.T) {
+	input := `<iframe src="https://open.spotify.com/embed/track/abc" width="300" height="380"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "open.spotify.com") {
+		t.Errorf("Spotify iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_InstagramIframePreserved(t *testing.T) {
+	input := `<iframe src="https://www.instagram.com/p/abc123/embed" width="400" height="500"></iframe>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "instagram.com") {
+		t.Errorf("Instagram iframe removed: %s", result)
+	}
+}
+
+func TestSanitizePostContent_DetailsTag(t *testing.T) {
+	input := `<details open><summary>Title</summary><p>Content</p></details>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "<details") {
+		t.Errorf("details tag removed: %s", result)
+	}
+	if !strings.Contains(result, "<summary>") {
+		t.Errorf("summary tag removed: %s", result)
+	}
+}

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -422,7 +422,7 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 		BoardID:  board.ID,
 		UserID:   userID,
 		Title:    req.Title,
-		Content:  req.Content,
+		Content:  common.SanitizePostContent(req.Content),
 		Status:   "published",
 		IsSecret: req.IsSecret != nil && *req.IsSecret,
 	}
@@ -524,7 +524,7 @@ func (h *V2Handler) UpdatePost(c *gin.Context) {
 		post.Title = req.Title
 	}
 	if req.Content != "" {
-		post.Content = req.Content
+		post.Content = common.SanitizePostContent(req.Content)
 	}
 	if err := h.postRepo.Update(post); err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 수정 실패", err)
@@ -835,7 +835,7 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		PostID:   postID,
 		UserID:   userID,
 		ParentID: req.ParentID,
-		Content:  req.Content,
+		Content:  common.SanitizeComment(req.Content),
 		Status:   "active",
 	}
 	if req.ParentID != nil {
@@ -955,7 +955,7 @@ func (h *V2Handler) UpdateComment(c *gin.Context) {
 		return
 	}
 
-	comment.Content = req.Content
+	comment.Content = common.SanitizeComment(req.Content)
 	if err := h.commentRepo.Update(comment); err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 수정 실패", err)
 		return


### PR DESCRIPTION
## Summary
- bluemonday 기반 서버사이드 HTML sanitizer 추가 (게시글/댓글/메시지)
- CreatePost/UpdatePost/CreateComment/UpdateComment 핸들러에 sanitize 적용
- CSS 속성 화이트리스트로 위험 속성(position, z-index 등) 차단
- iframe 허용 도메인: YouTube, Twitter/X, Bluesky, Instagram, Vimeo, Spotify, CodePen, TikTok
- 22개 테스트 추가

## Test plan
- [x] `go test ./internal/common/ -run TestSanitize` 22개 전부 통과
- [x] `make build` 성공
- [x] dev 환경 배포 후 promotion/218272 페이지 정상 로드 확인
- [ ] 새 글 작성 시 script 태그 제거 확인
- [ ] 소셜미디어 임베드 (Twitter, YouTube) 정상 동작 확인