### PR TITLE
프로덕션 부팅 마이그레이션 차단

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: canary
-      url: https://canary.damoang.net
+      url: https://canary.damoang.net/api/v1/health
     permissions:
       id-token: write
       contents: read
@@ -281,6 +281,21 @@ jobs:
           echo "Timeout"
           exit 1
 
+      - name: Verify public canary returns 200
+        run: |
+          for i in $(seq 1 30); do
+            code=$(curl -sS -o /tmp/backend-canary-public-health.out -w "%{http_code}" --max-time 10 "https://canary.damoang.net/api/v1/health" || echo "000")
+            echo "CHECK public canary /api/v1/health -> ${code}"
+            if [ "$code" = "200" ]; then
+              echo "✅ Public canary health check passed"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "❌ Public canary health check failed"
+          cat /tmp/backend-canary-public-health.out || true
+          exit 1
+
       - name: Notify Telegram (Approval)
         if: success()
         run: |
@@ -352,6 +367,21 @@ jobs:
             sleep 5
           done
           echo "Timeout"
+          exit 1
+
+      - name: Verify production returns 200
+        run: |
+          for i in $(seq 1 36); do
+            code=$(curl -sS -o /tmp/backend-production-health.out -w "%{http_code}" --max-time 10 "https://damoang.net/api/v1/health" || echo "000")
+            echo "CHECK production /api/v1/health -> ${code}"
+            if [ "$code" = "200" ]; then
+              echo "✅ Production health check passed"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "❌ Production health check failed"
+          cat /tmp/backend-production-health.out || true
           exit 1
 
       - name: Notify Discord (Production)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -87,6 +87,20 @@ func getConfigPath() string {
 	return fmt.Sprintf("configs/config.%s.yaml", env)
 }
 
+func shouldRunBootMigrations(env string) bool {
+	if override := strings.TrimSpace(os.Getenv("AUTO_MIGRATE_ON_BOOT")); override != "" {
+		override = strings.ToLower(override)
+		return override == "1" || override == "true" || override == "yes" || override == "on"
+	}
+
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "", "local", "development", "dev", "test":
+		return true
+	default:
+		return false
+	}
+}
+
 // memCachedPosts holds parsed post data in memory for fast filtering.
 type memCachedPosts struct {
 	items     []map[string]any // parsed post items (for filtering)
@@ -440,11 +454,15 @@ func main() {
 		db = nil
 	} else {
 		pkglogger.Info("Connected to MySQL")
-		if err := migration.Run(db); err != nil {
-			pkglogger.Info("Migration warning: %v", err)
-		}
-		if err := migration.RunV2Schema(db); err != nil {
-			pkglogger.Info("V2 schema migration warning: %v", err)
+		if shouldRunBootMigrations(env) {
+			if err := migration.Run(db); err != nil {
+				pkglogger.Info("Migration warning: %v", err)
+			}
+			if err := migration.RunV2Schema(db); err != nil {
+				pkglogger.Info("V2 schema migration warning: %v", err)
+			}
+		} else {
+			pkglogger.Info("Skipping boot migrations in APP_ENV=%s (set AUTO_MIGRATE_ON_BOOT=true to enable)", env)
 		}
 		if env == "" || env == "development" || env == "local" {
 			if err := migration.MigrateV2Data(db); err != nil {


### PR DESCRIPTION
## 요약
- 프로덕션/캔어리에서는 부팅 시 자동 마이그레이션을 기본 비활성화
- canary 내부 검증과 public 200 검증을 모두 유지
- production 배포 후 public 200 검증을 추가

## 배경
- 오늘 backend 재배포 시마다 부팅 중 migration.Run()/RunV2Schema() 때문에 health=503 상태가 길어져 rollout 장애가 발생했습니다.
- 배포 성공으로 처리된 뒤에도 실제 production /api/v1/health 가 200이 아닐 수 있어 재발 가능성이 있었습니다.

## 검증
- go build ./...
- go test ./...