### PR TITLE
fix: 소명글 검색 시 wr_content 본문 링크도 매칭

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -350,14 +350,16 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
 	}
 
-	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 매칭: 상대경로/풀URL 모두)
+	// 소명글 존재 여부 조회 (claim 게시판에서 wr_link1 또는 wr_content 매칭)
 	var claimPostID int
 	linkColon := "disciplinelog:" + strconv.Itoa(id)
 	linkSlash := "disciplinelog/" + strconv.Itoa(id)
 	linkLike := "%disciplinelog/" + strconv.Itoa(id)
+	contentLikeRel := `%href="/disciplinelog/` + strconv.Itoa(id) + `"%`
+	contentLikeFull := `%href="https://damoang.net/disciplinelog/` + strconv.Itoa(id) + `"%`
 	err = h.db.Table("g5_write_claim").
 		Select("wr_id").
-		Where("(wr_link1 = ? OR wr_link1 = ? OR wr_link1 LIKE ?) AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkColon, linkSlash, linkLike).
+		Where("(wr_link1 = ? OR wr_link1 = ? OR wr_link1 LIKE ? OR wr_content LIKE ? OR wr_content LIKE ?) AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", linkColon, linkSlash, linkLike, contentLikeRel, contentLikeFull).
 		Order("wr_id DESC").
 		Limit(1).
 		Scan(&claimPostID).Error


### PR DESCRIPTION
수동 작성된 소명글은 wr_link1에 disciplinelog 링크가 없고
본문(wr_content)에만 href로 링크가 있어서 연결이 안 되는
케이스(약 20건) 수정. href 속성의 따옴표로 정확한 ID 매칭.