### PR TITLE
ci: golangci-lint와 reviewdog 분리

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,11 +25,14 @@ jobs:
       with:
         go-version: '1.25'
 
+    - name: Install golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+        golangci-lint version
+
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v9
-      with:
-        version: v2.11.2
-        args: --timeout=5m
+      run: |
+        time golangci-lint run --timeout=5m -v ./...
 
   golangci-lint:
     name: golangci-lint
@@ -47,11 +50,22 @@ jobs:
       with:
         go-version: '1.25'
 
+    - name: Install golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+        golangci-lint version
+
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v9
+      run: |
+        set -o pipefail
+        time golangci-lint run --timeout=5m -v ./... 2>&1 | tee golangci-lint.log
+
+    - name: Upload golangci-lint log
+      if: always()
+      uses: actions/upload-artifact@v4
       with:
-        version: v2.11.2
-        args: --timeout=5m
+        name: golangci-lint-log
+        path: golangci-lint.log
 
   golangci-reviewdog:
     name: golangci-lint reviewdog
@@ -80,7 +94,8 @@ jobs:
 
     - name: Run golangci-lint for reviewdog
       run: |
-        golangci-lint run --timeout=5m --out-format=line-number > golangci.log 2>&1 || true
+        set -o pipefail
+        golangci-lint run --timeout=5m -v --out-format=line-number ./... > golangci.log 2>&1 || true
 
     - name: Setup reviewdog
       if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,11 @@ jobs:
         version: v2.11.2
         args: --timeout=5m
 
-  golangci-reviewdog:
-    name: golangci-lint with reviewdog
+  golangci-lint:
+    name: golangci-lint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -51,7 +52,47 @@ jobs:
       with:
         version: v2.11.2
         args: --timeout=5m
-        only-new-issues: true
+
+  golangci-reviewdog:
+    name: golangci-lint reviewdog
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.25'
+
+    - name: Install golangci-lint
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.11.2
+        golangci-lint version
+
+    - name: Run golangci-lint for reviewdog
+      run: |
+        golangci-lint run --timeout=5m --out-format=line-number > golangci.log 2>&1 || true
+
+    - name: Setup reviewdog
+      if: always()
+      uses: reviewdog/action-setup@v1
+
+    - name: Report with reviewdog
+      if: always()
+      continue-on-error: true
+      env:
+        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cat golangci.log | reviewdog -f=golangci-lint -name="golangci-lint reviewdog" -reporter=github-pr-review -filter-mode=nofilter -fail-on-error=false
 
   format:
     name: Format Check

--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -47,6 +47,7 @@ type WriteRestrictionResult struct {
 type BoardWriteRestrictionService struct {
 	db                   *gorm.DB
 	extendedSettingsRepo v2repo.BoardExtendedSettingsRepository
+	advertiserPolicySvc  *AdvertiserBoardPolicyService
 }
 
 // NewBoardWriteRestrictionService creates a new BoardWriteRestrictionService.
@@ -55,6 +56,11 @@ func NewBoardWriteRestrictionService(db *gorm.DB, repo v2repo.BoardExtendedSetti
 		db:                   db,
 		extendedSettingsRepo: repo,
 	}
+}
+
+// SetAdvertiserPolicyService keeps compatibility with shadow-mode tests and callers.
+func (s *BoardWriteRestrictionService) SetAdvertiserPolicyService(svc *AdvertiserBoardPolicyService) {
+	s.advertiserPolicySvc = svc
 }
 
 // Check verifies whether the given member can write to the specified board.


### PR DESCRIPTION
backend PR lint hang을 진단 가능하게 만들기 위해 순수 lint와 reviewdog 코멘트 단계를 분리합니다.\n\n- 필수 체크: golangci-lint\n- 보조 체크: golangci-lint reviewdog\n- 두 job 모두 timeout 설정\n- reviewdog는 CLI 실행 결과 파일 기반으로 동작\n