### PR TITLE
main push 시 canary만 배포, production은 workflow_dispatch full로

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Deploy mode. canary_only by default. full = canary + production.'
+        required: true
+        type: choice
+        default: canary_only
+        options:
+          - canary_only
+          - full
 
 env:
   REGISTRY: ghcr.io
@@ -307,6 +316,7 @@ jobs:
 
   deploy-production:
     needs: [build, deploy-canary, verify-canary]
+    if: always() && needs.verify-canary.result == 'success' && github.event_name == 'workflow_dispatch' && inputs.release_mode == 'full'
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
## Summary
프론트엔드(angple)와 동일한 배포 흐름으로 통일:
- `push to main` → canary만 자동 배포
- canary 확인 후 → `workflow_dispatch` + `release_mode: full` → production

## 운영 반영 방법
Actions → Deploy → Run workflow → release_mode: **full** 선택