### PR TITLE
fix: 소명 게시판 제목 자동 생성

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -385,6 +385,19 @@ func safeIntToUint64(v int) uint64 {
 	return uint64(v) // #nosec G115 -- IDs are always non-negative
 }
 
+// extractDisciplinelogID extracts the numeric ID from link1 values like "disciplinelog/1234" or "disciplinelog:1234"
+func extractDisciplinelogID(link1 string) string {
+	for _, prefix := range []string{"disciplinelog/", "disciplinelog:"} {
+		if strings.HasPrefix(link1, prefix) {
+			id := link1[len(prefix):]
+			if _, err := strconv.Atoi(id); err == nil {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
 func main() {
 	dotenvFiles := config.LoadDotEnv()
 
@@ -2296,6 +2309,14 @@ func main() {
 			if req.Link2 != nil {
 				post.WrLink2 = *req.Link2
 			}
+
+			// 소명 게시판: 제목 자동 생성 (disciplinelog 번호 기반)
+			if slug == "claim" && req.Link1 != nil {
+				if id := extractDisciplinelogID(*req.Link1); id != "" {
+					post.WrSubject = "[소명 #" + id + "]"
+				}
+			}
+
 			phaseDurations["validate"] = time.Since(phaseStart)
 			phaseStart = time.Now()
 


### PR DESCRIPTION
## Summary
- claim 게시판 글 작성 시 제목을 `[소명 #번호]` 형식으로 백엔드에서 강제 설정
- link1에서 disciplinelog 번호를 추출하여 자동 생성
- 사용자가 임의 제목을 입력해도 백엔드에서 덮어씀

## 프론트엔드 (별도 PR)
- claim 게시판일 때 제목 input을 readonly + 회색 배경으로 변경
- "소명 게시판 제목은 자동 생성됩니다" 안내 문구 표시

## Test plan
- [ ] 소명 글 작성 시 제목이 `[소명 #번호]`로 자동 생성되는지 확인
- [ ] 사용자가 제목을 변경해도 백엔드에서 강제 덮어쓰는지 확인
- [ ] disciplinelog_id 없이 직접 접근 시 차단되는지 확인 (기존 로직)