### PR TITLE
게시판 메타 조회를 메모리 캐시로 완화

### DIFF
--- a/internal/repository/gnuboard/board_repo.go
+++ b/internal/repository/gnuboard/board_repo.go
@@ -3,7 +3,18 @@ package gnuboard
 import (
 	"github.com/damoang/angple-backend/internal/domain/gnuboard"
 	"gorm.io/gorm"
+	"sync"
+	"time"
 )
+
+var boardByIDCache sync.Map
+
+type cachedBoard struct {
+	board     *gnuboard.G5Board
+	expiresAt time.Time
+}
+
+const boardByIDCacheTTL = 60 * time.Second
 
 // BoardRepository provides access to g5_board table
 type BoardRepository interface {
@@ -28,11 +39,27 @@ func NewBoardRepository(db *gorm.DB) BoardRepository {
 
 // FindByID finds a board by its table name (bo_table)
 func (r *boardRepository) FindByID(boardID string) (*gnuboard.G5Board, error) {
+	now := time.Now()
+	if cached, ok := boardByIDCache.Load(boardID); ok {
+		if entry, valid := cached.(*cachedBoard); valid && now.Before(entry.expiresAt) && entry.board != nil {
+			boardCopy := *entry.board
+			return &boardCopy, nil
+		}
+		boardByIDCache.Delete(boardID)
+	}
+
 	var board gnuboard.G5Board
 	err := r.db.Where("bo_table = ?", boardID).First(&board).Error
 	if err != nil {
 		return nil, err
 	}
+
+	boardCopy := board
+	boardByIDCache.Store(boardID, &cachedBoard{
+		board:     &boardCopy,
+		expiresAt: now.Add(boardByIDCacheTTL),
+	})
+
 	return &board, nil
 }
 
@@ -59,17 +86,29 @@ func (r *boardRepository) Exists(boardID string) bool {
 
 // Create creates a new board in g5_board
 func (r *boardRepository) Create(board *gnuboard.G5Board) error {
-	return r.db.Create(board).Error
+	if err := r.db.Create(board).Error; err != nil {
+		return err
+	}
+	boardByIDCache.Delete(board.BoTable)
+	return nil
 }
 
 // Update updates a board in g5_board
 func (r *boardRepository) Update(board *gnuboard.G5Board) error {
-	return r.db.Save(board).Error
+	if err := r.db.Save(board).Error; err != nil {
+		return err
+	}
+	boardByIDCache.Delete(board.BoTable)
+	return nil
 }
 
 // Delete deletes a board from g5_board
 func (r *boardRepository) Delete(boardID string) error {
-	return r.db.Where("bo_table = ?", boardID).Delete(&gnuboard.G5Board{}).Error
+	if err := r.db.Where("bo_table = ?", boardID).Delete(&gnuboard.G5Board{}).Error; err != nil {
+		return err
+	}
+	boardByIDCache.Delete(boardID)
+	return nil
 }
 
 // GetDB returns the underlying DB instance for raw operations


### PR DESCRIPTION
## 변경 사항
- g5_board 단건 조회를 repository 레벨 60초 메모리 캐시로 완화
- create/update/delete 시 캐시 무효화 추가

## 배경
- 운영 장애 시 g5_board WHERE bo_table = ? 단건 조회가 수십초~수분까지 지연됨
- 같은 보드 메타를 반복 조회하면서 timeout 연쇄가 발생함

## 검증
- go test ./...
- go build ./...