### PR TITLE
fix: 삭제 글과 댓글을 목록에서 유지

### DIFF
--- a/internal/domain/gnuboard/mypage.go
+++ b/internal/domain/gnuboard/mypage.go
@@ -7,19 +7,20 @@ import (
 
 // MyPost represents a post row from UNION ALL across g5_write_* tables
 type MyPost struct {
-	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
-	WrSubject  string    `gorm:"column:wr_subject" json:"wr_subject"`
-	WrContent  string    `gorm:"column:wr_content" json:"wr_content"`
-	WrHit      int       `gorm:"column:wr_hit" json:"wr_hit"`
-	WrGood     int       `gorm:"column:wr_good" json:"wr_good"`
-	WrNogood   int       `gorm:"column:wr_nogood" json:"wr_nogood"`
-	WrComment  int       `gorm:"column:wr_comment" json:"wr_comment"`
-	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
-	MbID       string    `gorm:"column:mb_id" json:"mb_id"`
-	WrName     string    `gorm:"column:wr_name" json:"wr_name"`
-	WrOption   string    `gorm:"column:wr_option" json:"wr_option"`
-	WrFile     int       `gorm:"column:wr_file" json:"wr_file"`
-	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+	WrID       int        `gorm:"column:wr_id" json:"wr_id"`
+	WrSubject  string     `gorm:"column:wr_subject" json:"wr_subject"`
+	WrContent  string     `gorm:"column:wr_content" json:"wr_content"`
+	WrHit      int        `gorm:"column:wr_hit" json:"wr_hit"`
+	WrGood     int        `gorm:"column:wr_good" json:"wr_good"`
+	WrNogood   int        `gorm:"column:wr_nogood" json:"wr_nogood"`
+	WrComment  int        `gorm:"column:wr_comment" json:"wr_comment"`
+	WrDatetime time.Time  `gorm:"column:wr_datetime" json:"wr_datetime"`
+	MbID       string     `gorm:"column:mb_id" json:"mb_id"`
+	WrName     string     `gorm:"column:wr_name" json:"wr_name"`
+	WrOption   string     `gorm:"column:wr_option" json:"wr_option"`
+	WrFile     int        `gorm:"column:wr_file" json:"wr_file"`
+	BoardID    string     `gorm:"column:board_id" json:"board_id"`
+	DeletedAt  *time.Time `gorm:"column:deleted_at" json:"deleted_at,omitempty"`
 }
 
 // ToPostResponse converts MyPost to the standard API response format
@@ -37,57 +38,72 @@ func (p *MyPost) ToPostResponse() map[string]interface{} {
 		"has_file":       p.WrFile > 0,
 		"is_secret":      strings.Contains(p.WrOption, "secret"),
 		"created_at":     p.WrDatetime.Format(time.RFC3339),
+		"deleted_at":     formatOptionalTime(p.DeletedAt),
 	}
 }
 
 // MyCommentRow represents a comment row from UNION ALL with parent post title
 type MyCommentRow struct {
-	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
-	WrContent  string    `gorm:"column:wr_content" json:"wr_content"`
-	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
-	MbID       string    `gorm:"column:mb_id" json:"mb_id"`
-	WrName     string    `gorm:"column:wr_name" json:"wr_name"`
-	WrParent   int       `gorm:"column:wr_parent" json:"wr_parent"`
-	WrGood     int       `gorm:"column:wr_good" json:"wr_good"`
-	WrNogood   int       `gorm:"column:wr_nogood" json:"wr_nogood"`
-	WrOption   string    `gorm:"column:wr_option" json:"wr_option"`
-	PostTitle  string    `gorm:"column:post_title" json:"post_title"`
-	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+	WrID            int        `gorm:"column:wr_id" json:"wr_id"`
+	WrContent       string     `gorm:"column:wr_content" json:"wr_content"`
+	WrDatetime      time.Time  `gorm:"column:wr_datetime" json:"wr_datetime"`
+	MbID            string     `gorm:"column:mb_id" json:"mb_id"`
+	WrName          string     `gorm:"column:wr_name" json:"wr_name"`
+	WrParent        int        `gorm:"column:wr_parent" json:"wr_parent"`
+	WrGood          int        `gorm:"column:wr_good" json:"wr_good"`
+	WrNogood        int        `gorm:"column:wr_nogood" json:"wr_nogood"`
+	WrOption        string     `gorm:"column:wr_option" json:"wr_option"`
+	PostTitle       string     `gorm:"column:post_title" json:"post_title"`
+	BoardID         string     `gorm:"column:board_id" json:"board_id"`
+	DeletedAt       *time.Time `gorm:"column:deleted_at" json:"deleted_at,omitempty"`
+	ParentDeletedAt *time.Time `gorm:"column:parent_deleted_at" json:"parent_deleted_at,omitempty"`
 }
 
 // ToCommentResponse converts MyCommentRow to the standard API response format
 func (c *MyCommentRow) ToCommentResponse() map[string]interface{} {
 	return map[string]interface{}{
-		"id":         c.WrID,
-		"content":    c.WrContent,
-		"author":     c.WrName,
-		"author_id":  c.MbID,
-		"likes":      c.WrGood,
-		"dislikes":   c.WrNogood,
-		"parent_id":  c.WrParent,
-		"post_id":    c.WrParent,
-		"post_title": c.PostTitle,
-		"board_id":   c.BoardID,
-		"is_secret":  strings.Contains(c.WrOption, "secret"),
-		"created_at": c.WrDatetime.Format(time.RFC3339),
+		"id":              c.WrID,
+		"content":         c.WrContent,
+		"author":          c.WrName,
+		"author_id":       c.MbID,
+		"likes":           c.WrGood,
+		"dislikes":        c.WrNogood,
+		"parent_id":       c.WrParent,
+		"post_id":         c.WrParent,
+		"post_title":      c.PostTitle,
+		"board_id":        c.BoardID,
+		"is_secret":       strings.Contains(c.WrOption, "secret"),
+		"created_at":      c.WrDatetime.Format(time.RFC3339),
+		"deleted_at":      formatOptionalTime(c.DeletedAt),
+		"post_deleted_at": formatOptionalTime(c.ParentDeletedAt),
 	}
 }
 
 // ActivityPost represents a public post for member activity API
 type ActivityPost struct {
-	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
-	WrSubject  string    `gorm:"column:wr_subject" json:"wr_subject"`
-	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
-	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+	WrID       int        `gorm:"column:wr_id" json:"wr_id"`
+	WrSubject  string     `gorm:"column:wr_subject" json:"wr_subject"`
+	WrDatetime time.Time  `gorm:"column:wr_datetime" json:"wr_datetime"`
+	BoardID    string     `gorm:"column:board_id" json:"board_id"`
+	DeletedAt  *time.Time `gorm:"column:deleted_at" json:"deleted_at,omitempty"`
 }
 
 // ActivityComment represents a public comment for member activity API
 type ActivityComment struct {
-	WrID       int       `gorm:"column:wr_id" json:"wr_id"`
-	WrContent  string    `gorm:"column:wr_content" json:"wr_content"`
-	WrParent   int       `gorm:"column:wr_parent" json:"wr_parent"`
-	WrDatetime time.Time `gorm:"column:wr_datetime" json:"wr_datetime"`
-	BoardID    string    `gorm:"column:board_id" json:"board_id"`
+	WrID            int        `gorm:"column:wr_id" json:"wr_id"`
+	WrContent       string     `gorm:"column:wr_content" json:"wr_content"`
+	WrParent        int        `gorm:"column:wr_parent" json:"wr_parent"`
+	WrDatetime      time.Time  `gorm:"column:wr_datetime" json:"wr_datetime"`
+	BoardID         string     `gorm:"column:board_id" json:"board_id"`
+	DeletedAt       *time.Time `gorm:"column:deleted_at" json:"deleted_at,omitempty"`
+	ParentDeletedAt *time.Time `gorm:"column:parent_deleted_at" json:"parent_deleted_at,omitempty"`
+}
+
+func formatOptionalTime(value *time.Time) interface{} {
+	if value == nil {
+		return nil
+	}
+	return value.Format(time.RFC3339)
 }
 
 // BoardStat represents post/comment counts per board for a member

