### PR TITLE
최근 활동에서 삭제된 글/댓글 제외

### DIFF
--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -531,7 +531,8 @@ func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gn
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 1
-		    AND (is_public = 1 OR is_deleted = 1)
+		    AND is_public = 1
+		    AND is_deleted = 0
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,
@@ -578,7 +579,8 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 2
-		    AND (is_public = 1 OR is_deleted = 1)
+		    AND is_public = 1
+		    AND is_deleted = 0
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,


### PR DESCRIPTION
## Summary
#8951 삭제된 댓글이 최근 댓글에 보이는 현상

- `FindPublicCommentsByMember`: `is_deleted = 0` 조건 추가
- `FindPublicPostsByMember`: 동일하게 삭제된 글 제외
- 기존: `is_public = 1 OR is_deleted = 1` (삭제된 것도 포함)
- 변경: `is_public = 1 AND is_deleted = 0` (삭제된 것 제외)

## Test plan
- [ ] 작성자 활동 패널에서 삭제된 댓글 안 보임
- [ ] 정상 댓글은 기존과 동일하게 표시