### PR TITLE
fix: 설치 API 인증 + board slug SQL injection 방어

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -983,7 +983,7 @@ func main() {
 			c.JSON(http.StatusOK, gin.H{"success": true, "data": nil})
 		})
 
-		router.GET("/api/v1/boards/:slug/notices", func(c *gin.Context) {
+		router.GET("/api/v1/boards/:slug/notices", middleware.ValidateBoardSlug(), func(c *gin.Context) {
 			slug := c.Param("slug")
 			ctx := c.Request.Context()
 
@@ -1532,6 +1532,7 @@ func main() {
 
 		// v1 boards routes → use Gnuboard g5_* tables
 		v1Boards := router.Group("/api/v1/boards")
+		v1Boards.Use(middleware.ValidateBoardSlug())
 		v1Boards.Use(middleware.OptionalJWTAuth(jwtManager))
 		v1Boards.Use(middleware.ArchiveBoardCheck())
 		v1Boards.Use(middleware.APICacheControl(10)) // 브라우저 캐시 10초

--- a/internal/handler/v2/install_handler.go
+++ b/internal/handler/v2/install_handler.go
@@ -54,6 +54,20 @@ type CreateAdminResponse struct {
 	Message string `json:"message"`
 }
 
+// RequireNotInstalled returns middleware that blocks access if installation is already complete
+func (h *InstallHandler) RequireNotInstalled() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var count int64
+		h.db.Table("v2_users").Where("level >= 10").Count(&count)
+		if count > 0 {
+			common.V2ErrorResponse(c, http.StatusForbidden, "이미 설치가 완료되었습니다", nil)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
 // TestDB handles POST /api/v2/install/test-db
 // @Summary Test database connection
 // @Description Tests if the provided database credentials are valid
@@ -221,12 +235,11 @@ func (h *InstallHandler) CheckInstallStatus(c *gin.Context) {
 	err := h.db.Table("v2_users").Where("level >= 10").Count(&adminCount).Error
 
 	if err != nil {
-		// Table doesn't exist or DB error
+		// Table doesn't exist or DB error — 내부 정보 노출 방지
 		common.V2Success(c, gin.H{
-			"installed":    false,
-			"hasDatabase":  false,
-			"hasAdmin":     false,
-			"errorMessage": err.Error(),
+			"installed":   false,
+			"hasDatabase": false,
+			"hasAdmin":    false,
 		})
 		return
 	}

--- a/internal/middleware/board_validate.go
+++ b/internal/middleware/board_validate.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/gin-gonic/gin"
+)
+
+// boardSlugRegex allows lowercase letters, digits, and underscores, max 20 chars.
+// Matches Gnuboard's board ID rules.
+var boardSlugRegex = regexp.MustCompile(`^[a-z0-9_]{1,20}$`)
+
+// ValidateBoardSlug rejects requests whose :slug parameter contains invalid characters.
+func ValidateBoardSlug() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		slug := c.Param("slug")
+		if slug == "" {
+			c.Next()
+			return
+		}
+		if !boardSlugRegex.MatchString(slug) {
+			common.ErrorResponse(c, http.StatusBadRequest, "Invalid board ID", nil)
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -39,6 +39,7 @@ func Setup(router *gin.Engine, h *v2handler.V2Handler, jwtManager *jwt.Manager, 
 
 	// Boards (OptionalJWTAuth로 인증된 사용자에게 permissions 제공)
 	boards := api.Group("/boards")
+	boards.Use(middleware.ValidateBoardSlug())
 	boards.Use(middleware.OptionalJWTAuth(jwtManager))
 	boards.Use(middleware.ArchiveBoardCheck())
 	boards.GET("", h.ListBoards)
@@ -187,13 +188,16 @@ func SetupMessage(router *gin.Engine, h *v2handler.MessageHandler, jwtManager *j
 	messages.DELETE("/:id", h.DeleteMessage)
 }
 
-// SetupInstall configures v2 installation routes (no authentication required)
+// SetupInstall configures v2 installation routes
 func SetupInstall(router *gin.Engine, h *v2handler.InstallHandler) {
 	install := router.Group("/api/v2/install")
 
 	install.GET("/status", h.CheckInstallStatus)
-	install.POST("/test-db", h.TestDB)
-	install.POST("/create-admin", h.CreateAdmin)
+
+	// 설치 미완료일 때만 접근 가능
+	installOnly := install.Group("", h.RequireNotInstalled())
+	installOnly.POST("/test-db", h.TestDB)
+	installOnly.POST("/create-admin", h.CreateAdmin)
 }
 
 // SetupMyPage configures user's own data routes (points, exp, posts, comments, stats)


### PR DESCRIPTION
## Summary
- 설치 완료 시 `/api/v2/install/test-db`, `/create-admin` 엔드포인트 차단 (SSRF + 관리자 재생성 방지)
- `CheckInstallStatus`에서 DB 에러 메시지 노출 제거
- board slug에 SQL injection 방어 미들웨어 추가 (`^[a-z0-9_]{1,20}$`)
- v1/v2 boards 라우트 그룹 + notices 라우트에 적용

## Test plan
- [ ] `curl -X POST localhost:8090/api/v2/install/test-db` → 403
- [ ] `curl -X POST localhost:8090/api/v2/install/create-admin` → 403
- [ ] `curl localhost:8090/api/v2/install/status` → 200 (errorMessage 없음)
- [ ] `curl localhost:8090/api/v1/boards/free/posts` → 200 정상
- [ ] `curl "localhost:8090/api/v1/boards/'; DROP TABLE--/posts"` → 400