### PR TITLE
feat: 사이트 로고 관리 시스템 (백엔드)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4371,6 +4371,10 @@ func main() {
 		v1Messages.POST("", banCheck, v1MsgHandler.SendMessage)
 		v1Messages.DELETE("/:id", v1MsgHandler.DeleteMessage)
 
+		// Site Logo
+		siteLogoRepo := v2repo.NewSiteLogoRepository(db)
+		v2routes.SetupSiteLogo(router, v2handler.NewSiteLogoHandler(siteLogoRepo), jwtManager)
+
 		// Banner, Promotion, License (v1 + v2 dual routes)
 		bannerRepo := v2repo.NewBannerRepository(db)
 		v2routes.SetupBanner(router, v2handler.NewBannerHandler(bannerRepo))

--- a/internal/domain/v2/site_logo.go
+++ b/internal/domain/v2/site_logo.go
@@ -1,0 +1,45 @@
+package v2
+
+import "time"
+
+// SiteLogo represents a site logo with optional scheduling
+type SiteLogo struct {
+	ID            uint64    `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	Name          string    `gorm:"column:name;type:varchar(100);not null" json:"name"`
+	LogoURL       string    `gorm:"column:logo_url;type:varchar(500);not null" json:"logo_url"`
+	ScheduleType  string    `gorm:"column:schedule_type;type:enum('recurring','date_range','default');not null" json:"schedule_type"`
+	RecurringDate *string   `gorm:"column:recurring_date;type:varchar(5)" json:"recurring_date,omitempty"`
+	StartDate     *string   `gorm:"column:start_date;type:date" json:"start_date,omitempty"`
+	EndDate       *string   `gorm:"column:end_date;type:date" json:"end_date,omitempty"`
+	Priority      int       `gorm:"column:priority;default:0" json:"priority"`
+	IsActive      bool      `gorm:"column:is_active;default:true" json:"is_active"`
+	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`
+}
+
+// TableName returns the table name for SiteLogo
+func (SiteLogo) TableName() string { return "site_logos" }
+
+// CreateSiteLogoRequest represents a request to create a site logo
+type CreateSiteLogoRequest struct {
+	Name          string  `json:"name" binding:"required"`
+	LogoURL       string  `json:"logo_url" binding:"required"`
+	ScheduleType  string  `json:"schedule_type" binding:"required,oneof=recurring date_range default"`
+	RecurringDate *string `json:"recurring_date,omitempty"`
+	StartDate     *string `json:"start_date,omitempty"`
+	EndDate       *string `json:"end_date,omitempty"`
+	Priority      int     `json:"priority"`
+	IsActive      *bool   `json:"is_active,omitempty"`
+}
+
+// UpdateSiteLogoRequest represents a request to update a site logo
+type UpdateSiteLogoRequest struct {
+	Name          *string `json:"name,omitempty"`
+	LogoURL       *string `json:"logo_url,omitempty"`
+	ScheduleType  *string `json:"schedule_type,omitempty" binding:"omitempty,oneof=recurring date_range default"`
+	RecurringDate *string `json:"recurring_date,omitempty"`
+	StartDate     *string `json:"start_date,omitempty"`
+	EndDate       *string `json:"end_date,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
+	IsActive      *bool   `json:"is_active,omitempty"`
+}

--- a/internal/handler/v2/site_logo_handler.go
+++ b/internal/handler/v2/site_logo_handler.go
@@ -1,0 +1,248 @@
+package v2
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+var mmddRegex = regexp.MustCompile(`^\d{2}-\d{2}$`)
+
+// SiteLogoHandler handles site logo API endpoints
+type SiteLogoHandler struct {
+	logoRepo v2repo.SiteLogoRepository
+}
+
+// NewSiteLogoHandler creates a new SiteLogoHandler
+func NewSiteLogoHandler(logoRepo v2repo.SiteLogoRepository) *SiteLogoHandler {
+	return &SiteLogoHandler{logoRepo: logoRepo}
+}
+
+// ListLogos handles GET /api/v1/admin/logos
+func (h *SiteLogoHandler) ListLogos(c *gin.Context) {
+	logos, err := h.logoRepo.FindAll()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 목록 조회 실패", err)
+		return
+	}
+	common.V2Success(c, logos)
+}
+
+// CreateLogo handles POST /api/v1/admin/logos
+func (h *SiteLogoHandler) CreateLogo(c *gin.Context) {
+	var req v2domain.CreateSiteLogoRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
+		return
+	}
+
+	if err := h.validateSchedule(req.ScheduleType, req.RecurringDate, req.StartDate, req.EndDate); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	// default 타입은 활성 상태 1개만 허용
+	isActive := true
+	if req.IsActive != nil {
+		isActive = *req.IsActive
+	}
+	if req.ScheduleType == "default" && isActive {
+		count, err := h.logoRepo.CountActiveDefault()
+		if err != nil {
+			common.V2ErrorResponse(c, http.StatusInternalServerError, "기본 로고 확인 실패", err)
+			return
+		}
+		if count > 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "활성 상태인 기본 로고는 1개만 허용됩니다", nil)
+			return
+		}
+	}
+
+	logo := &v2domain.SiteLogo{
+		Name:          req.Name,
+		LogoURL:       req.LogoURL,
+		ScheduleType:  req.ScheduleType,
+		RecurringDate: req.RecurringDate,
+		StartDate:     req.StartDate,
+		EndDate:       req.EndDate,
+		Priority:      req.Priority,
+		IsActive:      isActive,
+	}
+
+	if err := h.logoRepo.Create(logo); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 생성 실패", err)
+		return
+	}
+
+	common.V2Success(c, logo)
+}
+
+// UpdateLogo handles PUT /api/v1/admin/logos/:id
+func (h *SiteLogoHandler) UpdateLogo(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 로고 ID", err)
+		return
+	}
+
+	logo, err := h.logoRepo.FindByID(id)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			common.V2ErrorResponse(c, http.StatusNotFound, "로고를 찾을 수 없습니다", nil)
+			return
+		}
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 조회 실패", err)
+		return
+	}
+
+	var req v2domain.UpdateSiteLogoRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
+		return
+	}
+
+	if req.Name != nil {
+		logo.Name = *req.Name
+	}
+	if req.LogoURL != nil {
+		logo.LogoURL = *req.LogoURL
+	}
+	if req.ScheduleType != nil {
+		logo.ScheduleType = *req.ScheduleType
+	}
+	if req.RecurringDate != nil {
+		logo.RecurringDate = req.RecurringDate
+	}
+	if req.StartDate != nil {
+		logo.StartDate = req.StartDate
+	}
+	if req.EndDate != nil {
+		logo.EndDate = req.EndDate
+	}
+	if req.Priority != nil {
+		logo.Priority = *req.Priority
+	}
+	if req.IsActive != nil {
+		logo.IsActive = *req.IsActive
+	}
+
+	if err := h.validateSchedule(logo.ScheduleType, logo.RecurringDate, logo.StartDate, logo.EndDate); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
+		return
+	}
+
+	// default 타입 활성화 시 기존 활성 default 확인
+	if logo.ScheduleType == "default" && logo.IsActive {
+		count, err := h.logoRepo.CountActiveDefault()
+		if err != nil {
+			common.V2ErrorResponse(c, http.StatusInternalServerError, "기본 로고 확인 실패", err)
+			return
+		}
+		// 자기 자신 제외
+		existingLogo, _ := h.logoRepo.FindByID(id)
+		if existingLogo != nil && existingLogo.ScheduleType == "default" && existingLogo.IsActive {
+			count--
+		}
+		if count > 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "활성 상태인 기본 로고는 1개만 허용됩니다", nil)
+			return
+		}
+	}
+
+	if err := h.logoRepo.Update(logo); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 수정 실패", err)
+		return
+	}
+
+	common.V2Success(c, logo)
+}
+
+// DeleteLogo handles DELETE /api/v1/admin/logos/:id
+func (h *SiteLogoHandler) DeleteLogo(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 로고 ID", err)
+		return
+	}
+
+	if _, err := h.logoRepo.FindByID(id); err != nil {
+		if err == gorm.ErrRecordNotFound {
+			common.V2ErrorResponse(c, http.StatusNotFound, "로고를 찾을 수 없습니다", nil)
+			return
+		}
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 조회 실패", err)
+		return
+	}
+
+	if err := h.logoRepo.Delete(id); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 삭제 실패", err)
+		return
+	}
+
+	common.V2Success(c, gin.H{"message": "로고가 삭제되었습니다"})
+}
+
+// GetActiveLogo handles GET /api/v1/logos/active
+func (h *SiteLogoHandler) GetActiveLogo(c *gin.Context) {
+	kst := time.FixedZone("KST", 9*60*60)
+	now := time.Now().In(kst)
+	mmdd := now.Format("01-02")
+	today := now.Format("2006-01-02")
+
+	logo, err := h.logoRepo.FindActiveLogo(mmdd, today)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			common.V2Success(c, gin.H{"active": nil, "schedules": []interface{}{}})
+			return
+		}
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 조회 실패", err)
+		return
+	}
+
+	schedules, err := h.logoRepo.FindAllActive()
+	if err != nil {
+		schedules = []*v2domain.SiteLogo{}
+	}
+
+	common.V2Success(c, gin.H{
+		"active":    logo,
+		"schedules": schedules,
+	})
+}
+
+func (h *SiteLogoHandler) validateSchedule(scheduleType string, recurringDate, startDate, endDate *string) error {
+	switch scheduleType {
+	case "recurring":
+		if recurringDate == nil || *recurringDate == "" {
+			return &validationError{"recurring 타입은 recurring_date(MM-DD)가 필수입니다"}
+		}
+		if !mmddRegex.MatchString(*recurringDate) {
+			return &validationError{"recurring_date는 MM-DD 형식이어야 합니다 (예: 03-01)"}
+		}
+	case "date_range":
+		if startDate == nil || *startDate == "" || endDate == nil || *endDate == "" {
+			return &validationError{"date_range 타입은 start_date와 end_date가 필수입니다"}
+		}
+		if *startDate > *endDate {
+			return &validationError{"start_date는 end_date보다 이전이어야 합니다"}
+		}
+	case "default":
+		// no additional validation
+	}
+	return nil
+}
+
+type validationError struct {
+	msg string
+}
+
+func (e *validationError) Error() string {
+	return e.msg
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -2,13 +2,14 @@ package migration
 
 import (
 	"github.com/damoang/angple-backend/internal/domain"
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
 	pluginstoreDomain "github.com/damoang/angple-backend/internal/pluginstore/domain"
 	"gorm.io/gorm"
 )
 
 // Run executes AutoMigrate for core tables and seeds default data if empty.
 func Run(db *gorm.DB) error {
-	if err := db.AutoMigrate(&domain.Menu{}, &domain.MemberBlock{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
+	if err := db.AutoMigrate(&domain.Menu{}, &domain.MemberBlock{}, &v2domain.SiteLogo{}, &pluginstoreDomain.PluginInstallation{}, &pluginstoreDomain.PluginSetting{}, &pluginstoreDomain.PluginEvent{}, &pluginstoreDomain.PluginPermission{}, &pluginstoreDomain.PluginMigration{}); err != nil {
 		return err
 	}
 

--- a/internal/repository/v2/site_logo_repo.go
+++ b/internal/repository/v2/site_logo_repo.go
@@ -1,0 +1,96 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// SiteLogoRepository handles site logo data access
+type SiteLogoRepository interface {
+	FindAll() ([]*v2.SiteLogo, error)
+	FindByID(id uint64) (*v2.SiteLogo, error)
+	Create(logo *v2.SiteLogo) error
+	Update(logo *v2.SiteLogo) error
+	Delete(id uint64) error
+	FindActiveLogo(mmdd, today string) (*v2.SiteLogo, error)
+	FindAllActive() ([]*v2.SiteLogo, error)
+	CountActiveDefault() (int64, error)
+}
+
+type siteLogoRepository struct {
+	db *gorm.DB
+}
+
+// NewSiteLogoRepository creates a new SiteLogoRepository
+func NewSiteLogoRepository(db *gorm.DB) SiteLogoRepository {
+	return &siteLogoRepository{db: db}
+}
+
+func (r *siteLogoRepository) FindAll() ([]*v2.SiteLogo, error) {
+	var logos []*v2.SiteLogo
+	if err := r.db.Order("priority DESC, id DESC").Find(&logos).Error; err != nil {
+		return nil, err
+	}
+	return logos, nil
+}
+
+func (r *siteLogoRepository) FindByID(id uint64) (*v2.SiteLogo, error) {
+	var logo v2.SiteLogo
+	if err := r.db.First(&logo, id).Error; err != nil {
+		return nil, err
+	}
+	return &logo, nil
+}
+
+func (r *siteLogoRepository) Create(logo *v2.SiteLogo) error {
+	return r.db.Create(logo).Error
+}
+
+func (r *siteLogoRepository) Update(logo *v2.SiteLogo) error {
+	return r.db.Save(logo).Error
+}
+
+func (r *siteLogoRepository) Delete(id uint64) error {
+	return r.db.Delete(&v2.SiteLogo{}, id).Error
+}
+
+// FindActiveLogo returns the highest-priority active logo matching the given date.
+// Priority: recurring > date_range > default
+func (r *siteLogoRepository) FindActiveLogo(mmdd, today string) (*v2.SiteLogo, error) {
+	var logo v2.SiteLogo
+	err := r.db.
+		Where("is_active = ?", true).
+		Where(`(
+			(schedule_type = 'recurring' AND recurring_date = ?)
+			OR (schedule_type = 'date_range' AND start_date <= ? AND end_date >= ?)
+			OR schedule_type = 'default'
+		)`, mmdd, today, today).
+		Order(`CASE schedule_type WHEN 'recurring' THEN 1 WHEN 'date_range' THEN 2 WHEN 'default' THEN 3 END, priority DESC`).
+		First(&logo).Error
+	if err != nil {
+		return nil, err
+	}
+	return &logo, nil
+}
+
+// FindAllActive returns all active logos for client-side re-matching
+func (r *siteLogoRepository) FindAllActive() ([]*v2.SiteLogo, error) {
+	var logos []*v2.SiteLogo
+	if err := r.db.Where("is_active = ?", true).
+		Order(`CASE schedule_type WHEN 'recurring' THEN 1 WHEN 'date_range' THEN 2 WHEN 'default' THEN 3 END, priority DESC`).
+		Find(&logos).Error; err != nil {
+		return nil, err
+	}
+	return logos, nil
+}
+
+// CountActiveDefault returns the count of active default logos
+func (r *siteLogoRepository) CountActiveDefault() (int64, error) {
+	var count int64
+	if err := r.db.Model(&v2.SiteLogo{}).
+		Where("is_active = ? AND schedule_type = ?", true, "default").
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -273,6 +273,19 @@ func SetupLicense(router *gin.Engine, h *v2handler.LicenseHandler) {
 	router.POST("/api/v2/licenses/verify", h.Verify)
 }
 
+// SetupSiteLogo configures site logo routes (admin CRUD + public active logo)
+func SetupSiteLogo(router *gin.Engine, h *v2handler.SiteLogoHandler, jwtManager *jwt.Manager) {
+	admin := router.Group("/api/v1/admin/logos")
+	admin.Use(middleware.JWTAuth(jwtManager), middleware.RequireAdmin())
+	admin.GET("", h.ListLogos)
+	admin.POST("", h.CreateLogo)
+	admin.PUT("/:id", h.UpdateLogo)
+	admin.DELETE("/:id", h.DeleteLogo)
+
+	// public: 오늘의 로고 (SSR용)
+	router.GET("/api/v1/logos/active", h.GetActiveLogo)
+}
+
 // SetupFavorite configures board favorites routes
 func SetupFavorite(router *gin.Engine, h *v2handler.FavoriteHandler, jwtManager *jwt.Manager) {
 	auth := middleware.JWTAuth(jwtManager)


### PR DESCRIPTION
## 요약
- 날짜 기반 사이트 로고 스케줄링 시스템 (구글 두들/네이버 특별 로고 방식)
- Admin CRUD API + Public 활성 로고 조회 API

## 변경 사항
- `site_logos` 테이블 도메인 모델 + AutoMigrate
- Repository: CRUD + KST 기준 스케줄 매칭 쿼리 (recurring > date_range > default 우선순위)
- Handler: 유효성 검증 (MM-DD 형식, 날짜 범위, default 1개 제한)
- Routes: `/api/v1/admin/logos` (관리자), `/api/v1/logos/active` (공개)

## 스케줄 타입
| 타입 | 설명 | 예시 |
|------|------|------|
| `recurring` | 매년 반복 (MM-DD) | 삼일절 03-01, 한글날 10-09 |
| `date_range` | 기간 지정 | 설날 01-28~01-30 |
| `default` | 폴백 로고 | 평소 사용 |

## 테스트
```bash
curl http://localhost:8090/api/v1/logos/active
# {"success":true,"data":{"active":null,"schedules":[]}}
```