### PR TITLE
fix: 수정이력 양쪽 테이블 기록 + 삭제 grace period 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -377,6 +377,14 @@ func filterItems(items []map[string]any, blockedIDs []string) []map[string]any {
 	return filtered
 }
 
+// safeIntToUint64 converts int to uint64, clamping negative values to 0.
+func safeIntToUint64(v int) uint64 {
+	if v < 0 {
+		return 0
+	}
+	return uint64(v) // #nosec G115 -- IDs are always non-negative
+}
+
 func main() {
 	dotenvFiles := config.LoadDotEnv()
 
@@ -2363,7 +2371,7 @@ func main() {
 			if v2RevisionRepo != nil {
 				userIDUint, _ := strconv.ParseUint(mbID, 10, 64)
 				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
-					PostID:       uint64(post.WrID),
+					PostID:       safeIntToUint64(post.WrID),
 					Version:      1,
 					ChangeType:   "create",
 					Title:        post.WrSubject,
@@ -2636,7 +2644,7 @@ func main() {
 			if v2RevisionRepo != nil {
 				userIDUint, _ := strconv.ParseUint(mbID, 10, 64)
 				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
-					PostID:       uint64(createdComment.WrID),
+					PostID:       safeIntToUint64(createdComment.WrID),
 					Version:      1,
 					ChangeType:   "create",
 					Content:      createdComment.WrContent,
@@ -2745,9 +2753,9 @@ func main() {
 			if v2RevisionRepo != nil {
 				userIDUint, _ := strconv.ParseUint(userID, 10, 64)
 				nickname := middleware.GetNickname(c)
-				v2NextVer, _ := v2RevisionRepo.GetNextVersion(uint64(postID))
+				v2NextVer, _ := v2RevisionRepo.GetNextVersion(safeIntToUint64(postID))
 				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
-					PostID:       uint64(postID),
+					PostID:       safeIntToUint64(postID),
 					Version:      v2NextVer,
 					ChangeType:   "update",
 					Title:        post.WrSubject,
@@ -2904,9 +2912,9 @@ func main() {
 			if v2RevisionRepo != nil {
 				userIDUint, _ := strconv.ParseUint(userID, 10, 64)
 				nickname := middleware.GetNickname(c)
-				v2NextVer, _ := v2RevisionRepo.GetNextVersion(uint64(commentID))
+				v2NextVer, _ := v2RevisionRepo.GetNextVersion(safeIntToUint64(commentID))
 				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
-					PostID:       uint64(commentID),
+					PostID:       safeIntToUint64(commentID),
 					Version:      v2NextVer,
 					ChangeType:   "update",
 					Content:      comment.WrContent,

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2355,6 +2355,24 @@ func main() {
 			phaseDurations["insert"] = time.Since(phaseStart)
 			phaseStart = time.Now()
 
+			// 리비전 저장 (최초 작성) — 양쪽 테이블 모두 기록
+			db.Exec(`INSERT INTO g5_write_revisions
+				(board_id, wr_id, version, change_type, title, content, edited_by, edited_by_name, edited_at)
+				VALUES (?, ?, 1, 'create', ?, ?, ?, ?, NOW())`,
+				slug, post.WrID, post.WrSubject, post.WrContent, mbID, post.WrName)
+			if v2RevisionRepo != nil {
+				userIDUint, _ := strconv.ParseUint(mbID, 10, 64)
+				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
+					PostID:       uint64(post.WrID),
+					Version:      1,
+					ChangeType:   "create",
+					Title:        post.WrSubject,
+					Content:      post.WrContent,
+					EditedBy:     userIDUint,
+					EditedByName: post.WrName,
+				})
+			}
+
 			// 태그 저장 (g5_na_tag / g5_na_tag_log)
 			if len(req.Tags) > 0 {
 				if err := gnuTagRepo.SetPostTags(slug, post.WrID, req.Tags, mbID); err != nil {
@@ -2610,6 +2628,23 @@ func main() {
 			}
 			comment := createdComment
 
+			// 리비전 저장 (댓글 최초 작성) — 양쪽 테이블 모두 기록
+			db.Exec(`INSERT INTO g5_write_revisions
+				(board_id, wr_id, version, change_type, title, content, edited_by, edited_by_name, edited_at)
+				VALUES (?, ?, 1, 'create', NULL, ?, ?, ?, NOW())`,
+				slug, createdComment.WrID, createdComment.WrContent, mbID, authorName)
+			if v2RevisionRepo != nil {
+				userIDUint, _ := strconv.ParseUint(mbID, 10, 64)
+				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
+					PostID:       uint64(createdComment.WrID),
+					Version:      1,
+					ChangeType:   "create",
+					Content:      createdComment.WrContent,
+					EditedBy:     userIDUint,
+					EditedByName: authorName,
+				})
+			}
+
 			// 포인트 처리 (g5_point 기반 FIFO 소비)
 			if board.BoCommentPoint != 0 {
 				var pc *v2repo.PointConfig
@@ -2700,13 +2735,27 @@ func main() {
 				return
 			}
 
-			// 수정 전 내용을 리비전에 저장
+			// 수정 전 내용을 리비전에 저장 — 양쪽 테이블 모두 기록
 			var nextVersion int
 			db.Raw("SELECT COALESCE(MAX(version), 0) + 1 FROM g5_write_revisions WHERE board_id = ? AND wr_id = ?", slug, postID).Scan(&nextVersion)
 			db.Exec(`INSERT INTO g5_write_revisions
 				(board_id, wr_id, version, change_type, title, content, edited_by, edited_by_name, edited_at)
 				VALUES (?, ?, ?, 'update', ?, ?, ?, ?, NOW())`,
 				slug, postID, nextVersion, post.WrSubject, post.WrContent, userID, post.WrName)
+			if v2RevisionRepo != nil {
+				userIDUint, _ := strconv.ParseUint(userID, 10, 64)
+				nickname := middleware.GetNickname(c)
+				v2NextVer, _ := v2RevisionRepo.GetNextVersion(uint64(postID))
+				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
+					PostID:       uint64(postID),
+					Version:      v2NextVer,
+					ChangeType:   "update",
+					Title:        post.WrSubject,
+					Content:      post.WrContent,
+					EditedBy:     userIDUint,
+					EditedByName: nickname,
+				})
+			}
 
 			// g5_da_content_history에도 이중 기록
 			{
@@ -2844,7 +2893,7 @@ func main() {
 				return
 			}
 
-			// 수정 전 내용을 리비전에 저장
+			// 수정 전 내용을 리비전에 저장 — 양쪽 테이블 모두 기록
 			var nextVersion int
 			db.Raw("SELECT COALESCE(MAX(version), 0) + 1 FROM g5_write_revisions WHERE board_id = ? AND wr_id = ?",
 				slug, commentID).Scan(&nextVersion)
@@ -2852,6 +2901,19 @@ func main() {
 				(board_id, wr_id, version, change_type, title, content, edited_by, edited_by_name, edited_at)
 				VALUES (?, ?, ?, 'update', NULL, ?, ?, ?, NOW())`,
 				slug, commentID, nextVersion, comment.WrContent, userID, comment.WrName)
+			if v2RevisionRepo != nil {
+				userIDUint, _ := strconv.ParseUint(userID, 10, 64)
+				nickname := middleware.GetNickname(c)
+				v2NextVer, _ := v2RevisionRepo.GetNextVersion(uint64(commentID))
+				_ = v2RevisionRepo.Create(&v2domain.V2ContentRevision{
+					PostID:       uint64(commentID),
+					Version:      v2NextVer,
+					ChangeType:   "update",
+					Content:      comment.WrContent,
+					EditedBy:     userIDUint,
+					EditedByName: nickname,
+				})
+			}
 
 			// g5_da_content_history에도 이중 기록
 			{
@@ -3016,7 +3078,37 @@ func main() {
 				return
 			}
 
-			// 일반 사용자: 무조건 지연 소프트 삭제
+			// 일반 사용자: 작성 후 5분 이내면 즉시 소프트 삭제 (grace period)
+			const deleteGracePeriod = 5 * time.Minute
+			if time.Since(post.WrDatetime) <= deleteGracePeriod {
+				txErr := db.Transaction(func(tx *gorm.DB) error {
+					now := time.Now()
+					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ?", postID).Updates(map[string]interface{}{
+						"wr_deleted_at": now,
+						"wr_deleted_by": userID,
+					}).Error; err != nil {
+						return err
+					}
+					return createWriteAfterEvent(
+						tx,
+						writeAfterEventRepo,
+						gnuboard.WriteAfterEventTypePostDeleted,
+						slug,
+						postID,
+						withWriteAfterMember(post.MbID, post.WrName),
+						withWriteAfterSubject(post.WrSubject),
+						withWriteAfterOccurredAt(now),
+					)
+				})
+				if txErr != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
+					return
+				}
+				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
+				return
+			}
+
+			// 5분 초과: 지연 소프트 삭제
 			commentCount := post.WrComment
 			delayMinutes := gnuboard.CalculateDelay(commentCount)
 

--- a/internal/domain/gnuboard/scheduled_delete.go
+++ b/internal/domain/gnuboard/scheduled_delete.go
@@ -27,7 +27,7 @@ func (ScheduledDelete) TableName() string {
 func CalculateDelay(replyCount int) int {
 	switch {
 	case replyCount == 0:
-		return 10
+		return 5
 	case replyCount <= 4:
 		return 30
 	case replyCount <= 9:


### PR DESCRIPTION
## Summary
- v1 핸들러(글/댓글 작성·수정)에서 `g5_write_revisions`와 `v2_content_revisions` 양쪽에 리비전 기록
- 일반 사용자 글 삭제 시 작성 후 5분 이내면 즉시 소프트 삭제 (grace period)
- `CalculateDelay(replyCount==0)` 10분 → 5분으로 변경

## 변경 내용
| 핸들러 | g5_write_revisions | v2_content_revisions |
|--------|-------------------|---------------------|
| CreatePost | ✅ 추가 | ✅ 추가 |
| UpdatePost | ✅ 기존 | ✅ 추가 |
| CreateComment | ✅ 추가 | ✅ 추가 |
| UpdateComment | ✅ 기존 | ✅ 추가 |

## Test plan
- [ ] 글 작성 후 `g5_write_revisions`, `v2_content_revisions` 양쪽에 create 레코드 확인
- [ ] 글 수정 후 양쪽 테이블에 update 레코드 확인
- [ ] 댓글 작성/수정도 동일하게 확인
- [ ] 글 작성 후 5분 이내 삭제 시 즉시 삭제 확인 (scheduled_deletes 미생성)
- [ ] 글 작성 후 5분 초과 삭제 시 기존 지연 삭제 로직 동작 확인 (5분 지연)