### PR TITLE
댓글 수 보정과 동기화 크론 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -240,6 +240,46 @@ func adjustPostCommentCount(tx *gorm.DB, boardID string, postID int, delta int) 
 		Error
 }
 
+func softDeleteCommentAndAdjust(tx *gorm.DB, boardID string, postID int, commentID int, deletedBy string, deletedAt time.Time) (bool, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardID)
+	result := tx.Table(tableName).
+		Where("wr_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", commentID).
+		Updates(map[string]interface{}{
+			"wr_deleted_at": deletedAt,
+			"wr_deleted_by": deletedBy,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return false, nil
+	}
+	if err := adjustPostCommentCount(tx, boardID, postID, -1); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func restoreCommentAndAdjust(tx *gorm.DB, boardID string, postID int, commentID int) (bool, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardID)
+	result := tx.Table(tableName).
+		Where("wr_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NOT NULL", commentID).
+		Updates(map[string]interface{}{
+			"wr_deleted_at": nil,
+			"wr_deleted_by": nil,
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return false, nil
+	}
+	if err := adjustPostCommentCount(tx, boardID, postID, 1); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func logWritePhase(c *gin.Context, op, boardID string, targetID int, started time.Time, fields map[string]time.Duration) {
 	parts := make([]string, 0, len(fields))
 	for key, value := range fields {
@@ -3460,14 +3500,12 @@ func main() {
 			if userLevel >= 10 {
 				txErr := db.Transaction(func(tx *gorm.DB) error {
 					now := time.Now()
-					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
-						"wr_deleted_at": now,
-						"wr_deleted_by": userID,
-					}).Error; err != nil {
+					changed, err := softDeleteCommentAndAdjust(tx, slug, postID, commentID, userID, now)
+					if err != nil {
 						return err
 					}
-					if err := adjustPostCommentCount(tx, slug, postID, -1); err != nil {
-						return err
+					if !changed {
+						return nil
 					}
 					return createWriteAfterEvent(
 						tx,
@@ -3511,14 +3549,12 @@ func main() {
 				// 답글 없으면 즉시 삭제
 				txErr := db.Transaction(func(tx *gorm.DB) error {
 					now := time.Now()
-					if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
-						"wr_deleted_at": now,
-						"wr_deleted_by": userID,
-					}).Error; err != nil {
+					changed, err := softDeleteCommentAndAdjust(tx, slug, postID, commentID, userID, now)
+					if err != nil {
 						return err
 					}
-					if err := adjustPostCommentCount(tx, slug, postID, -1); err != nil {
-						return err
+					if !changed {
+						return nil
 					}
 					return createWriteAfterEvent(
 						tx,
@@ -3609,14 +3645,12 @@ func main() {
 			// 댓글 복구
 			postID, _ := strconv.Atoi(c.Param("id"))
 			txErr := db.Transaction(func(tx *gorm.DB) error {
-				if err := tx.Table(fmt.Sprintf("g5_write_%s", slug)).Where("wr_id = ? AND wr_is_comment = 1", commentID).Updates(map[string]interface{}{
-					"wr_deleted_at": nil,
-					"wr_deleted_by": nil,
-				}).Error; err != nil {
+				changed, err := restoreCommentAndAdjust(tx, slug, postID, commentID)
+				if err != nil {
 					return err
 				}
-				if err := adjustPostCommentCount(tx, slug, postID, 1); err != nil {
-					return err
+				if !changed {
+					return nil
 				}
 				return createWriteAfterEvent(
 					tx,
@@ -5036,6 +5070,7 @@ func main() {
 		cronGroup.POST("/point-expiry", cronHandler.PointExpiry)
 		cronGroup.POST("/point-expiry-notify", cronHandler.PointExpiryNotify)
 		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
+		cronGroup.POST("/sync-visible-comment-counts", cronHandler.SyncVisibleCommentCounts)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo, writeAfterEventRepo)

--- a/internal/cron/comment_counts.go
+++ b/internal/cron/comment_counts.go
@@ -1,0 +1,102 @@
+package cron
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type SyncVisibleCommentCountsResult struct {
+	BoardsChecked int      `json:"boards_checked"`
+	BoardsSynced  int      `json:"boards_synced"`
+	RowsUpdated   int64    `json:"rows_updated"`
+	Errors        int      `json:"errors"`
+	ErrorBoards   []string `json:"error_boards,omitempty"`
+}
+
+func runSyncVisibleCommentCounts(db *gorm.DB) (*SyncVisibleCommentCountsResult, error) {
+	var boards []string
+	if err := db.Table("g5_board").
+		Select("bo_table").
+		Where("bo_table <> ''").
+		Scan(&boards).Error; err != nil {
+		return nil, err
+	}
+
+	result := &SyncVisibleCommentCountsResult{
+		BoardsChecked: len(boards),
+		ErrorBoards:   make([]string, 0),
+	}
+
+	for _, boardID := range boards {
+		if strings.TrimSpace(boardID) == "" {
+			continue
+		}
+
+		rows, err := syncVisibleCommentCountsForBoard(db, boardID)
+		if err != nil {
+			result.Errors++
+			result.ErrorBoards = append(result.ErrorBoards, boardID)
+			log.Printf("[Cron:sync-visible-comment-counts] board=%s error=%v", boardID, err)
+			continue
+		}
+		if rows > 0 {
+			result.BoardsSynced++
+			result.RowsUpdated += rows
+		}
+	}
+
+	return result, nil
+}
+
+func syncVisibleCommentCountsForBoard(db *gorm.DB, boardID string) (int64, error) {
+	table := fmt.Sprintf("g5_write_%s", boardID)
+	switch db.Dialector.Name() {
+	case "sqlite":
+		return syncVisibleCommentCountsForBoardSQLite(db, table)
+	default:
+		return syncVisibleCommentCountsForBoardMySQL(db, table)
+	}
+}
+
+func syncVisibleCommentCountsForBoardMySQL(db *gorm.DB, table string) (int64, error) {
+	query := fmt.Sprintf(`
+		UPDATE %[1]s AS p
+		LEFT JOIN (
+			SELECT wr_parent, COUNT(*) AS visible_count
+			FROM %[1]s
+			WHERE wr_is_comment = 1 AND wr_deleted_at IS NULL
+			GROUP BY wr_parent
+		) AS c ON c.wr_parent = p.wr_id
+		SET p.wr_comment = COALESCE(c.visible_count, 0)
+		WHERE p.wr_is_comment = 0
+		  AND COALESCE(p.wr_comment, 0) <> COALESCE(c.visible_count, 0)
+	`, table)
+	res := db.Exec(query)
+	return res.RowsAffected, res.Error
+}
+
+func syncVisibleCommentCountsForBoardSQLite(db *gorm.DB, table string) (int64, error) {
+	query := fmt.Sprintf(`
+		UPDATE %[1]s
+		SET wr_comment = (
+			SELECT COUNT(*)
+			FROM %[1]s AS c
+			WHERE c.wr_parent = %[1]s.wr_id
+			  AND c.wr_is_comment = 1
+			  AND c.wr_deleted_at IS NULL
+		)
+		WHERE wr_is_comment = 0
+		  AND COALESCE(wr_comment, 0) <> COALESCE((
+			SELECT COUNT(*)
+			FROM %[1]s AS c
+			WHERE c.wr_parent = %[1]s.wr_id
+			  AND c.wr_is_comment = 1
+			  AND c.wr_deleted_at IS NULL
+		), 0)
+	`, table)
+	res := db.Exec(query)
+	return res.RowsAffected, res.Error
+}

--- a/internal/cron/comment_counts_test.go
+++ b/internal/cron/comment_counts_test.go
@@ -1,0 +1,66 @@
+package cron
+
+import (
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRunSyncVisibleCommentCountsReconcilesPosts(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	if err := db.Exec(`CREATE TABLE g5_board (bo_table TEXT PRIMARY KEY)`).Error; err != nil {
+		t.Fatalf("create g5_board: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO g5_board (bo_table) VALUES ('free')`).Error; err != nil {
+		t.Fatalf("insert g5_board: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE g5_write_free (
+		wr_id INTEGER PRIMARY KEY,
+		wr_parent INTEGER NOT NULL DEFAULT 0,
+		wr_is_comment INTEGER NOT NULL DEFAULT 0,
+		wr_comment INTEGER NOT NULL DEFAULT 0,
+		wr_deleted_at DATETIME NULL
+	)`).Error; err != nil {
+		t.Fatalf("create g5_write_free: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO g5_write_free (wr_id, wr_parent, wr_is_comment, wr_comment, wr_deleted_at) VALUES
+		(1, 1, 0, 99, NULL),
+		(2, 2, 0, 3, NULL),
+		(11, 1, 1, 0, NULL),
+		(12, 1, 1, 0, NULL),
+		(13, 1, 1, 0, '2026-03-24 15:00:00')
+	`).Error; err != nil {
+		t.Fatalf("seed g5_write_free: %v", err)
+	}
+
+	result, err := runSyncVisibleCommentCounts(db)
+	if err != nil {
+		t.Fatalf("runSyncVisibleCommentCounts: %v", err)
+	}
+	if result.BoardsChecked != 1 {
+		t.Fatalf("expected 1 board checked, got %d", result.BoardsChecked)
+	}
+	if result.BoardsSynced != 1 {
+		t.Fatalf("expected 1 board synced, got %d", result.BoardsSynced)
+	}
+
+	var count1, count2 int
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 1").Scan(&count1).Error; err != nil {
+		t.Fatalf("query post 1: %v", err)
+	}
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 2").Scan(&count2).Error; err != nil {
+		t.Fatalf("query post 2: %v", err)
+	}
+	if count1 != 2 {
+		t.Fatalf("expected post 1 wr_comment=2, got %d", count1)
+	}
+	if count2 != 0 {
+		t.Fatalf("expected post 2 wr_comment=0, got %d", count2)
+	}
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -154,3 +154,21 @@ func (h *Handler) AutoPromote(c *gin.Context) {
 	log.Printf("[Cron:auto-promote] promoted %d members: %v", result.PromotedCount, result.PromotedIDs)
 	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
 }
+
+// SyncVisibleCommentCounts handles POST /api/internal/cron/sync-visible-comment-counts
+func (h *Handler) SyncVisibleCommentCounts(c *gin.Context) {
+	if !h.verifySecret(c) {
+		return
+	}
+
+	result, err := runSyncVisibleCommentCounts(h.db)
+	if err != nil {
+		log.Printf("[Cron:sync-visible-comment-counts] error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	log.Printf("[Cron:sync-visible-comment-counts] checked=%d synced=%d rows=%d errors=%d",
+		result.BoardsChecked, result.BoardsSynced, result.RowsUpdated, result.Errors)
+	c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
+}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -121,6 +121,14 @@ func tableName(boardID string) string {
 	return fmt.Sprintf("g5_write_%s", boardID)
 }
 
+func clampCommentDelta(delta int) interface{} {
+	return gorm.Expr(
+		"CASE WHEN COALESCE(wr_comment, 0) + ? < 0 THEN 0 ELSE COALESCE(wr_comment, 0) + ? END",
+		delta,
+		delta,
+	)
+}
+
 func visibleCommentCountExpr(_ string, alias string) string {
 	if alias != "" {
 		return alias + ".wr_comment AS wr_comment"
@@ -770,14 +778,47 @@ func (r *writeRepository) FindCommentByID(boardID string, wrID int) (*gnuboard.G
 
 // CreateComment creates a new comment
 func (r *writeRepository) CreateComment(boardID string, comment *gnuboard.G5Write) error {
-	return r.db.Table(tableName(boardID)).Create(comment).Error
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Table(tableName(boardID)).Create(comment).Error; err != nil {
+			return err
+		}
+		if comment.WrParent <= 0 || comment.WrIsComment != 1 || comment.WrDeletedAt != nil {
+			return nil
+		}
+		return tx.Table(tableName(boardID)).
+			Where("wr_id = ?", comment.WrParent).
+			Update("wr_comment", clampCommentDelta(1)).
+			Error
+	})
 }
 
 // DeleteComment permanently deletes a comment from the database
 func (r *writeRepository) DeleteComment(boardID string, wrID int) error {
-	return r.db.Table(tableName(boardID)).
-		Where("wr_id = ? AND wr_is_comment = 1", wrID).
-		Delete(&gnuboard.G5Write{}).Error
+	table := tableName(boardID)
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var comment struct {
+			WrParent    int        `gorm:"column:wr_parent"`
+			WrDeletedAt *time.Time `gorm:"column:wr_deleted_at"`
+		}
+		if err := tx.Table(table).
+			Select("wr_parent, wr_deleted_at").
+			Where("wr_id = ? AND wr_is_comment = 1", wrID).
+			Take(&comment).Error; err != nil {
+			return err
+		}
+		if err := tx.Table(table).
+			Where("wr_id = ? AND wr_is_comment = 1", wrID).
+			Delete(&gnuboard.G5Write{}).Error; err != nil {
+			return err
+		}
+		if comment.WrParent <= 0 || comment.WrDeletedAt != nil {
+			return nil
+		}
+		return tx.Table(table).
+			Where("wr_id = ?", comment.WrParent).
+			Update("wr_comment", clampCommentDelta(-1)).
+			Error
+	})
 }
 
 // SoftDeleteComment marks a comment as deleted
@@ -804,22 +845,67 @@ func (r *writeRepository) SoftDeleteComment(boardID string, wrID int, deletedBy 
 			boardID, wrID, comment.MbID, comment.WrName, deletedBy, now, string(prevData))
 	}
 
-	return r.db.Table(table).
-		Where("wr_id = ? AND wr_is_comment = 1", wrID).
-		Updates(map[string]interface{}{
-			"wr_deleted_at": now,
-			"wr_deleted_by": deletedBy,
-		}).Error
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var comment struct {
+			WrParent    int        `gorm:"column:wr_parent"`
+			WrDeletedAt *time.Time `gorm:"column:wr_deleted_at"`
+		}
+		if err := tx.Table(table).
+			Select("wr_parent, wr_deleted_at").
+			Where("wr_id = ? AND wr_is_comment = 1", wrID).
+			Take(&comment).Error; err != nil {
+			return err
+		}
+		result := tx.Table(table).
+			Where("wr_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", wrID).
+			Updates(map[string]interface{}{
+				"wr_deleted_at": now,
+				"wr_deleted_by": deletedBy,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 || comment.WrParent <= 0 || comment.WrDeletedAt != nil {
+			return nil
+		}
+		return tx.Table(table).
+			Where("wr_id = ?", comment.WrParent).
+			Update("wr_comment", clampCommentDelta(-1)).
+			Error
+	})
 }
 
 // RestoreComment restores a soft deleted comment
 func (r *writeRepository) RestoreComment(boardID string, wrID int) error {
-	return r.db.Table(tableName(boardID)).
-		Where("wr_id = ? AND wr_is_comment = 1", wrID).
-		Updates(map[string]interface{}{
-			"wr_deleted_at": nil,
-			"wr_deleted_by": nil,
-		}).Error
+	table := tableName(boardID)
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var comment struct {
+			WrParent    int        `gorm:"column:wr_parent"`
+			WrDeletedAt *time.Time `gorm:"column:wr_deleted_at"`
+		}
+		if err := tx.Table(table).
+			Select("wr_parent, wr_deleted_at").
+			Where("wr_id = ? AND wr_is_comment = 1", wrID).
+			Take(&comment).Error; err != nil {
+			return err
+		}
+		result := tx.Table(table).
+			Where("wr_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NOT NULL", wrID).
+			Updates(map[string]interface{}{
+				"wr_deleted_at": nil,
+				"wr_deleted_by": nil,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 || comment.WrParent <= 0 || comment.WrDeletedAt == nil {
+			return nil
+		}
+		return tx.Table(table).
+			Where("wr_id = ?", comment.WrParent).
+			Update("wr_comment", clampCommentDelta(1)).
+			Error
+	})
 }
 
 // CountCommentReplies counts the number of replies to a specific comment.

--- a/internal/repository/gnuboard/write_repo_comment_count_test.go
+++ b/internal/repository/gnuboard/write_repo_comment_count_test.go
@@ -1,0 +1,181 @@
+package gnuboard
+
+import (
+	"testing"
+	"time"
+
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestWriteRepositorySoftDeleteAndRestoreCommentAdjustsParentCount(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:wr_comment_delete_restore?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	if err := db.Exec(`CREATE TABLE g5_write_free (
+		wr_id INTEGER PRIMARY KEY,
+		wr_num INTEGER NOT NULL DEFAULT 0,
+		wr_reply TEXT NOT NULL DEFAULT '',
+		wr_parent INTEGER NOT NULL DEFAULT 0,
+		wr_is_comment INTEGER NOT NULL DEFAULT 0,
+		wr_comment INTEGER NOT NULL DEFAULT 0,
+		wr_comment_reply TEXT NOT NULL DEFAULT '',
+		ca_name TEXT,
+		wr_option TEXT,
+		wr_subject TEXT,
+		wr_content TEXT,
+		wr_link1 TEXT,
+		wr_link2 TEXT,
+		wr_link1_hit INTEGER NOT NULL DEFAULT 0,
+		wr_link2_hit INTEGER NOT NULL DEFAULT 0,
+		wr_hit INTEGER NOT NULL DEFAULT 0,
+		wr_good INTEGER NOT NULL DEFAULT 0,
+		wr_nogood INTEGER NOT NULL DEFAULT 0,
+		wr_name TEXT,
+		mb_id TEXT,
+		wr_password TEXT,
+		wr_email TEXT,
+		wr_homepage TEXT,
+		wr_datetime DATETIME,
+		wr_file INTEGER NOT NULL DEFAULT 0,
+		wr_last TEXT,
+		wr_ip TEXT,
+		wr_9 TEXT,
+		wr_10 TEXT,
+		wr_deleted_at DATETIME NULL,
+		wr_deleted_by TEXT NULL
+	)`).Error; err != nil {
+		t.Fatalf("create g5_write_free: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE g5_da_content_history (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		bo_table TEXT,
+		wr_id INTEGER,
+		wr_is_comment INTEGER,
+		mb_id TEXT,
+		wr_name TEXT,
+		operation TEXT,
+		operated_by TEXT,
+		operated_at DATETIME,
+		previous_data TEXT
+	)`).Error; err != nil {
+		t.Fatalf("create g5_da_content_history: %v", err)
+	}
+	if err := db.Exec(`
+		INSERT INTO g5_write_free (wr_id, wr_parent, wr_is_comment, wr_comment, wr_comment_reply, wr_content, wr_name, mb_id, wr_deleted_at, wr_deleted_by) VALUES
+		(1, 1, 0, 1, '', 'post', 'author', 'author', NULL, NULL),
+		(2, 1, 1, 0, '', 'comment', 'commenter', 'commenter', NULL, NULL)
+	`).Error; err != nil {
+		t.Fatalf("seed g5_write_free: %v", err)
+	}
+
+	repo := NewWriteRepository(db)
+	if err := repo.SoftDeleteComment("free", 2, "admin"); err != nil {
+		t.Fatalf("SoftDeleteComment: %v", err)
+	}
+
+	var postCount int
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 1").Scan(&postCount).Error; err != nil {
+		t.Fatalf("query post count after delete: %v", err)
+	}
+	if postCount != 0 {
+		t.Fatalf("expected post count 0 after delete, got %d", postCount)
+	}
+
+	if err := repo.SoftDeleteComment("free", 2, "admin"); err != nil {
+		t.Fatalf("SoftDeleteComment second call: %v", err)
+	}
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 1").Scan(&postCount).Error; err != nil {
+		t.Fatalf("query post count after second delete: %v", err)
+	}
+	if postCount != 0 {
+		t.Fatalf("expected post count to stay 0 after second delete, got %d", postCount)
+	}
+
+	if err := repo.RestoreComment("free", 2); err != nil {
+		t.Fatalf("RestoreComment: %v", err)
+	}
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 1").Scan(&postCount).Error; err != nil {
+		t.Fatalf("query post count after restore: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("expected post count 1 after restore, got %d", postCount)
+	}
+
+	comment, err := repo.FindCommentByID("free", 2)
+	if err != nil {
+		t.Fatalf("FindCommentByID: %v", err)
+	}
+	if comment.WrDeletedAt != nil || comment.WrDeletedBy != nil {
+		t.Fatalf("expected comment restored, got deleted_at=%v deleted_by=%v", comment.WrDeletedAt, comment.WrDeletedBy)
+	}
+}
+
+func TestWriteRepositoryCreateCommentAdjustsParentCount(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:wr_comment_create?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	if err := db.Exec(`CREATE TABLE g5_write_free (
+		wr_id INTEGER PRIMARY KEY,
+		wr_num INTEGER NOT NULL DEFAULT 0,
+		wr_reply TEXT NOT NULL DEFAULT '',
+		wr_parent INTEGER NOT NULL DEFAULT 0,
+		wr_is_comment INTEGER NOT NULL DEFAULT 0,
+		wr_comment INTEGER NOT NULL DEFAULT 0,
+		wr_comment_reply TEXT NOT NULL DEFAULT '',
+		ca_name TEXT,
+		wr_option TEXT,
+		wr_subject TEXT,
+		wr_content TEXT,
+		wr_link1 TEXT,
+		wr_link2 TEXT,
+		wr_link1_hit INTEGER NOT NULL DEFAULT 0,
+		wr_link2_hit INTEGER NOT NULL DEFAULT 0,
+		wr_hit INTEGER NOT NULL DEFAULT 0,
+		wr_good INTEGER NOT NULL DEFAULT 0,
+		wr_nogood INTEGER NOT NULL DEFAULT 0,
+		mb_id TEXT,
+		wr_password TEXT,
+		wr_name TEXT,
+		wr_email TEXT,
+		wr_homepage TEXT,
+		wr_datetime DATETIME,
+		wr_file INTEGER NOT NULL DEFAULT 0,
+		wr_last TEXT,
+		wr_ip TEXT,
+		wr_9 TEXT,
+		wr_10 TEXT,
+		wr_deleted_at DATETIME NULL,
+		wr_deleted_by TEXT NULL
+	)`).Error; err != nil {
+		t.Fatalf("create g5_write_free: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO g5_write_free (wr_id, wr_parent, wr_is_comment, wr_comment, wr_comment_reply, wr_datetime) VALUES (1, 1, 0, 0, '', CURRENT_TIMESTAMP)`).Error; err != nil {
+		t.Fatalf("seed post: %v", err)
+	}
+
+	repo := NewWriteRepository(db)
+	comment := &gnudomain.G5Write{
+		WrID:           2,
+		WrParent:       1,
+		WrIsComment:    1,
+		WrCommentReply: "",
+		WrDatetime:     time.Now(),
+	}
+	if err := repo.CreateComment("free", comment); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	var postCount int
+	if err := db.Table("g5_write_free").Select("wr_comment").Where("wr_id = 1").Scan(&postCount).Error; err != nil {
+		t.Fatalf("query post count: %v", err)
+	}
+	if postCount != 1 {
+		t.Fatalf("expected post count 1 after create, got %d", postCount)
+	}
+}

--- a/internal/worker/delete_worker.go
+++ b/internal/worker/delete_worker.go
@@ -83,13 +83,17 @@ func (w *DeleteWorker) processPending() {
 			}
 			if err := w.db.Transaction(func(tx *gorm.DB) error {
 				now := time.Now()
-				if err := tx.Table("g5_write_"+sd.BoTable).
-					Where("wr_id = ? AND wr_is_comment = 1", sd.WrID).
+				result := tx.Table("g5_write_"+sd.BoTable).
+					Where("wr_id = ? AND wr_is_comment = 1 AND wr_deleted_at IS NULL", sd.WrID).
 					Updates(map[string]interface{}{
 						"wr_deleted_at": now,
 						"wr_deleted_by": sd.RequestedBy,
-					}).Error; err != nil {
-					return err
+					})
+				if result.Error != nil {
+					return result.Error
+				}
+				if result.RowsAffected == 0 {
+					return nil
 				}
 				if err := tx.Table("g5_write_"+sd.BoTable).
 					Where("wr_id = ?", comment.WrParent).


### PR DESCRIPTION
## 변경
- 댓글 soft delete/restore를 상태 전이 기준으로만 wr_comment를 보정하도록 변경
- 지연 삭제 워커도 중복 차감이 없도록 조건부 삭제로 보정
- g5_board 전체를 순회해 visible 댓글 수로 wr_comment를 맞추는 internal cron 추가
- 댓글 수 보정 테스트와 크론 동기화 테스트 추가

## 검증
- go test ./...
- go build ./...