### PR TITLE
최근 활동 삭제 표시 원복 (삭제된 항목 포함하되 표시)

### DIFF
--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -531,8 +531,7 @@ func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gn
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 1
-		    AND is_public = 1
-		    AND is_deleted = 0
+		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,
@@ -579,8 +578,7 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 2
-		    AND is_public = 1
-		    AND is_deleted = 0
+		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,


### PR DESCRIPTION
PR #356 원복. 삭제된 글/댓글을 제외하지 않고, 프론트에서 '삭제된 댓글입니다'로 표시.