### PR TITLE
fix: penalty_type=level 징계 시 활동 차단 누락 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4222,8 +4222,8 @@ func main() {
 		v2MemoRepo := v2repo.NewMemoRepository(db)
 		v2BlockRepo := v2repo.NewBlockRepository(db)
 		v2MessageRepo := v2repo.NewMessageRepository(db)
-		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager)
-		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager)
+		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager, db)
+		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager, db)
 		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
 		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
 		v2routes.SetupFavorite(router, v2handler.NewFavoriteHandler(db), jwtManager)
@@ -4430,7 +4430,7 @@ func main() {
 		})
 
 		// POST /api/v1/polls/:id/vote — 투표 참여
-		pollGroup.POST("/:id/vote", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		pollGroup.POST("/:id/vote", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			pollID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid poll ID"})

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -437,21 +437,17 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 	// disciplineType에 따라 적절한 필드만 업데이트
 	penaltyTypes := convertDisciplineType(disciplineType)
 
-	// "access" 유형에서만 mb_intercept_date 설정
-	// "level" 유형은 g5_member 변경 없음 (mb_level 강등도 하지 않음)
-	for _, pt := range penaltyTypes {
-		if pt == "access" {
-			var restrictionEndDate string
-			if disciplineDays == 9999 {
-				restrictionEndDate = "99991231"
-			} else {
-				restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
-			}
-			if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).
-				Update("mb_intercept_date", restrictionEndDate).Error; err != nil {
-				return err
-			}
-			break
+	// penalty_type 무관하게 disciplineDays > 0이면 항상 mb_intercept_date 설정
+	if disciplineDays > 0 || disciplineDays == 9999 {
+		var restrictionEndDate string
+		if disciplineDays == 9999 {
+			restrictionEndDate = "99991231"
+		} else {
+			restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
+		}
+		if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).
+			Update("mb_intercept_date", restrictionEndDate).Error; err != nil {
+			return err
 		}
 	}
 

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -55,7 +55,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 					END
 				 FROM g5_da_member_discipline
 				 WHERE penalty_mb_id = ?
-				   AND penalty_type IN ('intercept', 'both', 'all')
+				   AND penalty_type IN ('intercept', 'both', 'all', 'level')
 				   AND (
 						penalty_period = -1
 						OR (penalty_period > 0 AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW())

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -132,11 +132,12 @@ func SetupAdminSettings(router *gin.Engine, h *v2handler.AdminSettingsHandler, j
 }
 
 // SetupScrap configures v2 scrap routes
-func SetupScrap(router *gin.Engine, h *v2handler.ScrapHandler, jwtManager *jwt.Manager) {
+func SetupScrap(router *gin.Engine, h *v2handler.ScrapHandler, jwtManager *jwt.Manager, gnuDB *gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)
+	banCheck := middleware.BanCheck(gnuDB)
 
 	posts := router.Group("/api/v2/posts")
-	posts.POST("/:id/scrap", auth, h.AddScrap)
+	posts.POST("/:id/scrap", auth, banCheck, h.AddScrap)
 	posts.DELETE("/:id/scrap", auth, h.RemoveScrap)
 
 	me := router.Group("/api/v2/me", auth)
@@ -144,12 +145,13 @@ func SetupScrap(router *gin.Engine, h *v2handler.ScrapHandler, jwtManager *jwt.M
 }
 
 // SetupMemo configures v2 memo routes
-func SetupMemo(router *gin.Engine, h *v2handler.MemoHandler, jwtManager *jwt.Manager) {
+func SetupMemo(router *gin.Engine, h *v2handler.MemoHandler, jwtManager *jwt.Manager, gnuDB *gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)
+	banCheck := middleware.BanCheck(gnuDB)
 
 	memo := router.Group("/api/v2/members/:id/memo", auth)
 	memo.GET("", h.GetMemo)
-	memo.POST("", h.CreateMemo)
+	memo.POST("", banCheck, h.CreateMemo)
 	memo.PUT("", h.UpdateMemo)
 	memo.DELETE("", h.DeleteMemo)
 	memo.GET("/all", middleware.RequireAdmin(), h.GetAllMemos)


### PR DESCRIPTION
## Summary
- `ban_check.go` fallback 쿼리에 `penalty_type = 'level'` 추가 (기존 데이터 안전장치)
- 크론 처리(`report_process.go`) 시 `penalty_type` 무관하게 `mb_intercept_date` 항상 설정
- scrap, memo, poll vote 엔드포인트에 `banCheck` 미들웨어 추가
- 기존 `level` 징계 28건 `mb_intercept_date` DB 보정 완료

## Test plan
- [ ] 징계 회원 글쓰기/댓글 시도 → 403
- [ ] 징계 회원 스크랩/쪽지/투표 시도 → 403
- [ ] 징계 회원 로그인 → 정상
- [ ] 비징계 회원 정상 활동 확인