### PR TITLE
fix: 제한 종류 세분화 및 만료 discipline 레코드 정리

### DIFF
--- a/internal/cron/discipline_release.go
+++ b/internal/cron/discipline_release.go
@@ -84,5 +84,18 @@ func runDisciplineRelease(db *gorm.DB) (*DisciplineReleaseResult, error) {
 		}
 	}
 
+	// Clean up expired discipline records from g5_da_member_discipline
+	// (prevents fallback in ban_check from re-applying expired restrictions)
+	expiredResult := db.Exec(`
+		DELETE FROM g5_da_member_discipline
+		WHERE penalty_period > 0
+		  AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) < NOW()
+	`)
+	if expiredResult.Error != nil {
+		log.Printf("[Cron:discipline-release] failed to clean expired discipline records: %v", expiredResult.Error)
+	} else if expiredResult.RowsAffected > 0 {
+		log.Printf("[Cron:discipline-release] cleaned %d expired discipline records", expiredResult.RowsAffected)
+	}
+
 	return result, nil
 }

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -473,14 +473,14 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 
 	if existingID > 0 {
 		tx.Exec(`UPDATE g5_da_member_discipline SET
-			penalty_date_from = ?, penalty_period = ?, penalty_type = ?, prev_level = ?
+			penalty_date_from = ?, penalty_period = ?, penalty_type = ?, prev_level = ?, restriction_scope = ?
 			WHERE penalty_mb_id = ?`,
-			now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, member.MbLevel, targetMbID)
+			now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, member.MbLevel, "all", targetMbID)
 	} else {
 		tx.Exec(`INSERT INTO g5_da_member_discipline
-			(penalty_mb_id, penalty_date_from, penalty_period, penalty_type, sg_types, prev_level)
-			VALUES (?, ?, ?, ?, ?, ?)`,
-			targetMbID, now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, sgTypesStr, member.MbLevel)
+			(penalty_mb_id, penalty_date_from, penalty_period, penalty_type, sg_types, prev_level, restriction_scope)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			targetMbID, now.Format("2006-01-02 15:04:05"), penaltyPeriod, penaltyTypeValue, sgTypesStr, member.MbLevel, "all")
 	}
 
 	return nil

--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -21,7 +21,14 @@ const (
 // BanCheck checks if the authenticated user is banned (mb_intercept_date).
 // Banned users cannot create or update posts/comments.
 // Exception: banned users can only write/comment on the promotion board.
+// This checks all restriction scopes (equivalent to BanCheckScoped("all")).
 func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
+	return BanCheckScoped(gnuDB, "all")
+}
+
+// BanCheckScoped checks if the authenticated user is banned for a specific scope.
+// scope: "all" (any restriction), "write", "comment", "reaction"
+func BanCheckScoped(gnuDB *gorm.DB, scope string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		mbID := GetUserID(c)
 		if mbID == "" {
@@ -47,6 +54,10 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 		}
 
 		if needsFallback {
+			// scope별 매칭: "all" scope는 모든 restriction_scope에 매칭,
+			// 특정 scope는 "all" 또는 해당 scope에 매칭
+			scopeCondition := "AND restriction_scope IN ('all', ?)"
+
 			var penaltyEndDate string
 			fallbackErr := gnuDB.Raw(
 				`SELECT CASE
@@ -60,7 +71,8 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 						penalty_period = -1
 						OR (penalty_period > 0 AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW())
 				   )
-				 ORDER BY id DESC LIMIT 1`, mbID,
+				   `+scopeCondition+`
+				 ORDER BY id DESC LIMIT 1`, mbID, scope,
 			).Row().Scan(&penaltyEndDate)
 			if fallbackErr != nil || penaltyEndDate == "" {
 				c.Next()
@@ -85,6 +97,24 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// scope가 "all"이 아닌 경우, discipline 테이블에서 해당 scope 제한이 실제 있는지 확인
+		if scope != "all" {
+			var scopeCount int64
+			gnuDB.Raw(`
+				SELECT COUNT(*) FROM g5_da_member_discipline
+				WHERE penalty_mb_id = ?
+				  AND restriction_scope IN ('all', ?)
+				  AND (
+					penalty_period = -1
+					OR (penalty_period > 0 AND DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY) > NOW())
+				  )`, mbID, scope,
+			).Scan(&scopeCount)
+			if scopeCount == 0 {
+				c.Next()
+				return
+			}
+		}
+
 		// User is currently banned — only promotion and claim boards are allowed
 		slug := c.Param("slug")
 		if slug == promotionBoardSlug || slug == claimBoardSlug {
@@ -97,8 +127,19 @@ func BanCheck(gnuDB *gorm.DB) gin.HandlerFunc {
 		if banEnd.Year() >= 9999 {
 			banEndStr = "영구 이용제한"
 		}
+
+		scopeLabel := ""
+		switch scope {
+		case "comment":
+			scopeLabel = "댓글 "
+		case "reaction":
+			scopeLabel = "공감/추천 "
+		case "write":
+			scopeLabel = "글쓰기 "
+		}
+
 		common.ErrorResponse(c, http.StatusForbidden,
-			"이용제한 기간 중에는 해당 기능을 사용할 수 없습니다. (해제일: "+banEndStr+")", nil)
+			scopeLabel+"이용제한 기간 중에는 해당 기능을 사용할 수 없습니다. (해제일: "+banEndStr+")", nil)
 		c.Abort()
 	}
 }

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -42,6 +42,9 @@ func Run(db *gorm.DB) error {
 	if err := AddDisciplineLogPenaltyMbIDColumn(db); err != nil {
 		return err
 	}
+	if err := AddRestrictionScopeColumn(db); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/migration/restriction_scope.go
+++ b/internal/migration/restriction_scope.go
@@ -1,0 +1,27 @@
+package migration
+
+import (
+	"gorm.io/gorm"
+)
+
+// AddRestrictionScopeColumn adds restriction_scope column to g5_da_member_discipline
+// for fine-grained restriction control (all, write, comment, reaction).
+func AddRestrictionScopeColumn(db *gorm.DB) error {
+	var count int64
+	db.Raw(`
+		SELECT COUNT(*) FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'g5_da_member_discipline'
+		  AND COLUMN_NAME = 'restriction_scope'
+	`).Scan(&count)
+
+	if count > 0 {
+		return nil
+	}
+
+	return db.Exec(`
+		ALTER TABLE g5_da_member_discipline
+		ADD COLUMN restriction_scope VARCHAR(20) NOT NULL DEFAULT 'all'
+		COMMENT 'Restriction scope: all, write, comment, reaction'
+	`).Error
+}


### PR DESCRIPTION
## Summary
- `BanCheckScoped` 미들웨어 추가: scope별 제한 체크 (all/write/comment/reaction)
- `g5_da_member_discipline`에 `restriction_scope` 컬럼 추가 (자동 마이그레이션)
- `report_process`: 제재 적용 시 `restriction_scope` 저장 (기본값 `all`)
- `discipline_release`: 만료된 discipline 레코드 자동 삭제 — ban_check fallback이 삭제된 제재를 복원하는 버그 방지

## Test plan
- [ ] 빌드 확인 (CI)
- [ ] 마이그레이션 실행 후 `restriction_scope` 컬럼 생성 확인
- [ ] 기존 `BanCheck()` 동작 변경 없음 확인 (하위 호환)
- [ ] discipline_release 크론에서 만료 레코드 정리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)