### PR TITLE
자유게시판 댓글 수 서브쿼리 제거

### DIFF
--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -121,16 +121,11 @@ func tableName(boardID string) string {
 	return fmt.Sprintf("g5_write_%s", boardID)
 }
 
-func visibleCommentCountExpr(table, alias string) string {
-	parentRef := "wr_id"
+func visibleCommentCountExpr(_ string, alias string) string {
 	if alias != "" {
-		parentRef = alias + ".wr_id"
+		return alias + ".wr_comment AS wr_comment"
 	}
-	return fmt.Sprintf(
-		"(SELECT COUNT(*) FROM `%s` c WHERE c.wr_parent = %s AND c.wr_is_comment = 1 AND (c.wr_deleted_at IS NULL OR c.wr_deleted_at = '0000-00-00 00:00:00')) AS wr_comment",
-		table,
-		parentRef,
-	)
+	return "wr_comment"
 }
 
 func postSelectColumns(boardID, alias string) string {


### PR DESCRIPTION
## 요약
- g5_write_free 목록 조회에서 per-row 댓글 수 COUNT 서브쿼리를 제거합니다.
- 저장된 wr_comment 값을 그대로 사용해 동시 COUNT 폭주를 막습니다.

## 검증
- go test ./internal/repository/gnuboard/...