### PR TITLE
혼합 대소문자 게시판 슬러그 허용

### DIFF
--- a/internal/middleware/board_validate.go
+++ b/internal/middleware/board_validate.go
@@ -8,9 +8,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// BoardSlugRegex allows lowercase letters, digits, and underscores, max 20 chars.
-// Matches Gnuboard's board ID rules.
-var BoardSlugRegex = regexp.MustCompile(`^[a-z0-9_]{1,20}$`)
+// BoardSlugRegex allows ASCII letters, digits, and underscores, max 20 chars.
+// Some legacy Gnuboard boards in production use mixed-case bo_table values
+// such as MSSurface, so uppercase slugs must also pass validation.
+var BoardSlugRegex = regexp.MustCompile(`^[A-Za-z0-9_]{1,20}$`)
 
 // ValidateBoardSlug rejects requests whose :slug parameter contains invalid characters.
 func ValidateBoardSlug() gin.HandlerFunc {


### PR DESCRIPTION
## 요약
- board slug 검증 정규식에서 대문자도 허용
- MSSurface 같은 mixed-case bo_table 보드가 400으로 차단되지 않게 수정

## 검증
- go test ./... (기존 중복 선언 오류로 실패: internal/middleware/internal_cron.go, internal/middleware/admin.go)
- go build ./... (같은 기존 오류로 실패)