### PR TITLE
fix: mb_intercept_date datetime 정밀도 + 소명 댓글 제한

### DIFF
--- a/internal/cron/discipline_release.go
+++ b/internal/cron/discipline_release.go
@@ -1,11 +1,32 @@
 package cron
 
 import (
+	"fmt"
 	"log"
 	"time"
 
 	"gorm.io/gorm"
 )
+
+const (
+	cronInterceptDateFormat      = "2006-01-02 15:04:05"
+	cronInterceptDateDashFormat  = "2006-01-02"
+	cronInterceptDateShortFormat = "20060102"
+)
+
+// parseInterceptDateForCron parses mb_intercept_date (YYYYMMDD or YYYY-MM-DD HH:MM:SS)
+func parseInterceptDateForCron(s string) (time.Time, error) {
+	if t, err := time.ParseInLocation(cronInterceptDateFormat, s, time.Local); err == nil {
+		return t, nil
+	}
+	if t, err := time.ParseInLocation(cronInterceptDateDashFormat, s, time.Local); err == nil {
+		return t.Add(24*time.Hour - time.Second), nil
+	}
+	if t, err := time.ParseInLocation(cronInterceptDateShortFormat, s, time.Local); err == nil {
+		return t.Add(24*time.Hour - time.Second), nil
+	}
+	return time.Time{}, fmt.Errorf("unknown date format: %s", s)
+}
 
 // DisciplineReleaseResult contains the result of discipline release
 type DisciplineReleaseResult struct {
@@ -27,14 +48,29 @@ func runDisciplineRelease(db *gorm.DB) (*DisciplineReleaseResult, error) {
 	// LevelRestoredCount, LevelRestoredIDs는 항상 0/empty (struct 호환성 유지)
 
 	// Clear expired intercept dates
-	var interceptIDs []string
+	// 형식이 혼재(YYYYMMDD, YYYY-MM-DD HH:MM:SS)할 수 있으므로 모든 후보를 로드 → Go에서 파싱
+	type interceptRow struct {
+		MbID          string `gorm:"column:mb_id"`
+		InterceptDate string `gorm:"column:mb_intercept_date"`
+	}
+	var candidates []interceptRow
 	if err := db.Raw(`
-		SELECT mb_id FROM g5_member
+		SELECT mb_id, mb_intercept_date FROM g5_member
 		WHERE mb_intercept_date != '' AND mb_intercept_date != '0000-00-00'
-		  AND mb_intercept_date < ?
 		  AND mb_intercept_date NOT LIKE '9999%'
-	`, now.Format("20060102")).Scan(&interceptIDs).Error; err != nil {
+	`).Scan(&candidates).Error; err != nil {
 		return nil, err
+	}
+
+	var interceptIDs []string
+	for _, c := range candidates {
+		banEnd, err := parseInterceptDateForCron(c.InterceptDate)
+		if err != nil {
+			continue
+		}
+		if now.After(banEnd) {
+			interceptIDs = append(interceptIDs, c.MbID)
+		}
 	}
 
 	if len(interceptIDs) > 0 {

--- a/internal/cron/discipline_release_test.go
+++ b/internal/cron/discipline_release_test.go
@@ -1,0 +1,95 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseInterceptDateForCron(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		checkFunc func(t *testing.T, got time.Time)
+	}{
+		{
+			name:  "datetime format",
+			input: "2026-03-19 11:00:01",
+			checkFunc: func(t *testing.T, got time.Time) {
+				expected := time.Date(2026, 3, 19, 11, 0, 1, 0, time.Local)
+				if !got.Equal(expected) {
+					t.Errorf("expected %v, got %v", expected, got)
+				}
+			},
+		},
+		{
+			name:  "short YYYYMMDD — end of day",
+			input: "20260319",
+			checkFunc: func(t *testing.T, got time.Time) {
+				if got.Hour() != 23 || got.Minute() != 59 || got.Second() != 59 {
+					t.Errorf("expected 23:59:59, got %s", got.Format("15:04:05"))
+				}
+			},
+		},
+		{
+			name:  "dash format — end of day",
+			input: "2026-03-19",
+			checkFunc: func(t *testing.T, got time.Time) {
+				if got.Hour() != 23 || got.Minute() != 59 || got.Second() != 59 {
+					t.Errorf("expected 23:59:59, got %s", got.Format("15:04:05"))
+				}
+			},
+		},
+		{
+			name:    "invalid",
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseInterceptDateForCron(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, got)
+			}
+		})
+	}
+}
+
+func TestCronExpiredDetection(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.Local)
+
+	// datetime 형식: 11시에 만료 → 12시 now 기준 만료됨
+	banEnd, _ := parseInterceptDateForCron("2026-03-19 11:00:01")
+	if !now.After(banEnd) {
+		t.Error("datetime ban ending at 11:00:01 should be expired at 12:00:00")
+	}
+
+	// datetime 형식: 13시에 만료 → 아직 유효
+	banEnd2, _ := parseInterceptDateForCron("2026-03-19 13:00:00")
+	if now.After(banEnd2) {
+		t.Error("datetime ban ending at 13:00:00 should NOT be expired at 12:00:00")
+	}
+
+	// YYYYMMDD 형식: 20260319 → 23:59:59까지 유효 → 12시에는 아직 유효
+	banEnd3, _ := parseInterceptDateForCron("20260319")
+	if now.After(banEnd3) {
+		t.Error("YYYYMMDD ban for 20260319 should NOT be expired at 12:00:00 (valid until 23:59:59)")
+	}
+
+	// YYYYMMDD 형식: 20260318 → 어제 → 만료됨
+	banEnd4, _ := parseInterceptDateForCron("20260318")
+	if !now.After(banEnd4) {
+		t.Error("YYYYMMDD ban for 20260318 should be expired at 2026-03-19 12:00:00")
+	}
+}

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -443,7 +443,7 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 		if disciplineDays == 9999 {
 			restrictionEndDate = "99991231"
 		} else {
-			restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
+			restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("2006-01-02 15:04:05")
 		}
 		if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).
 			Update("mb_intercept_date", restrictionEndDate).Error; err != nil {

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -809,6 +809,22 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 	// 레벨 체크 (미들웨어 우회 방어)
 	userLevel := middleware.GetUserLevel(c)
 
+	// 소명 게시판: admin과 글 작성자만 댓글 가능
+	if slug == "claim" {
+		isAdmin := userLevel >= 10
+		if !isAdmin {
+			post, postErr := h.postRepo.FindByID(postID)
+			if postErr != nil {
+				common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 조회 실패", postErr)
+				return
+			}
+			if post.UserID != userID {
+				common.V2ErrorResponse(c, http.StatusForbidden, "소명 게시판에서는 관리자와 글 작성자만 댓글을 작성할 수 있습니다.", nil)
+				return
+			}
+		}
+	}
+
 	// 제휴 링크 차단 검증 (deal, economy 게시판)
 	if err := common.ValidateAffiliateLinks(req.Content, slug, userLevel, false); err != nil {
 		common.V2ErrorResponse(c, http.StatusForbidden, err.Error(), err)

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -51,7 +51,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			fallbackErr := gnuDB.Raw(
 				`SELECT CASE
 						WHEN penalty_period = -1 THEN '99991231'
-						ELSE DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y%m%d')
+						ELSE DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y-%m-%d %H:%i:%s')
 					END
 				 FROM g5_da_member_discipline
 				 WHERE penalty_mb_id = ?
@@ -66,7 +66,7 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 				c.Next()
 				return
 			}
-			// 활성 제재 발견 — mb_intercept_date 자동 복구(backfill, varchar(8) YYYYMMDD)
+			// 활성 제재 발견 — mb_intercept_date 자동 복구(backfill, datetime 형식)
 			gnuDB.Exec("UPDATE g5_member SET mb_intercept_date = ? WHERE mb_id = ?", penaltyEndDate, mbID)
 			interceptDate = penaltyEndDate
 		}

--- a/internal/middleware/ban_check_test.go
+++ b/internal/middleware/ban_check_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseInterceptDate(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		checkFunc func(t *testing.T, got time.Time)
+	}{
+		{
+			name:  "datetime format (future)",
+			input: now.Add(2 * time.Hour).Format("2006-01-02 15:04:05"),
+			checkFunc: func(t *testing.T, got time.Time) {
+				diff := got.Sub(now.Add(2 * time.Hour))
+				if diff < -2*time.Second || diff > 2*time.Second {
+					t.Errorf("expected ~2h from now, got diff=%v", diff)
+				}
+			},
+		},
+		{
+			name:  "datetime format (past)",
+			input: now.Add(-1 * time.Hour).Format("2006-01-02 15:04:05"),
+			checkFunc: func(t *testing.T, got time.Time) {
+				if !now.After(got) {
+					t.Error("expected past time to be before now")
+				}
+			},
+		},
+		{
+			name:  "short YYYYMMDD format — end of day",
+			input: now.Format("20060102"),
+			checkFunc: func(t *testing.T, got time.Time) {
+				// Should be 23:59:59 of that day
+				if got.Hour() != 23 || got.Minute() != 59 || got.Second() != 59 {
+					t.Errorf("expected 23:59:59, got %s", got.Format("15:04:05"))
+				}
+			},
+		},
+		{
+			name:  "dash YYYY-MM-DD format — end of day",
+			input: now.Format("2006-01-02"),
+			checkFunc: func(t *testing.T, got time.Time) {
+				if got.Hour() != 23 || got.Minute() != 59 || got.Second() != 59 {
+					t.Errorf("expected 23:59:59, got %s", got.Format("15:04:05"))
+				}
+			},
+		},
+		{
+			name:  "permanent ban 99991231",
+			input: "99991231",
+			checkFunc: func(t *testing.T, got time.Time) {
+				if got.Year() != 9999 {
+					t.Errorf("expected year 9999, got %d", got.Year())
+				}
+			},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "garbage",
+			input:   "not-a-date",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseInterceptDate(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, got)
+			}
+		})
+	}
+}
+
+func TestParseInterceptDateTimePrecision(t *testing.T) {
+	// 핵심 시나리오: 오전 11시에 제재가 풀려야 하는데 YYYYMMDD로 저장하면 23:59:59까지 제재
+	// datetime으로 저장하면 정확한 시간에 풀림
+
+	// 시나리오: 3/18 11:00:01에 1일 제재 → 3/19 11:00:01에 만료
+	banEnd := "2026-03-19 11:00:01"
+	parsed, err := parseInterceptDate(banEnd)
+	if err != nil {
+		t.Fatalf("failed to parse datetime: %v", err)
+	}
+
+	// 3/19 10:00에는 아직 제재 중
+	checkTime := time.Date(2026, 3, 19, 10, 0, 0, 0, time.Local)
+	if checkTime.After(parsed) {
+		t.Error("10:00 should still be banned, but After returned true")
+	}
+
+	// 3/19 11:01에는 제재 해제
+	checkTime = time.Date(2026, 3, 19, 11, 1, 0, 0, time.Local)
+	if !checkTime.After(parsed) {
+		t.Error("11:01 should be unbanned, but After returned false")
+	}
+
+	// 대조: YYYYMMDD 형식이면 23:59:59까지 제재
+	banEndShort := "20260319"
+	parsedShort, err := parseInterceptDate(banEndShort)
+	if err != nil {
+		t.Fatalf("failed to parse short date: %v", err)
+	}
+	// 3/19 11:01에도 여전히 제재 중 (이것이 기존 버그)
+	if checkTime.After(parsedShort) {
+		t.Error("with YYYYMMDD format, 11:01 should still be banned until 23:59:59")
+	}
+}


### PR DESCRIPTION
## Summary
- **제재 해제 시간 정밀도**: `mb_intercept_date`를 YYYYMMDD → datetime(YYYY-MM-DD HH:MM:SS) 형식으로 저장하여 시/분/초 단위 정확한 해제 지원
- **크론 호환성**: `discipline_release` 크론이 혼재된 날짜 형식(YYYYMMDD, datetime)을 Go에서 파싱하여 정확한 만료 판별
- **소명 게시판 댓글 제한**: claim 게시판에서 admin(레벨10+)과 글 작성자만 댓글 작성 가능

## Test plan
- [x] `parseInterceptDate` 단위 테스트 — datetime/YYYYMMDD/YYYY-MM-DD 3가지 형식 파싱 검증
- [x] `parseInterceptDateForCron` 단위 테스트 — 크론 만료 판별 검증
- [x] 시간 정밀도 시나리오 테스트 — 11시 만료 제재가 10시에 유지/11시 이후 해제 확인
- [ ] claim 게시판 댓글: 일반유저 → 403, 글작성자 → 성공, admin → 성공