### PR TITLE
썸네일 크기 변환 근본 수정: 다른 크기 suffix 교체 지원

### DIFF
--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -41,10 +41,16 @@ func toThumbnailURL(rawURL string, size string) string {
 	if thumbnailRegex == nil {
 		return rawURL
 	}
-	// 이미 썸네일 URL이면 이중 변환 방지
-	if thumbnailSuffixRegex.MatchString(rawURL) {
+	// 이미 요청한 크기와 동일한 썸네일이면 스킵
+	if strings.HasSuffix(rawURL, "-"+size+".webp") {
 		return rawURL
 	}
+	// 다른 크기의 썸네일이면 크기 suffix 제거 후 재생성
+	if loc := thumbnailSuffixRegex.FindStringIndex(rawURL); loc != nil {
+		base := rawURL[:loc[0]]
+		return base + "-" + size + ".webp"
+	}
+	// 썸네일이 아닌 일반 URL → 기존 로직
 	m := thumbnailRegex.FindStringSubmatch(rawURL)
 	if m == nil {
 		return rawURL


### PR DESCRIPTION
## Summary
- `toThumbnailURL`: 요청 크기와 다른 썸네일(`-835x626.webp`)이면 suffix 교체하여 올바른 크기 반환
- 기존 문제: `-숫자x숫자.webp` 무조건 스킵 → 835x626 그대로 사용
- 변경: 요청 크기와 동일할 때만 스킵, 다르면 원본 기준 재생성

## Test plan
- [ ] `dbc1c18-835x626.webp` → `dbc1c18-400x225.webp`로 변환 확인
- [ ] 이미 `400x225`인 URL은 변환 스킵 확인
- [ ] suffix 없는 일반 이미지 URL 변환 정상 확인