### PR TITLE
feat: promotion 게시판 본문 이미지 원본 서빙

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1827,7 +1827,7 @@ func main() {
 				}
 			}
 
-			postDetail := v1handler.TransformToV1PostDetail(post, isNotice)
+			postDetail := v1handler.TransformToV1PostDetail(post, isNotice, slug)
 
 			// 태그 조회
 			if tags, err := gnuTagRepo.GetPostTags(slug, id); err == nil && len(tags) > 0 {
@@ -2390,7 +2390,7 @@ func main() {
 
 			payload := gin.H{
 				"success": true,
-				"data":    v1handler.TransformToV1PostDetail(&post, false),
+				"data":    v1handler.TransformToV1PostDetail(&post, false, slug),
 			}
 			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusCreated, payload)
 			phaseDurations["after_write"] = time.Since(phaseStart)

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -24,9 +24,11 @@ func init() {
 	if cdnURL != "" {
 		if parsed, err := url.Parse(cdnURL); err == nil {
 			host := regexp.QuoteMeta(parsed.Host)
+			// cdn.damoang.net 레거시 URL도 매칭 (에디터 업로드 시점에 따라 도메인이 다름)
+			hostPattern := "(?:" + host + "|cdn\\.damoang\\.net)"
 			// GIF 제외: 애니메이션 손실 방지
-			thumbnailRegex = regexp.MustCompile(`(?i)^(https?://` + host + `/data/(?:file|editor)/.+)\.(jpg|jpeg|png|webp)$`)
-			imgTagSrcRegex = regexp.MustCompile(`(<img\s[^>]*?src=)(["'])(https?://` + host + `/data/(?:file|editor)/.+?\.(?:jpg|jpeg|png|webp))(["'])`)
+			thumbnailRegex = regexp.MustCompile(`(?i)^(https?://` + hostPattern + `/data/(?:file|editor)/.+)\.(jpg|jpeg|png|webp)$`)
+			imgTagSrcRegex = regexp.MustCompile(`(<img\s[^>]*?src=)(["'])(https?://` + hostPattern + `/data/(?:file|editor)/.+?\.(?:jpg|jpeg|png|webp))(["'])`)
 		}
 	}
 }
@@ -63,7 +65,7 @@ func optimizeContentImages(html string) string {
 		imgPrefix := parts[1] // <img ... src=
 		quote := parts[2]     // " or '
 		originalURL := parts[3]
-		thumbURL := toThumbnailURL(originalURL, "835x626")
+		thumbURL := toThumbnailURL(originalURL, "1200x900")
 		if thumbURL == originalURL {
 			return match
 		}
@@ -132,13 +134,18 @@ func normalizeMediaURL(raw string) string {
 	return raw
 }
 
-func normalizeMediaContent(raw string) string {
+func normalizeMediaContent(raw string, boardID ...string) string {
 	cdnURL := strings.TrimRight(os.Getenv("CDN_URL"), "/")
 	if raw == "" {
 		return raw
 	}
 
+	skipThumbnail := len(boardID) > 0 && boardID[0] == "promotion"
+
 	if cdnURL == "" {
+		if skipThumbnail {
+			return raw
+		}
 		return optimizeContentImages(raw)
 	}
 
@@ -161,6 +168,9 @@ func normalizeMediaContent(raw string) string {
 		`href='data/`, `href='`+cdnURL+`/data/`,
 	)
 	result := replacer.Replace(raw)
+	if skipThumbnail {
+		return result
+	}
 	return optimizeContentImages(result)
 }
 
@@ -247,9 +257,9 @@ func TransformToV1Post(w *gnuboard.G5Write, isNotice bool) map[string]any {
 }
 
 // TransformToV1PostDetail converts G5Write to detailed v1 API response format
-func TransformToV1PostDetail(w *gnuboard.G5Write, isNotice bool) map[string]any {
+func TransformToV1PostDetail(w *gnuboard.G5Write, isNotice bool, boardID ...string) map[string]any {
 	result := TransformToV1Post(w, isNotice)
-	result["content"] = normalizeMediaContent(w.WrContent)
+	result["content"] = normalizeMediaContent(w.WrContent, boardID...)
 	if w.Wr9 != "" {
 		result["extra_9"] = w.Wr9
 	}


### PR DESCRIPTION
## Summary
- promotion 게시판에서 본문 이미지 썸네일 변환을 스킵하여 원본 이미지 그대로 서빙
- 광고주 이미지(1000px)가 1200px 썸네일로 업스케일되면서 왜곡되는 문제 해결
- cdn.damoang.net 레거시 URL 매칭 추가
- 본문 이미지 기본 썸네일 사이즈 835x626 → 1200x900 변경

## 변경 내용
- `normalizeMediaContent(raw, boardID ...string)` — promotion이면 썸네일 변환 스킵
- `TransformToV1PostDetail(w, isNotice, boardID ...string)` — boardID 전달
- 호출부 2곳 (`cmd/api/main.go`) slug 전달

## Test plan
- [ ] `dev.damoang.net/promotion/218668` → img src에 원본 URL (썸네일 접미사 없음)
- [ ] `dev.damoang.net/free/XXXXX` → img src에 `-1200x900.webp` 접미사 확인
- [ ] 기존 게시판 이미지 정상 표시 확인