### PR TITLE
fix: 자동 등업에 실명인증 조건을 반영

### DIFF
--- a/internal/cron/auto_promote.go
+++ b/internal/cron/auto_promote.go
@@ -17,11 +17,11 @@ type AutoPromoteResult struct {
 }
 
 // runAutoPromote promotes members from mb_level 2 to 3
-// Conditions: mb_login_days >= 7 AND as_exp >= 3000
+// Conditions: mb_certify <> '' AND mb_login_days >= 7 AND as_exp >= 3000
 func runAutoPromote(db *gorm.DB, notiRepo gnurepo.NotiRepository) (*AutoPromoteResult, error) {
 	now := time.Now()
 
-	// 조건 충족 회원 조회: mb_level=2, 로그인 7일 이상, 경험치 3000 이상
+	// 조건 충족 회원 조회: mb_level=2, 실명인증, 로그인 7일 이상, 경험치 3000 이상
 	type candidate struct {
 		MbID string `gorm:"column:mb_id"`
 	}
@@ -29,6 +29,7 @@ func runAutoPromote(db *gorm.DB, notiRepo gnurepo.NotiRepository) (*AutoPromoteR
 	if err := db.Table("g5_member").
 		Select("mb_id").
 		Where("mb_level = 2 AND mb_login_days >= 7 AND as_exp >= 3000").
+		Where("COALESCE(mb_certify, '') <> ''").
 		Where("mb_leave_date = '' AND mb_intercept_date = ''").
 		Find(&candidates).Error; err != nil {
 		return nil, fmt.Errorf("후보 조회 실패: %w", err)

--- a/internal/cron/auto_promote_test.go
+++ b/internal/cron/auto_promote_test.go
@@ -1,0 +1,59 @@
+package cron
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRunAutoPromoteRequiresCertification(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	if err := db.Exec(`CREATE TABLE g5_member (
+		mb_id TEXT PRIMARY KEY,
+		mb_level INTEGER,
+		mb_login_days INTEGER,
+		as_exp INTEGER,
+		mb_certify TEXT,
+		mb_leave_date TEXT,
+		mb_intercept_date TEXT
+	)`).Error; err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	if err := db.Exec(`
+		INSERT INTO g5_member (mb_id, mb_level, mb_login_days, as_exp, mb_certify, mb_leave_date, mb_intercept_date) VALUES
+		('certified_user', 2, 7, 3000, 'simple', '', ''),
+		('uncertified_user', 2, 30, 9000, '', '', '')
+	`).Error; err != nil {
+		t.Fatalf("insert members: %v", err)
+	}
+
+	result, err := runAutoPromote(db, nil)
+	if err != nil {
+		t.Fatalf("runAutoPromote: %v", err)
+	}
+	if result.PromotedCount != 1 {
+		t.Fatalf("expected 1 promoted member, got %d", result.PromotedCount)
+	}
+
+	var certifiedLevel int
+	if err := db.Table("g5_member").Select("mb_level").Where("mb_id = ?", "certified_user").Scan(&certifiedLevel).Error; err != nil {
+		t.Fatalf("query certified member: %v", err)
+	}
+	if certifiedLevel != 3 {
+		t.Fatalf("expected certified member to be promoted to 3, got %d", certifiedLevel)
+	}
+
+	var uncertifiedLevel int
+	if err := db.Table("g5_member").Select("mb_level").Where("mb_id = ?", "uncertified_user").Scan(&uncertifiedLevel).Error; err != nil {
+		t.Fatalf("query uncertified member: %v", err)
+	}
+	if uncertifiedLevel != 2 {
+		t.Fatalf("expected uncertified member to stay at 2, got %d", uncertifiedLevel)
+	}
+}

--- a/internal/service/v2/auth_service.go
+++ b/internal/service/v2/auth_service.go
@@ -201,6 +201,10 @@ func isBcryptHash(hash string) bool {
 	return len(hash) == 60 && (hash[:4] == "$2a$" || hash[:4] == "$2b$" || hash[:4] == "$2y$")
 }
 
+func isEligibleForAutoPromotion(level, loginDays, exp int, certify string) bool {
+	return level == 2 && loginDays >= 7 && exp >= 3000 && certify != ""
+}
+
 // checkAndPromote checks if the user meets auto-promotion criteria and promotes them.
 // Currently supports 2→3 (앙님) promotion.
 func (s *V2AuthService) checkAndPromote(mbID string) (bool, int) {
@@ -212,17 +216,18 @@ func (s *V2AuthService) checkAndPromote(mbID string) (bool, int) {
 		MbLevel   int `gorm:"column:mb_level"`
 		LoginDays int `gorm:"column:mb_login_days"`
 		Exp       int `gorm:"column:as_exp"`
+		Certify   string `gorm:"column:mb_certify"`
 	}
 	if err := s.db.Table("g5_member").
-		Select("mb_level, mb_login_days, as_exp").
+		Select("mb_level, mb_login_days, as_exp, mb_certify").
 		Where("mb_id = ?", mbID).
 		First(&member).Error; err != nil {
 		log.Printf("[v2-auth] checkAndPromote: member query failed for %s: %v", mbID, err)
 		return false, 0
 	}
 
-	// 2→3 (앙님) 조건: 로그인 7일 이상 + 경험치 3000 이상
-	if member.MbLevel == 2 && member.LoginDays >= 7 && member.Exp >= 3000 {
+	// 2→3 (앙님) 조건: 실명인증 + 로그인 7일 이상 + 경험치 3000 이상
+	if isEligibleForAutoPromotion(member.MbLevel, member.LoginDays, member.Exp, member.Certify) {
 		if err := s.db.Table("g5_member").
 			Where("mb_id = ?", mbID).
 			Update("mb_level", 3).Error; err != nil {

--- a/internal/service/v2/auth_service_test.go
+++ b/internal/service/v2/auth_service_test.go
@@ -1,0 +1,48 @@
+package v2
+
+import "testing"
+
+func TestIsEligibleForAutoPromotion(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     int
+		loginDays int
+		exp       int
+		certify   string
+		want      bool
+	}{
+		{
+			name:      "eligible certified member",
+			level:     2,
+			loginDays: 7,
+			exp:       3000,
+			certify:   "simple",
+			want:      true,
+		},
+		{
+			name:      "rejects uncertified member",
+			level:     2,
+			loginDays: 10,
+			exp:       12000,
+			certify:   "",
+			want:      false,
+		},
+		{
+			name:      "rejects wrong level",
+			level:     3,
+			loginDays: 10,
+			exp:       12000,
+			certify:   "simple",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEligibleForAutoPromotion(tt.level, tt.loginDays, tt.exp, tt.certify)
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 요약\n- 로그인 자동 등업 조건에 실명인증을 추가\n- cron 자동 승급도 동일한 실명인증 조건을 사용하도록 정렬\n- 관련 단위 테스트 추가\n\n## 검증\n- go test ./internal/service/v2 ./internal/cron\n- go build ./...