### PR TITLE
삭제 예약 취소 후 재삭제 불가 수정

### DIFF
--- a/internal/repository/gnuboard/scheduled_delete_repo.go
+++ b/internal/repository/gnuboard/scheduled_delete_repo.go
@@ -34,6 +34,9 @@ func NewScheduledDeleteRepository(db *gorm.DB) ScheduledDeleteRepository {
 }
 
 func (r *scheduledDeleteRepository) Create(sd *gnuboard.ScheduledDelete) error {
+	// 이전 cancelled/executed 레코드가 있으면 삭제하여 UNIQUE KEY 충돌 방지
+	r.db.Where("bo_table = ? AND wr_id = ? AND status IN ('cancelled', 'executed')",
+		sd.BoTable, sd.WrID).Delete(&gnuboard.ScheduledDelete{})
 	return r.db.Create(sd).Error
 }
 


### PR DESCRIPTION
## Summary
- 삭제 예약 → 취소 → 재삭제 시 `UNIQUE KEY (bo_table, wr_id)` 충돌으로 실패
- `Create()` 시 기존 `cancelled`/`executed` 레코드를 먼저 DELETE하여 충돌 방지
- `pending` 레코드는 건드리지 않음 (기존 FindByPost 체크가 처리)

## 재현 사례
- `damoang.net/free/6018855` — 삭제 예약 취소 후 재삭제 불가 (메일 문의)
- `g5_scheduled_deletes` id=1199, status=cancelled 레코드가 남아 새 INSERT 차단

## Test plan
- [ ] `go build ./...` 통과
- [ ] cancelled 레코드 있는 글에서 재삭제 시도 → 성공
- [ ] 정상 삭제 → 취소 → 재삭제 전체 플로우 테스트