### PR TITLE
fix: 크론 GROUP BY에 admin_discipline_reasons 추가

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -85,7 +85,7 @@ func runProcessApprovedReports(db *gorm.DB) (*ProcessReportsResult, error) {
 			COUNT(*) as report_count
 		FROM g5_na_singo
 		WHERE admin_approved = 1 AND processed = 0
-		GROUP BY target_mb_id, admin_discipline_days, admin_discipline_type, DATE(admin_datetime)
+		GROUP BY target_mb_id, admin_discipline_days, admin_discipline_type, admin_discipline_reasons, DATE(admin_datetime)
 		ORDER BY MAX(admin_datetime) ASC
 	`).Scan(&groups).Error; err != nil {
 		return nil, fmt.Errorf("승인된 신고 조회 실패: %w", err)


### PR DESCRIPTION
## Summary
- 승인 건 배치 처리 시 GROUP BY에 admin_discipline_reasons 추가
- 같은 유저에 대해 다른 사유로 승인된 건들이 별도 그룹으로 처리됨

## Test plan
- [ ] make build 성공
- [ ] 크론 실행 시 다른 사유 건이 별도 처리되는지 확인