### PR TITLE
fix: 글 수정 시 첨부파일 이미지 깨짐 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2456,12 +2456,12 @@ func main() {
 				var boardFiles []gnuboard.G5BoardFile
 				for i, f := range req.Files {
 					boardFiles = append(boardFiles, gnuboard.G5BoardFile{
-						BoTable:    slug,
-						WrID:       post.WrID,
-						BfNo:       i,
-						BfSource:   f.Filename,
-						BfFile:     f.Key[strings.LastIndex(f.Key, "/")+1:],
-						BfFileURL:  f.URL,
+						BoTable:   slug,
+						WrID:      post.WrID,
+						BfNo:      i,
+						BfSource:  f.Filename,
+						BfFile:    f.Key[strings.LastIndex(f.Key, "/")+1:],
+						BfFileURL: f.URL,
 
 						BfFilesize: f.Size,
 						BfWidth:    f.Width,
@@ -2930,13 +2930,13 @@ func main() {
 					var boardFiles []gnuboard.G5BoardFile
 					for i, f := range *req.Files {
 						boardFiles = append(boardFiles, gnuboard.G5BoardFile{
-							BoTable:    slug,
-							WrID:       postID,
-							BfNo:       i,
-							BfSource:   f.Filename,
-							BfFile:     f.Key[strings.LastIndex(f.Key, "/")+1:],
-							BfFileURL:  f.URL,
-	
+							BoTable:   slug,
+							WrID:      postID,
+							BfNo:      i,
+							BfSource:  f.Filename,
+							BfFile:    f.Key[strings.LastIndex(f.Key, "/")+1:],
+							BfFileURL: f.URL,
+
 							BfFilesize: f.Size,
 							BfWidth:    f.Width,
 							BfHeight:   f.Height,

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2462,7 +2462,7 @@ func main() {
 						BfSource:   f.Filename,
 						BfFile:     f.Key[strings.LastIndex(f.Key, "/")+1:],
 						BfFileURL:  f.URL,
-						BfStorage:  "s3",
+
 						BfFilesize: f.Size,
 						BfWidth:    f.Width,
 						BfHeight:   f.Height,
@@ -2936,7 +2936,7 @@ func main() {
 							BfSource:   f.Filename,
 							BfFile:     f.Key[strings.LastIndex(f.Key, "/")+1:],
 							BfFileURL:  f.URL,
-							BfStorage:  "s3",
+	
 							BfFilesize: f.Size,
 							BfWidth:    f.Width,
 							BfHeight:   f.Height,

--- a/internal/domain/gnuboard/board_file.go
+++ b/internal/domain/gnuboard/board_file.go
@@ -14,8 +14,6 @@ type G5BoardFile struct {
 	BfFile     string    `gorm:"column:bf_file" json:"bf_file"`         // 저장된 파일명 (레거시: 해시파일명)
 	BfContent  string    `gorm:"column:bf_content" json:"bf_content"`   // 파일 설명
 	BfDownload int       `gorm:"column:bf_download" json:"bf_download"` // 다운로드 횟수
-	BfFileURL  string    `gorm:"column:bf_fileurl" json:"bf_fileurl"`   // S3 전체 URL
-	BfStorage  string    `gorm:"column:bf_storage" json:"bf_storage"`   // 저장소 타입 (s3)
 	BfFilesize int64     `gorm:"column:bf_filesize" json:"bf_filesize"` // 파일 크기
 	BfWidth    int       `gorm:"column:bf_width" json:"bf_width"`       // 이미지 가로
 	BfHeight   int       `gorm:"column:bf_height" json:"bf_height"`     // 이미지 세로

--- a/internal/domain/gnuboard/board_file.go
+++ b/internal/domain/gnuboard/board_file.go
@@ -1,6 +1,9 @@
 package gnuboard
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // G5BoardFile represents the g5_board_file table (file attachments)
 type G5BoardFile struct {
@@ -17,6 +20,7 @@ type G5BoardFile struct {
 	BfWidth    int       `gorm:"column:bf_width" json:"bf_width"`       // 이미지 가로
 	BfHeight   int       `gorm:"column:bf_height" json:"bf_height"`     // 이미지 세로
 	BfType     int       `gorm:"column:bf_type" json:"bf_type"`         // 파일 타입 (0: 일반, 1: 이미지 등)
+	BfFileURL  string    `gorm:"column:bf_fileurl" json:"bf_fileurl"`   // CDN URL (있으면 우선 사용)
 	BfDateTime time.Time `gorm:"column:bf_datetime" json:"bf_datetime"`
 }
 
@@ -45,8 +49,20 @@ func (f *G5BoardFile) ToFileResponse(baseURL string) FileResponse {
 	// 이미지 여부 판단 (bf_type이 1이거나 이미지 확장자인 경우)
 	isImage := f.BfType == 1 || f.BfWidth > 0 || f.BfHeight > 0
 
-	// 파일 URL 생성
-	fileURL := baseURL + "/data/file/" + f.BoTable + "/" + f.BfFile
+	// 파일 URL 생성: bf_fileurl이 있으면 우선 사용 (레거시 CDN 호스트 치환)
+	var fileURL string
+	if f.BfFileURL != "" {
+		fileURL = f.BfFileURL
+		// 레거시 CDN 호스트를 현재 baseURL로 치환
+		for _, legacy := range []string{"https://cdn.damoang.net", "http://cdn.damoang.net", "https://s3.damoang.net", "http://s3.damoang.net"} {
+			if strings.HasPrefix(fileURL, legacy) {
+				fileURL = baseURL + strings.TrimPrefix(fileURL, legacy)
+				break
+			}
+		}
+	} else {
+		fileURL = baseURL + "/data/file/" + f.BoTable + "/" + f.BfFile
+	}
 	thumbnailURL := ""
 	if isImage {
 		thumbnailURL = fileURL // 이미지인 경우 썸네일로 사용

--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -130,6 +130,10 @@ func normalizeMediaContent(raw string, _ ...string) string {
 		`src='https://s3.damoang.net/data/`, `src='`+cdnURL+`/data/`,
 		`src="http://s3.damoang.net/data/`, `src="`+cdnURL+`/data/`,
 		`src='http://s3.damoang.net/data/`, `src='`+cdnURL+`/data/`,
+		`src="https://cdn.damoang.net/data/`, `src="`+cdnURL+`/data/`,
+		`src='https://cdn.damoang.net/data/`, `src='`+cdnURL+`/data/`,
+		`src="http://cdn.damoang.net/data/`, `src="`+cdnURL+`/data/`,
+		`src='http://cdn.damoang.net/data/`, `src='`+cdnURL+`/data/`,
 		`src="/data/`, `src="`+cdnURL+`/data/`,
 		`src='/data/`, `src='`+cdnURL+`/data/`,
 		`src="data/`, `src="`+cdnURL+`/data/`,
@@ -138,6 +142,10 @@ func normalizeMediaContent(raw string, _ ...string) string {
 		`href='https://s3.damoang.net/data/`, `href='`+cdnURL+`/data/`,
 		`href="http://s3.damoang.net/data/`, `href="`+cdnURL+`/data/`,
 		`href='http://s3.damoang.net/data/`, `href='`+cdnURL+`/data/`,
+		`href="https://cdn.damoang.net/data/`, `href="`+cdnURL+`/data/`,
+		`href='https://cdn.damoang.net/data/`, `href='`+cdnURL+`/data/`,
+		`href="http://cdn.damoang.net/data/`, `href="`+cdnURL+`/data/`,
+		`href='http://cdn.damoang.net/data/`, `href='`+cdnURL+`/data/`,
 		`href="/data/`, `href="`+cdnURL+`/data/`,
 		`href='/data/`, `href='`+cdnURL+`/data/`,
 		`href="data/`, `href="`+cdnURL+`/data/`,
@@ -150,6 +158,8 @@ func rewriteLegacyCDNHost(raw, cdnURL string) string {
 	replacements := [][2]string{
 		{"https://s3.damoang.net/data/", cdnURL + "/data/"},
 		{"http://s3.damoang.net/data/", cdnURL + "/data/"},
+		{"https://cdn.damoang.net/data/", cdnURL + "/data/"},
+		{"http://cdn.damoang.net/data/", cdnURL + "/data/"},
 	}
 
 	for _, pair := range replacements {


### PR DESCRIPTION
## Summary
- `G5BoardFile`에 `bf_fileurl` 필드 추가, `ToFileResponse()`에서 DB에 저장된 CDN URL 우선 사용
- 레거시 CDN 호스트(`cdn.damoang.net`, `s3.damoang.net`)를 현재 baseURL로 자동 치환
- 본문 HTML의 `cdn.damoang.net` 이미지 URL도 변환되도록 `normalizeMediaContent` + `rewriteLegacyCDNHost` 보강

## Test plan
- [ ] 첨부파일 있는 글 수정 화면 → 이미지 정상 표시
- [ ] 본문에 `cdn.damoang.net` URL 포함된 글 → 이미지 정상 표시

Fixes #8813