### PR TITLE
fix: 보안 취약점 일괄 수정 (시크릿, cron, marketplace, rate limit)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -580,8 +580,8 @@ func main() {
 		// router.Use(middleware.WriteRateLimit(redisClient, middleware.WriteRateLimitConfig(), "/api/v2/media"))
 	}
 
-	// Prometheus metrics
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	// Prometheus metrics (localhost only)
+	router.GET("/metrics", middleware.RequireLocalhost(), gin.WrapH(promhttp.Handler()))
 
 	// Health Check (DB ping 포함 — 커넥션 죽으면 K8s가 파드 재시작)
 	router.GET("/health", func(c *gin.Context) {
@@ -625,8 +625,8 @@ func main() {
 		})
 	})
 
-	// Swagger UI
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	// Swagger UI (localhost only — 프로덕션 API 스키마 노출 방지)
+	router.GET("/swagger/*any", middleware.RequireLocalhost(), ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	// v2 API routes (only if DB is connected)
 	if db != nil {
@@ -723,11 +723,18 @@ func main() {
 		v2AuthSvc := v2svc.NewV2AuthService(v2UserRepo, jwtManager, v2ExpRepo)
 		v2AuthSvc.SetPromotionDeps(db, gnurepo.NewNotiRepository(db))
 		v2AuthHandler := v2handler.NewV2AuthHandler(v2AuthSvc)
-		v2routes.SetupAuth(router, v2AuthHandler, jwtManager)
+
+		// 로그인 rate limit (10회/분)
+		loginRateLimit := middleware.RateLimit(redisClient, middleware.RateLimitConfig{
+			RequestsPerMinute: 10,
+			KeyPrefix:         "api:ratelimit:login:",
+			Message:           "로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.",
+		})
+		v2routes.SetupAuth(router, v2AuthHandler, jwtManager, loginRateLimit)
 
 		// v1 compatibility routes (frontend calls /api/v1/*)
 		v1Auth := router.Group("/api/v1/auth")
-		v1Auth.POST("/login", v2AuthHandler.Login)
+		v1Auth.POST("/login", loginRateLimit, v2AuthHandler.Login)
 		v1Auth.POST("/refresh", v2AuthHandler.RefreshToken)
 		v1Auth.POST("/logout", v2AuthHandler.Logout)
 		v1Auth.GET("/me", middleware.JWTAuth(jwtManager), v2AuthHandler.GetMe)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3624,6 +3624,10 @@ func main() {
 				return
 			}
 
+			if !middleware.BoardSlugRegex.MatchString(req.TargetBoardID) {
+				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "Invalid target board ID"})
+				return
+			}
 			if srcBoard == req.TargetBoardID {
 				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "같은 게시판으로는 이동할 수 없습니다"})
 				return
@@ -4806,12 +4810,14 @@ func main() {
 		mp.POST("/:name/download", marketplaceHandler.TrackDownload)
 
 		mpDev := router.Group("/api/v2/marketplace/developers")
+		mpDev.Use(middleware.JWTAuth(jwtManager))
 		mpDev.POST("/register", marketplaceHandler.RegisterDeveloper)
 		mpDev.GET("/me", marketplaceHandler.GetMyProfile)
 		mpDev.POST("/submissions", marketplaceHandler.SubmitPlugin)
 		mpDev.GET("/submissions", marketplaceHandler.ListMySubmissions)
 
 		mpAdmin := router.Group("/api/v2/admin/marketplace")
+		mpAdmin.Use(middleware.JWTAuth(jwtManager), middleware.RequireAdmin())
 		mpAdmin.GET("/submissions/pending", marketplaceHandler.ListPendingSubmissions)
 		mpAdmin.POST("/submissions/:id/review", marketplaceHandler.ReviewSubmission)
 
@@ -4825,10 +4831,11 @@ func main() {
 			givingGroup.GET("/list", givingHandler.List)
 		}
 
-		// Internal cron endpoints (curl-based cron jobs)
+		// Internal cron endpoints (curl-based cron jobs, localhost only)
 		cronHandler := cron.NewHandler(db)
 		cronHandler.SetPointExpiryDeps(pointConfigRepo, gnuPointWriteRepo, gnurepo.NewNotiRepository(db))
 		cronGroup := router.Group("/api/internal/cron")
+		cronGroup.Use(middleware.RequireLocalhost())
 		cronGroup.POST("/member-lock-release", cronHandler.MemberLockRelease)
 		cronGroup.POST("/update-member-levels", cronHandler.UpdateMemberLevels)
 		cronGroup.POST("/process-approved-reports", cronHandler.ProcessApprovedReports)

--- a/internal/middleware/admin.go
+++ b/internal/middleware/admin.go
@@ -7,6 +7,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// RequireLocalhost blocks requests not originating from 127.0.0.1 or ::1
+func RequireLocalhost() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := getRemoteIP(c)
+		if ip != "127.0.0.1" && ip != "::1" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.Next()
+	}
+}
+
 // RequireAdmin checks that the authenticated user has admin level (>= 10)
 func RequireAdmin() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/damoang/angple-backend/pkg/jwt"
 	"github.com/gin-gonic/gin"
 )
