### PR TITLE
리포트 크론 날짜 override + 작성자 ai 변경

### DIFF
--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
@@ -121,12 +122,24 @@ func (h *Handler) DisciplineRelease(c *gin.Context) {
 }
 
 // UpdateReportPattern handles POST /api/internal/cron/update-report-pattern
+// Optional query param: ?date=2026-03-22 to override reference date
 func (h *Handler) UpdateReportPattern(c *gin.Context) {
 	if !h.verifySecret(c) {
 		return
 	}
 
-	result, err := runUpdateReportPattern(h.db)
+	var result *ReportPatternResult
+	var err error
+	if dateStr := c.Query("date"); dateStr != "" {
+		t, parseErr := time.Parse("2006-01-02", dateStr)
+		if parseErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid date format, use YYYY-MM-DD"})
+			return
+		}
+		result, err = runUpdateReportPatternAt(h.db, t)
+	} else {
+		result, err = runUpdateReportPattern(h.db)
+	}
 	if err != nil {
 		log.Printf("[Cron:update-report-pattern] error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})

--- a/internal/cron/report_pattern.go
+++ b/internal/cron/report_pattern.go
@@ -78,7 +78,11 @@ const singoTypeCondition = "sg_type IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,1
 
 // runUpdateReportPattern generates a weekly report pattern analysis
 func runUpdateReportPattern(db *gorm.DB) (*ReportPatternResult, error) {
-	now := time.Now()
+	return runUpdateReportPatternAt(db, time.Now())
+}
+
+// runUpdateReportPatternAt generates a report using the given reference time
+func runUpdateReportPatternAt(db *gorm.DB, now time.Time) (*ReportPatternResult, error) {
 
 	// 지난 주 일요일~토요일 계산
 	startDate, endDate := getLastWeekRange(now)
@@ -507,9 +511,9 @@ func saveReportPost(db *gorm.DB, stats *reportStats, subject string, now time.Ti
 			wr_subject = ?,
 			wr_content = ?,
 			wr_9 = ?,
-			mb_id = 'admin',
+			mb_id = 'ai',
 			wr_password = '',
-			wr_name = '관리자',
+			wr_name = '다모앙',
 			wr_datetime = ?,
 			wr_last = ?,
 			wr_ip = '127.0.0.1'


### PR DESCRIPTION
## Summary
- `?date=2026-03-22` 파라미터로 특정 날짜 기준 리포트 생성
- 조기 실행/데이터 누락 시 수동 재생성 가능
- 작성자: admin → ai (다모앙)

## 배경
report/272가 3/17에 조기 실행되어 3/18~21 통계 누락.
날짜 override 없어서 지난 주 리포트 재생성 불가했음.

## 배포 후 실행
```bash
curl -X POST 'http://127.0.0.1:30081/api/internal/cron/update-report-pattern?secret=...&date=2026-03-22'
```

## Test plan
- [ ] `go build ./...` 통과
- [ ] `?date=2026-03-22` → 3/15~3/21 리포트 생성
- [ ] 날짜 없으면 기존처럼 이번 주 생성