### PR TITLE
나눔 목록 상태 모델 정리

### DIFF
--- a/internal/domain/giving/model.go
+++ b/internal/domain/giving/model.go
@@ -1,0 +1,85 @@
+package giving
+
+import (
+	"fmt"
+	"time"
+)
+
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusWaiting  Status = "waiting"
+	StatusPaused   Status = "paused"
+	StatusEnded    Status = "ended"
+	StatusNoGiving Status = "no_giving"
+)
+
+type Meta struct {
+	StartRaw         string
+	EndRaw           string
+	StateRaw         string
+	ParticipantCount int
+}
+
+type Normalized struct {
+	GivingStart      string
+	GivingEnd        string
+	Status           Status
+	ParticipantCount int
+	IsPaused         bool
+	IsUrgent         bool
+}
+
+// ParseTime parses the time formats currently stored in giving posts.
+func ParseTime(s string) (time.Time, error) {
+	formats := []string{
+		"2006-01-02T15:04",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+	}
+	loc, _ := time.LoadLocation("Asia/Seoul")
+	for _, f := range formats {
+		if t, err := time.ParseInLocation(f, s, loc); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse time: %s", s)
+}
+
+func Normalize(now time.Time, meta Meta) Normalized {
+	normalized := Normalized{
+		GivingStart:      meta.StartRaw,
+		GivingEnd:        meta.EndRaw,
+		ParticipantCount: meta.ParticipantCount,
+		Status:           StatusNoGiving,
+	}
+
+	startTime, startErr := ParseTime(meta.StartRaw)
+	endTime, endErr := ParseTime(meta.EndRaw)
+	hasSchedule := meta.StartRaw != "" && meta.EndRaw != "" && startErr == nil && endErr == nil
+
+	switch {
+	case meta.StateRaw == "2":
+		normalized.Status = StatusEnded
+	case meta.StateRaw == "1" && hasSchedule:
+		normalized.Status = StatusPaused
+		normalized.IsPaused = true
+	case !hasSchedule:
+		normalized.Status = StatusNoGiving
+	case now.After(endTime):
+		normalized.Status = StatusEnded
+	case !now.Before(startTime):
+		normalized.Status = StatusActive
+	default:
+		normalized.Status = StatusWaiting
+	}
+
+	if normalized.Status == StatusActive {
+		diff := endTime.Sub(now)
+		normalized.IsUrgent = diff > 0 && diff <= 24*time.Hour
+	}
+
+	return normalized
+}

--- a/internal/domain/giving/model_test.go
+++ b/internal/domain/giving/model_test.go
@@ -1,0 +1,69 @@
+package giving
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeStatuses(t *testing.T) {
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.FixedZone("KST", 9*60*60))
+
+	tests := []struct {
+		name string
+		meta Meta
+		want Status
+	}{
+		{
+			name: "active",
+			meta: Meta{StartRaw: "2026-03-24T11:00", EndRaw: "2026-03-24T13:00"},
+			want: StatusActive,
+		},
+		{
+			name: "waiting",
+			meta: Meta{StartRaw: "2026-03-24T13:00", EndRaw: "2026-03-24T15:00"},
+			want: StatusWaiting,
+		},
+		{
+			name: "paused",
+			meta: Meta{StartRaw: "2026-03-24T11:00", EndRaw: "2026-03-24T13:00", StateRaw: "1"},
+			want: StatusPaused,
+		},
+		{
+			name: "ended by time",
+			meta: Meta{StartRaw: "2026-03-24T09:00", EndRaw: "2026-03-24T11:00"},
+			want: StatusEnded,
+		},
+		{
+			name: "ended by force",
+			meta: Meta{StartRaw: "2026-03-24T13:00", EndRaw: "2026-03-24T15:00", StateRaw: "2"},
+			want: StatusEnded,
+		},
+		{
+			name: "no giving without schedule",
+			meta: Meta{},
+			want: StatusNoGiving,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Normalize(now, tt.meta)
+			if got.Status != tt.want {
+				t.Fatalf("status = %s, want %s", got.Status, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeUrgentWindow(t *testing.T) {
+	now := time.Date(2026, 3, 24, 12, 0, 0, 0, time.FixedZone("KST", 9*60*60))
+
+	got := Normalize(now, Meta{
+		StartRaw: "2026-03-24T11:00",
+		EndRaw:   "2026-03-24T23:00",
+	})
+
+	if !got.IsUrgent {
+		t.Fatalf("expected active giving within 24h to be urgent")
+	}
+}

--- a/internal/handler/giving_handler.go
+++ b/internal/handler/giving_handler.go
@@ -1,11 +1,12 @@
 package handler
 
 import (
-	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
+	givingdomain "github.com/damoang/angple-backend/internal/domain/giving"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -24,8 +25,13 @@ func NewGivingHandler(db *gorm.DB) *GivingHandler {
 type GivingListItem struct {
 	ID               int    `json:"id"`
 	Title            string `json:"title"`
+	Extra4           string `json:"extra_4,omitempty"`
 	Extra5           string `json:"extra_5"`
+	GivingStart      string `json:"giving_start,omitempty"`
+	GivingEnd        string `json:"giving_end,omitempty"`
+	GivingStatus     string `json:"giving_status"`
 	ParticipantCount int    `json:"participant_count"`
+	IsPaused         bool   `json:"is_paused"`
 	IsUrgent         bool   `json:"is_urgent"`
 }
 
@@ -46,38 +52,20 @@ func (h *GivingHandler) List(c *gin.Context) {
 	type givingRow struct {
 		WrID             int    `gorm:"column:wr_id"`
 		WrSubject        string `gorm:"column:wr_subject"`
+		Wr4              string `gorm:"column:wr_4"` // start_time
 		Wr5              string `gorm:"column:wr_5"` // end_time
+		Wr7              string `gorm:"column:wr_7"` // state
 		ParticipantCount int    `gorm:"column:participant_count"`
 	}
 
 	query := h.db.Table("g5_write_giving AS g").
-		Select(`g.wr_id, g.wr_subject, g.wr_5,
+		Select(`g.wr_id, g.wr_subject, g.wr_4, g.wr_5, g.wr_7,
 			COALESCE((SELECT COUNT(DISTINCT b.mb_id) FROM g5_giving_bid b WHERE b.wr_id = g.wr_id), 0) AS participant_count`).
-		Where("g.wr_is_comment = 0")
-
-	nowStr := now.Format("2006-01-02T15:04")
-	switch tab {
-	case "active":
-		query = query.
-			Where("(g.wr_7 = '' OR g.wr_7 IS NULL)").
-			Where("g.wr_5 != '' AND g.wr_5 > ?", nowStr)
-	case "ended":
-		query = query.Where(
-			"(g.wr_5 != '' AND g.wr_5 <= ?) OR g.wr_7 = '2'", nowStr,
-		)
-	}
-
-	switch sortBy {
-	case "urgent":
-		query = query.Order("g.wr_5 ASC")
-	case "newest":
-		query = query.Order("g.wr_id DESC")
-	default:
-		query = query.Order("g.wr_5 ASC")
-	}
+		Where("g.wr_is_comment = 0").
+		Where("g.wr_deleted_at IS NULL")
 
 	var rows []givingRow
-	if err := query.Limit(limit).Find(&rows).Error; err != nil {
+	if err := query.Find(&rows).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,
 			"error":   "Failed to fetch giving list",
@@ -87,42 +75,53 @@ func (h *GivingHandler) List(c *gin.Context) {
 
 	items := make([]GivingListItem, 0, len(rows))
 	for _, r := range rows {
-		isUrgent := false
-		if r.Wr5 != "" {
-			if endTime, err := parseGivingTime(r.Wr5); err == nil {
-				diff := endTime.Sub(now)
-				isUrgent = diff > 0 && diff <= 24*time.Hour
-			}
+		meta := givingdomain.Normalize(now, givingdomain.Meta{
+			StartRaw:         r.Wr4,
+			EndRaw:           r.Wr5,
+			StateRaw:         r.Wr7,
+			ParticipantCount: r.ParticipantCount,
+		})
+
+		if meta.Status == givingdomain.StatusNoGiving {
+			continue
+		}
+		if tab == "active" && meta.Status == givingdomain.StatusEnded {
+			continue
+		}
+		if tab == "ended" && meta.Status != givingdomain.StatusEnded {
+			continue
 		}
 
 		items = append(items, GivingListItem{
 			ID:               r.WrID,
 			Title:            r.WrSubject,
+			Extra4:           r.Wr4,
 			Extra5:           r.Wr5,
-			ParticipantCount: r.ParticipantCount,
-			IsUrgent:         isUrgent,
+			GivingStart:      meta.GivingStart,
+			GivingEnd:        meta.GivingEnd,
+			GivingStatus:     string(meta.Status),
+			ParticipantCount: meta.ParticipantCount,
+			IsPaused:         meta.IsPaused,
+			IsUrgent:         meta.IsUrgent,
 		})
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		switch sortBy {
+		case "newest":
+			return items[i].ID > items[j].ID
+		case "urgent":
+			fallthrough
+		default:
+			return items[i].GivingEnd < items[j].GivingEnd
+		}
+	})
+	if len(items) > limit {
+		items = items[:limit]
 	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"data":    items,
 	})
-}
-
-// parseGivingTime parses various time formats used in giving posts
-func parseGivingTime(s string) (time.Time, error) {
-	formats := []string{
-		"2006-01-02T15:04",
-		"2006-01-02T15:04:05",
-		"2006-01-02 15:04:05",
-		"2006-01-02 15:04",
-	}
-	loc, _ := time.LoadLocation("Asia/Seoul")
-	for _, f := range formats {
-		if t, err := time.ParseInLocation(f, s, loc); err == nil {
-			return t, nil
-		}
-	}
-	return time.Time{}, fmt.Errorf("cannot parse time: %s", s)
 }


### PR DESCRIPTION
## 요약
- 나눔 상태 계산을 백엔드 도메인 모델로 분리
- 나눔 목록 API가 공통 상태/시간/참여수 필드를 응답하도록 정리
- 향후 별도 참여 테이블과 응모 기능을 붙이기 쉬운 구조로 정리

## 검증
- go test ./...
- go build ./...