+
+// internalSecret is loaded from INTERNAL_SECRET env var at startup
+var internalSecret = os.Getenv("INTERNAL_SECRET")
 
 // getRemoteIP extracts the actual connection IP from RemoteAddr (ignores X-Forwarded-For)
 // RemoteAddr format: "IP:port" or "[IPv6]:port"
@@ -48,7 +52,7 @@ func JWTAuth(jwtManager *jwt.Manager) gin.HandlerFunc {
 		// 1. 127.0.0.1에서 오는 요청 (nginx → SvelteKit → Backend)
 		// 2. 공유 시크릿 일치 (CloudFront가 직접 Backend로 라우팅하는 경우)
 		isLocalhost := remoteIP == "127.0.0.1" || remoteIP == "::1"
-		hasValidSecret := internalSecret == "angple-internal-dev-2026"
+		hasValidSecret := internalSecret != "" && internalSecret == c.GetHeader("X-Internal-Secret")
 		if internalAuth == "sveltekit-session" && (isLocalhost || hasValidSecret) {
 			userID := c.GetHeader("X-Internal-User-ID")
 			levelStr := c.GetHeader("X-Internal-User-Level")
@@ -123,7 +127,7 @@ func OptionalJWTAuth(jwtManager *jwt.Manager) gin.HandlerFunc {
 		internalAuth := c.GetHeader("X-Internal-Auth")
 		internalSecret := c.GetHeader("X-Internal-Secret")
 		isLocalhost := remoteIP == "127.0.0.1" || remoteIP == "::1"
-		hasValidSecret := internalSecret == "angple-internal-dev-2026"
+		hasValidSecret := internalSecret != "" && internalSecret == c.GetHeader("X-Internal-Secret")
 		if internalAuth == "sveltekit-session" && (isLocalhost || hasValidSecret) {
 			userID := c.GetHeader("X-Internal-User-ID")
 			levelStr := c.GetHeader("X-Internal-User-Level")

--- a/internal/middleware/board_validate.go
+++ b/internal/middleware/board_validate.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// boardSlugRegex allows lowercase letters, digits, and underscores, max 20 chars.
+// BoardSlugRegex allows lowercase letters, digits, and underscores, max 20 chars.
 // Matches Gnuboard's board ID rules.
-var boardSlugRegex = regexp.MustCompile(`^[a-z0-9_]{1,20}$`)
+var BoardSlugRegex = regexp.MustCompile(`^[a-z0-9_]{1,20}$`)
 
 // ValidateBoardSlug rejects requests whose :slug parameter contains invalid characters.
 func ValidateBoardSlug() gin.HandlerFunc {
@@ -20,7 +20,7 @@ func ValidateBoardSlug() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		if !boardSlugRegex.MatchString(slug) {
+		if !BoardSlugRegex.MatchString(slug) {
 			common.ErrorResponse(c, http.StatusBadRequest, "Invalid board ID", nil)
 			c.Abort()
 			return

--- a/internal/middleware/rate_limit.go
+++ b/internal/middleware/rate_limit.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -61,9 +60,9 @@ func RateLimit(redisClient *redis.Client, cfg RateLimitConfig) gin.HandlerFunc {
 			return
 		}
 
-		// SSR 요청은 rate limit 우회 (SvelteKit 서버 사이드 렌더링)
-		userAgent := c.GetHeader("User-Agent")
-		if strings.HasPrefix(userAgent, "Angple-Web-SSR") {
+		// SSR 요청은 rate limit 우회 (localhost에서 오는 SvelteKit 요청만)
+		remoteIP := getRemoteIP(c)
+		if remoteIP == "127.0.0.1" || remoteIP == "::1" {
 			c.Next()
 			return
 		}

--- a/internal/middleware/tenant_db.go
+++ b/internal/middleware/tenant_db.go
@@ -2,10 +2,14 @@ package middleware
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 
 	"gorm.io/gorm"
 )
+
+// schemaNameRegex validates schema names (alphanumeric + underscore, max 64 chars)
+var schemaNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{1,64}$`)
 
 // TenantDBResolver resolves the correct database connection for a tenant
 // based on the site's DB strategy (shared, schema, dedicated)
@@ -36,7 +40,7 @@ func (r *TenantDBResolver) ResolveDB(_, dbStrategy, schemaName string) *gorm.DB 
 
 // resolveSchema returns a session scoped to the given schema
 func (r *TenantDBResolver) resolveSchema(schemaName string) *gorm.DB {
-	if schemaName == "" {
+	if schemaName == "" || !schemaNameRegex.MatchString(schemaName) {
 		return r.defaultDB
 	}
 
@@ -58,12 +62,18 @@ func (r *TenantDBResolver) resolveSchema(schemaName string) *gorm.DB {
 
 // CreateSchema creates a new database schema for a tenant
 func (r *TenantDBResolver) CreateSchema(schemaName string) error {
+	if !schemaNameRegex.MatchString(schemaName) {
+		return fmt.Errorf("invalid schema name: %s", schemaName)
+	}
 	sql := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci", schemaName)
 	return r.defaultDB.Exec(sql).Error
 }
 
 // DropSchema drops a tenant's database schema
 func (r *TenantDBResolver) DropSchema(schemaName string) error {
+	if !schemaNameRegex.MatchString(schemaName) {
+		return fmt.Errorf("invalid schema name: %s", schemaName)
+	}
 	sql := fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", schemaName)
 	r.schemaDbs.Delete(schemaName)
 	return r.defaultDB.Exec(sql).Error

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -10,9 +10,10 @@ import (
 )
 
 // SetupAuth configures v2 authentication routes
-func SetupAuth(router *gin.Engine, h *v2handler.V2AuthHandler, jwtManager *jwt.Manager) {
+func SetupAuth(router *gin.Engine, h *v2handler.V2AuthHandler, jwtManager *jwt.Manager, loginRateLimit ...gin.HandlerFunc) {
 	authGroup := router.Group("/api/v2/auth")
-	authGroup.POST("/login", h.Login)
+	loginHandlers := append(loginRateLimit, h.Login)
+	authGroup.POST("/login", loginHandlers...)
 	authGroup.POST("/refresh", h.RefreshToken)
 	authGroup.POST("/logout", h.Logout)
 	authGroup.GET("/me", middleware.JWTAuth(jwtManager), h.GetMe)


### PR DESCRIPTION
## Summary
- 내부 인증 시크릿 환경변수화 (`INTERNAL_SECRET`)
- cron 엔드포인트 localhost 제한
- marketplace 엔드포인트 인증 추가 (JWTAuth, RequireAdmin)
- post move TargetBoardID SQL injection 방어
- rate limit User-Agent spoofing 우회 제거 → localhost 체크
- tenant schema SQL injection 방어 (정규식 검증)
- swagger/metrics 엔드포인트 localhost 제한
- 로그인 rate limit 추가 (10회/분)

## Test plan
- [ ] dev 환경에서 로그인 정상 동작 확인
- [ ] `/api/internal/cron/*` 외부 접근 차단 확인
- [ ] `/swagger/*`, `/metrics` 외부 접근 차단 확인
- [ ] marketplace 엔드포인트 인증 필요 확인