### PR TITLE
fix: internal cron 미들웨어 누락 보정

### DIFF
--- a/internal/middleware/internal_cron.go
+++ b/internal/middleware/internal_cron.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireInternalCron allows localhost calls or trusted internal callers that
+// present the shared INTERNAL_SECRET header. Cron handlers still validate their
+// own CRON_SECRET query parameter.
+func RequireInternalCron() gin.HandlerFunc {
+	internalSecret := os.Getenv("INTERNAL_SECRET")
+
+	return func(c *gin.Context) {
+		ip := getRemoteIP(c)
+		if ip == "127.0.0.1" || ip == "::1" {
+			c.Next()
+			return
+		}
+
+		headerSecret := c.GetHeader("X-Internal-Secret")
+		if internalSecret != "" && headerSecret == internalSecret {
+			c.Next()
+			return
+		}
+
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	}
+}


### PR DESCRIPTION
## 변경사항
- 누락된 internal cron 미들웨어를 정식 파일로 추가
- /api/internal/cron 라우트 빌드 실패를 해소

## 배경
- 직전 affiliate 저장형 동기화 머지 후 backend CI에서  미정의로 빌드가 실패했습니다.
- 카나리 배포를 다시 열기 위한 최소 수정입니다.