--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -152,6 +152,13 @@ type activityResponse struct {
 	RecentComments []map[string]interface{} `json:"recentComments"`
 }
 
+func formatNullableTime(t *time.Time) interface{} {
+	if t == nil {
+		return nil
+	}
+	return t.Format(time.RFC3339)
+}
+
 // GetMemberActivity handles GET /api/v1/members/:id/activity
 func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
 	mbID := c.Param("id")
@@ -215,6 +222,7 @@ func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
 				"wr_id":       p.WrID,
 				"wr_subject":  p.WrSubject,
 				"wr_datetime": p.WrDatetime.Format("2006-01-02 15:04:05"),
+				"deleted_at":  formatNullableTime(p.DeletedAt),
 				"href":        fmt.Sprintf("/%s/%d", p.BoardID, p.WrID),
 			})
 		}
@@ -229,13 +237,15 @@ func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
 		comments = make([]map[string]interface{}, 0, len(rawComments))
 		for _, cm := range rawComments {
 			comments = append(comments, map[string]interface{}{
-				"bo_table":     cm.BoardID,
-				"bo_subject":   boardSubjects[cm.BoardID],
-				"wr_id":        cm.WrID,
-				"parent_wr_id": cm.WrParent,
-				"preview":      stripHTMLPreview(cm.WrContent, 80),
-				"wr_datetime":  cm.WrDatetime.Format("2006-01-02 15:04:05"),
-				"href":         fmt.Sprintf("/%s/%d#c_%d", cm.BoardID, cm.WrParent, cm.WrID),
+				"bo_table":        cm.BoardID,
+				"bo_subject":      boardSubjects[cm.BoardID],
+				"wr_id":           cm.WrID,
+				"parent_wr_id":    cm.WrParent,
+				"preview":         stripHTMLPreview(cm.WrContent, 80),
+				"wr_datetime":     cm.WrDatetime.Format("2006-01-02 15:04:05"),
+				"deleted_at":      formatNullableTime(cm.DeletedAt),
+				"post_deleted_at": formatNullableTime(cm.ParentDeletedAt),
+				"href":            fmt.Sprintf("/%s/%d#c_%d", cm.BoardID, cm.WrParent, cm.WrID),
 			})
 		}
 	}()

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -109,10 +109,10 @@ func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gn
 			var cnt int64
 			if boardID == largeBoardID {
 				// Use member_activity_feed covering index instead of scanning 600K-row table
-				r.db.Raw("SELECT COUNT(*) FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 1 AND is_deleted = 0", mbID, largeBoardID).Scan(&cnt)
+				r.db.Raw("SELECT COUNT(*) FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 1", mbID, largeBoardID).Scan(&cnt)
 			} else {
 				table := fmt.Sprintf("g5_write_%s", boardID)
-				r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL", table), mbID).Scan(&cnt)
+				r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0", table), mbID).Scan(&cnt)
 			}
 			if cnt > 0 {
 				muCounts.Lock()
@@ -145,20 +145,20 @@ func (r *myPageRepository) FindPostsByMember(mbID string, page, limit int) ([]gn
 				// Step 1: Get write_ids from activity_feed (covering index scan, ~1ms)
 				var writeIDs []int
 				r.db.Raw(
-					"SELECT write_id FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 1 AND is_deleted = 0 ORDER BY source_created_at DESC LIMIT ?",
+					"SELECT write_id FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 1 ORDER BY source_created_at DESC LIMIT ?",
 					mbID, largeBoardID, perTable,
 				).Scan(&writeIDs)
 				if len(writeIDs) > 0 {
 					// Step 2: Batch PK lookup for full post data
 					r.db.Raw(
-						fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `g5_write_%s` WHERE wr_id IN ? ORDER BY wr_datetime DESC", largeBoardID, largeBoardID),
+						fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id, wr_deleted_at AS deleted_at FROM `g5_write_%s` WHERE wr_id IN ? ORDER BY wr_datetime DESC", largeBoardID, largeBoardID),
 						writeIDs,
 					).Scan(&rows)
 				}
 			} else {
 				table := fmt.Sprintf("g5_write_%s", bc.boardID)
 				r.db.Raw(
-					fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND wr_deleted_at IS NULL ORDER BY wr_datetime DESC LIMIT %d", bc.boardID, table, perTable),
+					fmt.Sprintf("SELECT wr_id, wr_subject, wr_content, wr_hit, wr_good, wr_nogood, wr_comment, wr_datetime, mb_id, wr_name, wr_option, wr_file, '%s' as board_id, wr_deleted_at AS deleted_at FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 ORDER BY wr_datetime DESC LIMIT %d", bc.boardID, table, perTable),
 					mbID,
 				).Scan(&rows)
 			}
@@ -218,10 +218,10 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 			var cnt int64
 			if boardID == largeBoardID {
 				// Use member_activity_feed covering index instead of scanning 600K-row table
-				r.db.Raw("SELECT COUNT(*) FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 2 AND is_deleted = 0", mbID, largeBoardID).Scan(&cnt)
+				r.db.Raw("SELECT COUNT(*) FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 2", mbID, largeBoardID).Scan(&cnt)
 			} else {
 				table := fmt.Sprintf("g5_write_%s", boardID)
-				r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", table), mbID).Scan(&cnt)
+				r.db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM `%s` WHERE mb_id = ? AND wr_is_comment = 1", table), mbID).Scan(&cnt)
 			}
 			if cnt > 0 {
 				muCounts.Lock()
@@ -258,7 +258,7 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 				}
 				var refs []commentRef
 				r.db.Raw(
-					"SELECT write_id, COALESCE(parent_title, '') as parent_title FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 2 AND is_deleted = 0 ORDER BY source_created_at DESC LIMIT ?",
+					"SELECT write_id, COALESCE(parent_title, '') as parent_title FROM member_activity_feed WHERE member_id = ? AND board_id = ? AND activity_type = 2 ORDER BY source_created_at DESC LIMIT ?",
 					mbID, largeBoardID, perTable,
 				).Scan(&refs)
 				if len(refs) > 0 {
@@ -270,7 +270,7 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 					}
 					// Step 2: Batch PK lookup for comment data (no LEFT JOIN needed)
 					r.db.Raw(
-						fmt.Sprintf("SELECT wr_id, wr_content, wr_datetime, mb_id, wr_name, wr_parent, wr_good, wr_nogood, wr_option, '' as post_title, '%s' as board_id FROM `g5_write_%s` WHERE wr_id IN ? AND wr_is_comment = 1 ORDER BY wr_datetime DESC", largeBoardID, largeBoardID),
+						fmt.Sprintf("SELECT c.wr_id, c.wr_content, c.wr_datetime, c.mb_id, c.wr_name, c.wr_parent, c.wr_good, c.wr_nogood, c.wr_option, '' as post_title, '%s' as board_id, c.wr_deleted_at AS deleted_at, p.wr_deleted_at AS parent_deleted_at FROM `g5_write_%s` c LEFT JOIN `g5_write_%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 WHERE c.wr_id IN ? AND c.wr_is_comment = 1 ORDER BY c.wr_datetime DESC", largeBoardID, largeBoardID, largeBoardID),
 						writeIDs,
 					).Scan(&rows)
 					// Fill parent titles from activity_feed (avoids expensive LEFT JOIN)
@@ -283,7 +283,7 @@ func (r *myPageRepository) FindCommentsByMember(mbID string, page, limit int) ([
 			} else {
 				table := fmt.Sprintf("g5_write_%s", bc.boardID)
 				r.db.Raw(
-					fmt.Sprintf("SELECT c.wr_id, c.wr_content, c.wr_datetime, c.mb_id, c.wr_name, c.wr_parent, c.wr_good, c.wr_nogood, c.wr_option, COALESCE(p.wr_subject, '') as post_title, '%s' as board_id FROM `%s` c LEFT JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND c.wr_deleted_at IS NULL ORDER BY c.wr_datetime DESC LIMIT %d", bc.boardID, table, table, perTable),
+					fmt.Sprintf("SELECT c.wr_id, c.wr_content, c.wr_datetime, c.mb_id, c.wr_name, c.wr_parent, c.wr_good, c.wr_nogood, c.wr_option, CASE WHEN p.wr_deleted_at IS NOT NULL THEN '[삭제된 글]' ELSE COALESCE(p.wr_subject, '') END as post_title, '%s' as board_id, c.wr_deleted_at AS deleted_at, p.wr_deleted_at AS parent_deleted_at FROM `%s` c LEFT JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 WHERE c.mb_id = ? AND c.wr_is_comment = 1 ORDER BY c.wr_datetime DESC LIMIT %d", bc.boardID, table, table, perTable),
 					mbID,
 				).Scan(&rows)
 			}
@@ -526,12 +526,12 @@ func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gn
 		`SELECT write_id AS wr_id,
 		        COALESCE(title, '') AS wr_subject,
 		        source_created_at AS wr_datetime,
-		        board_id
+		        board_id,
+		        CASE WHEN is_deleted = 1 THEN source_updated_at ELSE NULL END AS deleted_at
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 1
-		    AND is_public = 1
-		    AND is_deleted = 0
+		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,
@@ -549,7 +549,7 @@ func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gn
 	for _, b := range boards {
 		table := fmt.Sprintf("g5_write_%s", b.BoTable)
 		unions = append(unions, fmt.Sprintf(
-			"(SELECT wr_id, wr_subject, wr_datetime, '%s' as board_id FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND (wr_option NOT LIKE '%%secret%%' OR wr_option IS NULL) AND (wr_7 IS NULL OR wr_7 != 'lock') AND wr_deleted_at IS NULL ORDER BY wr_id DESC LIMIT %d)",
+			"(SELECT wr_id, wr_subject, wr_datetime, '%s' as board_id, wr_deleted_at AS deleted_at FROM `%s` WHERE mb_id = ? AND wr_is_comment = 0 AND (wr_option NOT LIKE '%%secret%%' OR wr_option IS NULL) AND (wr_7 IS NULL OR wr_7 != 'lock') ORDER BY wr_id DESC LIMIT %d)",
 			b.BoTable, table, limit))
 		args = append(args, mbID)
 	}
@@ -572,12 +572,13 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 		        COALESCE(content_preview, '') AS wr_content,
 		        COALESCE(parent_write_id, 0) AS wr_parent,
 		        source_created_at AS wr_datetime,
-		        board_id
+		        board_id,
+		        CASE WHEN is_deleted = 1 THEN source_updated_at ELSE NULL END AS deleted_at,
+		        NULL AS parent_deleted_at
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 2
-		    AND is_public = 1
-		    AND is_deleted = 0
+		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,
@@ -595,7 +596,7 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 	for _, b := range boards {
 		table := fmt.Sprintf("g5_write_%s", b.BoTable)
 		unions = append(unions, fmt.Sprintf(
-			"(SELECT c.wr_id, c.wr_content, c.wr_parent, c.wr_datetime, '%s' as board_id FROM `%s` c INNER JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 AND (p.wr_option NOT LIKE '%%secret%%' OR p.wr_option IS NULL) AND (p.wr_7 IS NULL OR p.wr_7 != 'lock') AND p.wr_deleted_at IS NULL WHERE c.mb_id = ? AND c.wr_is_comment = 1 AND c.wr_deleted_at IS NULL ORDER BY c.wr_id DESC LIMIT %d)",
+			"(SELECT c.wr_id, c.wr_content, c.wr_parent, c.wr_datetime, '%s' as board_id, c.wr_deleted_at AS deleted_at, p.wr_deleted_at AS parent_deleted_at FROM `%s` c INNER JOIN `%s` p ON c.wr_parent = p.wr_id AND p.wr_is_comment = 0 AND (p.wr_option NOT LIKE '%%secret%%' OR p.wr_option IS NULL) AND (p.wr_7 IS NULL OR p.wr_7 != 'lock') WHERE c.mb_id = ? AND c.wr_is_comment = 1 ORDER BY c.wr_id DESC LIMIT %d)",
 			b.BoTable, table, table, limit))
 		args = append(args, mbID)
 	}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -177,7 +177,8 @@ func (r *writeRepository) getSortField(boardID string) string {
 // Beyond this offset, the deferred JOIN subquery still scans too many index rows.
 const maxPostOffset = 30000
 
-// FindPosts retrieves posts (not comments, not deleted) from a board with pagination
+// FindPosts retrieves posts (not comments) from a board with pagination.
+// Soft-deleted posts stay in the list so users can still trace their own activity.
 func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
 	var posts []*gnuboard.G5Write
 	var total int64
@@ -191,7 +192,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	// Posts count with Redis cache (shared across all pods)
 	total = r.getCachedPostCount(boardID)
 	if total == 0 {
-		countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')")
+		countQuery := r.db.Table(table).Where("wr_is_comment = 0")
 		if err := countQuery.Count(&total).Error; err != nil {
 			return nil, 0, err
 		}
@@ -207,7 +208,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 		cols := prefixColumns(coreColumns, "t")
 		err := r.db.Raw(
 			fmt.Sprintf(
-				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
+				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
 				cols, table, table,
 			),
 			limit, offset,
@@ -216,7 +217,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
 			err = r.db.Table(table).
 				Select(coreColumns).
-				Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
+				Where("wr_is_comment = 0").
 				Order(orderClause).
 				Offset(offset).
 				Limit(limit).
@@ -227,7 +228,7 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 
 	err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").
+		Where("wr_is_comment = 0").
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).
@@ -244,7 +245,7 @@ func (r *writeRepository) FindPostsByCategory(boardID string, category string, p
 	offset := (page - 1) * limit
 	table := tableName(boardID)
 
-	baseWhere := "wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND ca_name = ?"
+	baseWhere := "wr_is_comment = 0 AND ca_name = ?"
 
 	if err := r.db.Table(table).Where(baseWhere, category).Count(&total).Error; err != nil {
 		return nil, 0, err
@@ -273,7 +274,7 @@ func (r *writeRepository) FindPostsAfter(boardID string, limit int, cursorWrNum 
 
 	total = r.getCachedPostCount(boardID)
 	if total == 0 {
-		countQuery := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')")
+		countQuery := r.db.Table(table).Where("wr_is_comment = 0")
 		if err := countQuery.Count(&total).Error; err != nil {
 			return nil, 0, err
 		}
@@ -288,7 +289,7 @@ func (r *writeRepository) FindPostsAfter(boardID string, limit int, cursorWrNum 
 	selectCols := strings.Join(coreColumns, ", ")
 	err := r.db.Raw(
 		fmt.Sprintf(
-			"SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?)) ORDER BY wr_num, wr_reply LIMIT ?",
+			"SELECT %s FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?)) ORDER BY wr_num, wr_reply LIMIT ?",
 			selectCols,
 			table,
 		),
@@ -297,7 +298,7 @@ func (r *writeRepository) FindPostsAfter(boardID string, limit int, cursorWrNum 
 	if err != nil && strings.Contains(err.Error(), "idx_list_page") {
 		err = r.db.Table(table).
 			Select(coreColumns).
-			Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?))", cursorWrNum, cursorWrNum, cursorWrReply).
+			Where("wr_is_comment = 0 AND (wr_num > ? OR (wr_num = ? AND wr_reply > ?))", cursorWrNum, cursorWrNum, cursorWrReply).
 			Order(orderClause).
 			Limit(limit).
 			Find(&posts).Error
@@ -323,7 +324,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 	// Reuse cached total count (same as FindPosts — avoids expensive COUNT on large tables)
 	total := r.getCachedPostCount(boardID)
 	if total == 0 {
-		if err := r.db.Table(table).Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')").Count(&total).Error; err != nil {
+		if err := r.db.Table(table).Where("wr_is_comment = 0").Count(&total).Error; err != nil {
 			return nil, 0, err
 		}
 		r.setCachedPostCount(boardID, total)
@@ -336,7 +337,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 		cols := prefixColumns(coreColumns, "t")
 		err := r.db.Raw(
 			fmt.Sprintf(
-				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ? ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
+				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND mb_id NOT IN ? ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
 				cols, table, table,
 			),
 			excludeMbIDs, limit, offset,
@@ -344,7 +345,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
 			err = r.db.Table(table).
 				Select(coreColumns).
-				Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ?", excludeMbIDs).
+				Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
 				Order(orderClause).
 				Offset(offset).
 				Limit(limit).
@@ -355,7 +356,7 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 
 	err := r.db.Table(table).
 		Select(coreColumns).
-		Where("wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00') AND mb_id NOT IN ?", excludeMbIDs).
+		Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
 		Order(orderClause).
 		Offset(offset).
 		Limit(limit).


### PR DESCRIPTION
## 요약\n- 게시판 목록에서 soft-deleted 글을 숨기지 않도록 수정\n- 내 글/내 댓글 및 작성자 최근 활동 API에 deleted_at 정보를 포함\n- 삭제된 부모 글의 댓글도 최근 활동에서 유지\n\n## 검증\n- go test ./internal/handler/... ./internal/repository/gnuboard/... ./internal/domain/gnuboard/...\n- git diff --check