### PR TITLE
fix: 소명글 링크 매칭 시 풀 URL도 지원

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -350,13 +350,14 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
 	}
 
-	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 매칭: 슬래시/콜론 양쪽)
+	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 매칭: 상대경로/풀URL 모두)
 	var claimPostID int
 	linkColon := "disciplinelog:" + strconv.Itoa(id)
 	linkSlash := "disciplinelog/" + strconv.Itoa(id)
+	linkLike := "%disciplinelog/" + strconv.Itoa(id)
 	err = h.db.Table("g5_write_claim").
 		Select("wr_id").
-		Where("(wr_link1 = ? OR wr_link1 = ?) AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkColon, linkSlash).
+		Where("(wr_link1 = ? OR wr_link1 = ? OR wr_link1 LIKE ?) AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkColon, linkSlash, linkLike).
 		Order("wr_id DESC").
 		Limit(1).
 		Scan(&claimPostID).Error


### PR DESCRIPTION
## Summary
- disciplinelog 상세에서 소명글 보기 버튼이 안 보이던 버그 수정
- 프론트에서 wr_link1에 풀 URL 저장 → 백엔드 LIKE 패턴 추가로 매칭

## Test plan
- [x] `curl localhost:8090/api/v1/discipline-logs/3337` → claim_post_id: 1266 확인
- [ ] dev.damoang.net/disciplinelog/3337 에서 "소명글 보기" 버튼 표시 확인