### PR TITLE
Sphinx 검색 관련성 정렬 및 author 와일드카드 적용

### DIFF
--- a/pkg/sphinx/sphinx.go
+++ b/pkg/sphinx/sphinx.go
@@ -76,7 +76,7 @@ func buildMatchExpr(searchField, searchQuery string) string {
 	case "title_content":
 		return fmt.Sprintf("@(wr_subject,wr_content) %s", wildcarded)
 	case "author":
-		return fmt.Sprintf("@(wr_name,mb_id) %s", escaped)
+		return fmt.Sprintf("@(wr_name,mb_id) %s", wildcarded)
 	default:
 		return fmt.Sprintf("@(wr_subject,wr_content) %s", wildcarded)
 	}
@@ -112,7 +112,7 @@ func (c *Client) Search(boardID, searchField, searchQuery string, page, limit in
 	offset := (page - 1) * limit
 
 	query := fmt.Sprintf(
-		"SELECT wr_id FROM %s WHERE MATCH('%s') AND wr_is_comment=0 ORDER BY wr_id DESC LIMIT %d, %d OPTION max_matches=10000",
+		"SELECT wr_id FROM %s WHERE MATCH('%s') AND wr_is_comment=0 ORDER BY WEIGHT() DESC, wr_id DESC LIMIT %d, %d OPTION max_matches=10000, ranker=sph04",
 		index, matchExpr, offset, limit,
 	)
 


### PR DESCRIPTION
## Summary
- 검색 결과를 `WEIGHT() DESC` (관련성 순)으로 정렬 (기존: `wr_id DESC` 최신순만)
- `ranker=sph04` BM25 기반 랭킹 적용
- author 검색에 와일드카드 적용 (부분 일치 지원)

## Test plan
- [ ] `go build ./...` 통과
- [ ] 검색 결과가 관련성 높은 순으로 나오는지 확인
- [ ] 작성자 검색 시 부분 일치 동작 확인