### PR TITLE
fix: 소명 게시판 + 이용제한 버그 수정

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -229,7 +229,7 @@ func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 
 		h.db.Table(table).Where(filter, memberID).Count(&total)
 		h.db.Table(table).Select(disciplineLogColumns).Where(filter, memberID).
-			Order("wr_num, wr_reply").Offset(offset).Limit(limit).Find(&posts)
+			Order("wr_id DESC").Offset(offset).Limit(limit).Find(&posts)
 	} else {
 		var err error
 		posts, total, err = h.writeRepo.FindPosts("disciplinelog", page, limit)
@@ -350,12 +350,13 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
 	}
 
-	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 = 'disciplinelog:{id}')
+	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 매칭: 슬래시/콜론 양쪽)
 	var claimPostID int
-	linkValue := "disciplinelog:" + strconv.Itoa(id)
+	linkColon := "disciplinelog:" + strconv.Itoa(id)
+	linkSlash := "disciplinelog/" + strconv.Itoa(id)
 	err = h.db.Table("g5_write_claim").
 		Select("wr_id").
-		Where("wr_link1 = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkValue).
+		Where("(wr_link1 = ? OR wr_link1 = ?) AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkColon, linkSlash).
 		Order("wr_id DESC").
 		Limit(1).
 		Scan(&claimPostID).Error

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -476,6 +477,7 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 
 // UpdatePost handles PUT /api/v1/boards/:slug/posts/:id
 func (h *V2Handler) UpdatePost(c *gin.Context) {
+	slug := c.Param("slug")
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
@@ -486,6 +488,16 @@ func (h *V2Handler) UpdatePost(c *gin.Context) {
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
 		return
+	}
+
+	// 소명글 수정 차단: claim 게시판에서 disciplinelog 연동 글은 수정 불가
+	if slug == "claim" && h.gnuDB != nil && middleware.GetUserLevel(c) < 10 {
+		var link1 string
+		h.gnuDB.Table("g5_write_claim").Select("wr_link1").Where("wr_id = ?", id).Scan(&link1)
+		if strings.HasPrefix(link1, "disciplinelog") {
+			common.V2ErrorResponse(c, http.StatusForbidden, "소명글은 수정할 수 없습니다.", nil)
+			return
+		}
 	}
 
 	// 권한 체크: 작성자 또는 관리자만 수정 가능
@@ -535,6 +547,7 @@ func (h *V2Handler) UpdatePost(c *gin.Context) {
 
 // DeletePost handles DELETE /api/v1/boards/:slug/posts/:id (soft delete)
 func (h *V2Handler) DeletePost(c *gin.Context) {
+	slug := c.Param("slug")
 	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 게시글 ID", err)
@@ -545,6 +558,16 @@ func (h *V2Handler) DeletePost(c *gin.Context) {
 	if err != nil {
 		common.V2ErrorResponse(c, http.StatusNotFound, "게시글을 찾을 수 없습니다", err)
 		return
+	}
+
+	// 소명글 삭제 차단: claim 게시판에서 disciplinelog 연동 글은 삭제 불가
+	if slug == "claim" && h.gnuDB != nil && middleware.GetUserLevel(c) < 10 {
+		var link1 string
+		h.gnuDB.Table("g5_write_claim").Select("wr_link1").Where("wr_id = ?", id).Scan(&link1)
+		if strings.HasPrefix(link1, "disciplinelog") {
+			common.V2ErrorResponse(c, http.StatusForbidden, "소명글은 삭제할 수 없습니다.", nil)
+			return
+		}
 	}
 
 	// 권한 체크: 작성자 또는 관리자만 삭제 가능

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -35,8 +35,18 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			Select("mb_intercept_date").
 			Where("mb_id = ?", mbID).
 			Row().Scan(&interceptDate)
-		if err != nil || interceptDate == "" {
-			// mb_intercept_date가 비어있어도 g5_da_member_discipline에 활성 제재가 있으면 차단
+		// mb_intercept_date가 비어있거나, 파싱 실패하거나, 만료된 경우 → fallback으로 discipline 테이블 재확인
+		needsFallback := (err != nil || interceptDate == "")
+		if !needsFallback {
+			banEnd, parseErr := parseInterceptDate(interceptDate)
+			if parseErr != nil {
+				needsFallback = true
+			} else if time.Now().After(banEnd) {
+				needsFallback = true
+			}
+		}
+
+		if needsFallback {
 			var penaltyEndDate string
 			fallbackErr := gnuDB.Raw(
 				`SELECT CASE
@@ -69,9 +79,8 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		now := time.Now()
-		if now.After(banEnd) {
-			// Ban expired
+		if time.Now().After(banEnd) {
+			// Ban expired (and no active discipline found in fallback)
 			c.Next()
 			return
 		}


### PR DESCRIPTION
## Summary
- wr_link1 슬래시/콜론 양쪽 매칭으로 레거시 소명글 53건 호환
- 소명글 수정/삭제 차단 (관리자 제외)
- BanCheck 만료 후 g5_da_member_discipline 테이블 재확인 (bug/8454)
- 이용제한 내역 최신순 정렬 (bug/8447)

## Test plan
- [ ] disciplinelog 상세 API에서 레거시 소명글(슬래시 형식)도 claim_post_id 반환 확인
- [ ] claim 게시판에서 소명글 수정/삭제 시 403 반환 확인
- [ ] mb_intercept_date 만료 + discipline 활성 제재 → 글쓰기 차단 확인
- [ ] 이용제한 20건 이상 회원의 전체 내역 최신순 정렬 확인