### PR TITLE
백엔드 카나리 헬스체크 경로 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: canary
-      url: https://canary.damoang.net/api/v1/health
+      url: https://canary.damoang.net
     permissions:
       id-token: write
       contents: read
@@ -132,17 +132,60 @@ jobs:
           echo "Timeout"
           exit 1
 
-      - name: Smoke test
+      - name: Smoke test (via SSM)
         run: |
-          for i in {1..30}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" -A "GitHub-Actions-Healthcheck" https://canary.damoang.net/api/v1/health || echo "000")
-            if [ "$STATUS" = "200" ]; then
-              echo "✅ Canary healthy"
+          cat > /tmp/backend-canary-smoke-params.json <<'JSON'
+          {
+            "commands": [
+              "set -euo pipefail",
+              "for i in $(seq 1 30); do STATUS=$(curl -s -o /dev/null -w \"%{http_code}\" http://127.0.0.1:30083/health || echo 000); if [ \"$STATUS\" = \"200\" ]; then echo \"✅ Backend canary health OK\"; exit 0; fi; sleep 2; done",
+              "echo \"❌ Backend canary health failed\"",
+              "exit 1"
+            ]
+          }
+          JSON
+
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "i-038a1d1f00798d94b" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file:///tmp/backend-canary-smoke-params.json \
+            --timeout-seconds 180 \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "i-038a1d1f00798d94b" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            if [ "$STATUS" = "Success" ]; then
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text || true
               exit 0
+            elif [ "$STATUS" = "Failed" ]; then
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardOutputContent" \
+                --output text || true
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "i-038a1d1f00798d94b" \
+                --query "StandardErrorContent" \
+                --output text || true
+              exit 1
             fi
             sleep 2
           done
-          echo "❌ Canary failed (Status: $STATUS)"
+
+          echo "Timeout"
           exit 1
 
       - name: Notify Discord (Canary)
@@ -244,8 +287,8 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
             -d "chat_id=${{ secrets.TELEGRAM_DEPLOY_CHAT_ID }}" \
-            -d "text=✅ angple backend canary verified%0A%0ARepo: ${{ github.repository }}%0ACommit: ${{ github.sha }}%0ATag: \`${{ needs.build.outputs.sha_tag }}\`%0ADigest: \`${{ needs.build.outputs.image_digest }}\`%0ACanary: https://canary.damoang.net/api/v1/health%0AGate Approval: ${RUN_URL}%0A%0ACanary 검증 통과 후 Environment approval 을 하면 production 배포가 진행됩니다." \
-            -d "reply_markup={\"inline_keyboard\":[[{\"text\":\"Canary 열기\",\"url\":\"https://canary.damoang.net/api/v1/health\"},{\"text\":\"Gate Approval\",\"url\":\"${RUN_URL}\"}]]}"
+            -d "text=✅ angple backend canary verified%0A%0ARepo: ${{ github.repository }}%0ACommit: ${{ github.sha }}%0ATag: \`${{ needs.build.outputs.sha_tag }}\`%0ADigest: \`${{ needs.build.outputs.image_digest }}\`%0ACanary Host: https://canary.damoang.net%0AGate Approval: ${RUN_URL}%0A%0A백엔드 canary 헬스체크는 배포 대상 인스턴스에서 내부 NodePort 기준으로 검증되었습니다." \
+            -d "reply_markup={\"inline_keyboard\":[[{\"text\":\"Canary Host\",\"url\":\"https://canary.damoang.net\"},{\"text\":\"Gate Approval\",\"url\":\"${RUN_URL}\"}]]}"
 
   deploy-production:
     needs: [build, deploy-canary, verify-canary]


### PR DESCRIPTION
## 요약
- backend deploy workflow의 canary smoke test를 외부 canary host가 아니라 배포 대상 EC2 내부 NodePort 기준으로 검증하도록 수정
- 잘못된  링크 문구를 정리

## 배경
- 현재 canary host는 ALB 규칙상 backend canary target으로 직접 연결되지 않아 외부 502가 발생함
- 실제 canary 파드는 에서 정상 응답 중이었고, workflow 검증식만 인프라와 어긋나 있었음

## 검증
- workflow YAML 파싱 확인 ()
- 운영 canary pod  200 및 외부 canary host 502 상태 대조 확인