### PR TITLE
자유게시판 목록 count 제거와 이벤트 경로 반영

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -766,8 +766,16 @@ func main() {
 		if redisClient != nil {
 			myPageHandler.SetRedisClient(redisClient)
 		}
+		anniversaryDrawRepo := gnurepo.NewAnniversaryDrawRepository(db)
+		anniversaryEventHandler := v2handler.NewAnniversaryEventHandler(
+			anniversaryDrawRepo,
+			gnuPointWriteRepo,
+			pointConfigRepo,
+			db,
+		)
 		v2routes.SetupMyPage(router, pointHandler, expHandler, myPageHandler, jwtManager)
 		v2routes.SetupMemberActivity(router, myPageHandler)
+		v2routes.SetupAnniversaryEvent(router, anniversaryEventHandler, jwtManager)
 
 		// Admin XP + Point config management routes
 		v2routes.SetupAdminXP(router, expHandler, jwtManager)
@@ -1752,12 +1760,22 @@ func main() {
 
 			var posts []*gnuboard.G5Write
 			var total int64
+			var hasNext bool
+			useHasNextPagination := !isSearching && !useCursor && (slug == "free" || slug == "hello")
 			if isSearching && category != "" {
 				posts, total, err = gnuWriteRepo.SearchPostsByCategory(slug, sfl, stx, category, page, limit)
 			} else if isSearching {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
 			} else if useCursor {
 				posts, total, err = gnuWriteRepo.FindPostsAfter(slug, limit, cursorWrNum, cursorWrReply)
+			} else if useHasNextPagination && category != "" && len(blockedIDs) > 0 {
+				posts, hasNext, err = gnuWriteRepo.FindPostsByCategoryFilteredHasNext(slug, category, page, limit, blockedIDs)
+			} else if useHasNextPagination && category != "" && len(blockedIDs) == 0 {
+				posts, hasNext, err = gnuWriteRepo.FindPostsByCategoryHasNext(slug, category, page, limit)
+			} else if useHasNextPagination && len(blockedIDs) > 0 {
+				posts, hasNext, err = gnuWriteRepo.FindPostsFilteredHasNext(slug, page, limit, blockedIDs)
+			} else if useHasNextPagination {
+				posts, hasNext, err = gnuWriteRepo.FindPostsHasNext(slug, page, limit)
 			} else if category != "" {
 				posts, total, err = gnuWriteRepo.FindPostsByCategory(slug, category, page, limit)
 			} else {
@@ -1814,7 +1832,12 @@ func main() {
 				}
 			}
 
-			meta := gin.H{"board_id": slug, "page": page, "limit": limit, "total": total}
+			meta := gin.H{"board_id": slug, "page": page, "limit": limit}
+			if useHasNextPagination {
+				meta["has_next"] = hasNext
+			} else {
+				meta["total"] = total
+			}
 			if useCursor && len(posts) > 0 {
 				last := posts[len(posts)-1]
 				meta["next_cursor_wr_num"] = last.WrNum

--- a/internal/domain/gnuboard/anniversary_draw.go
+++ b/internal/domain/gnuboard/anniversary_draw.go
@@ -1,0 +1,22 @@
+package gnuboard
+
+import "time"
+
+const AnniversaryEventCode2026 = "2026_2nd_anniversary"
+
+// AnniversaryDrawEntry stores one draw participation per member for the anniversary event.
+type AnniversaryDrawEntry struct {
+	ID          uint64     `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	EventCode   string     `gorm:"column:event_code" json:"event_code"`
+	MbID        string     `gorm:"column:mb_id" json:"mb_id"`
+	DrawResult  string     `gorm:"column:draw_result" json:"draw_result"`
+	PointAmount int        `gorm:"column:point_amount" json:"point_amount"`
+	GrantedAt   *time.Time `gorm:"column:granted_at" json:"granted_at,omitempty"`
+	PointPoID   *int       `gorm:"column:point_po_id" json:"point_po_id,omitempty"`
+	CreatedAt   time.Time  `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (AnniversaryDrawEntry) TableName() string {
+	return "event_anniversary_draw_entries"
+}

--- a/internal/handler/v2/advertiser_board_policy_handler.go
+++ b/internal/handler/v2/advertiser_board_policy_handler.go
@@ -1,0 +1,208 @@
+package v2
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/middleware"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// AdvertiserBoardPolicyHandler handles advertiser board policy endpoints.
+// This policy is rollout-safe by design: a persisted policy does not affect runtime
+// unless explicitly enabled, and current code uses shadow mode only.
+type AdvertiserBoardPolicyHandler struct {
+	boardRepo           v2repo.BoardRepository
+	policyRepo          v2repo.AdvertiserBoardPolicyRepository
+	writeRestrictionSvc *service.BoardWriteRestrictionService
+	gnuDB               *gorm.DB
+}
+
+func NewAdvertiserBoardPolicyHandler(
+	boardRepo v2repo.BoardRepository,
+	policyRepo v2repo.AdvertiserBoardPolicyRepository,
+	writeRestrictionSvc *service.BoardWriteRestrictionService,
+	gnuDB *gorm.DB,
+) *AdvertiserBoardPolicyHandler {
+	return &AdvertiserBoardPolicyHandler{
+		boardRepo:           boardRepo,
+		policyRepo:          policyRepo,
+		writeRestrictionSvc: writeRestrictionSvc,
+		gnuDB:               gnuDB,
+	}
+}
+
+func (h *AdvertiserBoardPolicyHandler) GetPolicy(c *gin.Context) {
+	slug := c.Param("slug")
+
+	if middleware.GetUserLevel(c) < 10 {
+		common.V2ErrorResponse(c, http.StatusForbidden, "관리자 권한이 필요합니다", nil)
+		return
+	}
+
+	if _, err := h.boardRepo.FindBySlug(slug); err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+
+	policy, err := h.policyRepo.FindByBoardSlug(slug)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "광고주 정책 조회 실패", err)
+		return
+	}
+
+	common.V2Success(c, policy)
+}
+
+func (h *AdvertiserBoardPolicyHandler) UpdatePolicy(c *gin.Context) {
+	slug := c.Param("slug")
+
+	if middleware.GetUserLevel(c) < 10 {
+		common.V2ErrorResponse(c, http.StatusForbidden, "관리자 권한이 필요합니다", nil)
+		return
+	}
+
+	if _, err := h.boardRepo.FindBySlug(slug); err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+
+	var req struct {
+		Enabled                      *bool   `json:"enabled"`
+		Mode                         *string `json:"mode"`
+		AllowActiveAdvertiserRead    *bool   `json:"allow_active_advertiser_read"`
+		AllowActiveAdvertiserWrite   *bool   `json:"allow_active_advertiser_write"`
+		AllowActiveAdvertiserComment *bool   `json:"allow_active_advertiser_comment"`
+		RequireCertification         *bool   `json:"require_certification"`
+		DailyPostLimit               *int    `json:"daily_post_limit"`
+		AllowedRoutesJSON            *string `json:"allowed_routes_json"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	policy, err := h.policyRepo.FindByBoardSlug(slug)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "광고주 정책 조회 실패", err)
+		return
+	}
+
+	if req.Enabled != nil {
+		policy.Enabled = *req.Enabled
+	}
+	if req.Mode != nil {
+		mode := strings.ToLower(strings.TrimSpace(*req.Mode))
+		if mode != "" && mode != "shadow" && mode != "enforce" {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "mode는 shadow 또는 enforce만 허용됩니다", nil)
+			return
+		}
+		if mode != "" {
+			policy.Mode = mode
+		}
+	}
+	if req.AllowActiveAdvertiserRead != nil {
+		policy.AllowActiveAdvertiserRead = *req.AllowActiveAdvertiserRead
+	}
+	if req.AllowActiveAdvertiserWrite != nil {
+		policy.AllowActiveAdvertiserWrite = *req.AllowActiveAdvertiserWrite
+	}
+	if req.AllowActiveAdvertiserComment != nil {
+		policy.AllowActiveAdvertiserComment = *req.AllowActiveAdvertiserComment
+	}
+	if req.RequireCertification != nil {
+		policy.RequireCertification = *req.RequireCertification
+	}
+	if req.DailyPostLimit != nil {
+		if *req.DailyPostLimit < 0 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "daily_post_limit은 0 이상이어야 합니다", nil)
+			return
+		}
+		policy.DailyPostLimit = *req.DailyPostLimit
+	}
+	if req.AllowedRoutesJSON != nil {
+		policy.AllowedRoutesJSON = req.AllowedRoutesJSON
+	}
+
+	if policy.Mode == "" {
+		policy.Mode = "shadow"
+	}
+	policy.BoardID = slug
+
+	if err := h.policyRepo.Upsert(policy); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "광고주 정책 저장 실패", err)
+		return
+	}
+
+	common.V2Success(c, policy)
+}
+
+func (h *AdvertiserBoardPolicyHandler) EvaluatePolicy(c *gin.Context) {
+	slug := c.Param("slug")
+
+	if middleware.GetUserLevel(c) < 10 {
+		common.V2ErrorResponse(c, http.StatusForbidden, "관리자 권한이 필요합니다", nil)
+		return
+	}
+
+	if _, err := h.boardRepo.FindBySlug(slug); err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "게시판을 찾을 수 없습니다", err)
+		return
+	}
+
+	memberID := strings.TrimSpace(c.Query("member_id"))
+	if memberID == "" {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "member_id가 필요합니다", nil)
+		return
+	}
+
+	memberLevel, err := h.lookupMemberLevel(memberID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "회원 레벨 조회 실패", err)
+		return
+	}
+
+	comparison, err := h.writeRestrictionSvc.CompareWithAdvertiserPolicy(slug, memberID, memberLevel)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "광고주 정책 dry-run 평가 실패", err)
+		return
+	}
+
+	common.V2Success(c, gin.H{
+		"board_id":     slug,
+		"member_id":    memberID,
+		"member_level": memberLevel,
+		"base":         comparison.Base,
+		"policy":       comparison.Policy,
+		"candidate":    comparison.Candidate,
+		"would_change": !writeRestrictionMatches(comparison.Base, comparison.Candidate),
+	})
+}
+
+func (h *AdvertiserBoardPolicyHandler) lookupMemberLevel(memberID string) (int, error) {
+	var row struct {
+		MbLevel int `gorm:"column:mb_level"`
+	}
+
+	if err := h.gnuDB.Table("g5_member").Select("mb_level").Where("mb_id = ?", memberID).Take(&row).Error; err != nil {
+		return 0, err
+	}
+	return row.MbLevel, nil
+}
+
+func writeRestrictionMatches(a, b *service.WriteRestrictionResult) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return a.CanWrite == b.CanWrite &&
+		a.Remaining == b.Remaining &&
+		a.DailyLimit == b.DailyLimit &&
+		a.TotalLimit == b.TotalLimit &&
+		a.TotalCount == b.TotalCount &&
+		a.Reason == b.Reason
+}

--- a/internal/handler/v2/anniversary_event_handler.go
+++ b/internal/handler/v2/anniversary_event_handler.go
@@ -1,0 +1,282 @@
+package v2
+
+import (
+	"crypto/rand"
+	"math/big"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"github.com/damoang/angple-backend/internal/middleware"
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+const anniversaryDrawRelTable = "@event-2026-2nd-anniversary"
+const anniversaryDrawRelAction = "@anniversary-draw"
+
+type anniversaryReward struct {
+	Result      string
+	PointAmount int
+	Weight      int64
+}
+
+var anniversaryRewards = []anniversaryReward{
+	{Result: "함께 만든 큰 울림", PointAmount: 100, Weight: 5},
+	{Result: "열린 참여의 기쁨", PointAmount: 50, Weight: 15},
+	{Result: "작은 목소리의 힘", PointAmount: 30, Weight: 30},
+	{Result: "따뜻한 연결", PointAmount: 10, Weight: 50},
+}
+
+type AnniversaryEventHandler struct {
+	repo            gnurepo.AnniversaryDrawRepository
+	pointWriteRepo  v2repo.GnuboardPointWriteRepository
+	pointConfigRepo v2repo.PointConfigRepository
+	db              *gorm.DB
+}
+
+func NewAnniversaryEventHandler(
+	repo gnurepo.AnniversaryDrawRepository,
+	pointWriteRepo v2repo.GnuboardPointWriteRepository,
+	pointConfigRepo v2repo.PointConfigRepository,
+	db *gorm.DB,
+) *AnniversaryEventHandler {
+	return &AnniversaryEventHandler{
+		repo:            repo,
+		pointWriteRepo:  pointWriteRepo,
+		pointConfigRepo: pointConfigRepo,
+		db:              db,
+	}
+}
+
+type anniversaryDrawResponse struct {
+	EventCode             string  `json:"event_code"`
+	Participated          bool    `json:"participated"`
+	AlreadyParticipated   bool    `json:"already_participated"`
+	DrawResult            string  `json:"draw_result,omitempty"`
+	PointAmount           int     `json:"point_amount,omitempty"`
+	DeferredGrantMessage  string  `json:"deferred_grant_message"`
+	GrantScheduledDateKST string  `json:"grant_scheduled_date_kst"`
+	GrantedAt             *string `json:"granted_at,omitempty"`
+	CreatedAt             *string `json:"created_at,omitempty"`
+}
+
+func (h *AnniversaryEventHandler) GetStatus(c *gin.Context) {
+	mbID := middleware.GetUserID(c)
+	if mbID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	entry, err := h.repo.GetByMember(gnudomain.AnniversaryEventCode2026, mbID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "이벤트 참여 조회에 실패했습니다", err)
+		return
+	}
+
+	common.V2Success(c, buildAnniversaryDrawResponse(entry, entry != nil))
+}
+
+func (h *AnniversaryEventHandler) Participate(c *gin.Context) {
+	mbID := middleware.GetUserID(c)
+	if mbID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	existing, err := h.repo.GetByMember(gnudomain.AnniversaryEventCode2026, mbID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "이벤트 참여 조회에 실패했습니다", err)
+		return
+	}
+	if existing != nil {
+		common.V2Success(c, buildAnniversaryDrawResponse(existing, true))
+		return
+	}
+
+	reward, err := pickAnniversaryReward()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "이벤트 결과 생성에 실패했습니다", err)
+		return
+	}
+
+	entry := &gnudomain.AnniversaryDrawEntry{
+		EventCode:   gnudomain.AnniversaryEventCode2026,
+		MbID:        mbID,
+		DrawResult:  reward.Result,
+		PointAmount: reward.PointAmount,
+	}
+	if err := h.repo.Create(entry); err != nil {
+		// Unique constraint race: load the existing row and return it.
+		existing, loadErr := h.repo.GetByMember(gnudomain.AnniversaryEventCode2026, mbID)
+		if loadErr == nil && existing != nil {
+			common.V2Success(c, buildAnniversaryDrawResponse(existing, true))
+			return
+		}
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "이벤트 참여 저장에 실패했습니다", err)
+		return
+	}
+
+	common.V2Success(c, buildAnniversaryDrawResponse(entry, false))
+}
+
+type anniversaryGrantRequest struct {
+	Limit int `json:"limit"`
+}
+
+func (h *AnniversaryEventHandler) AdminGrantPending(c *gin.Context) {
+	if h.pointWriteRepo == nil || h.pointConfigRepo == nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 지급 기능이 비활성화되어 있습니다", nil)
+		return
+	}
+
+	var req anniversaryGrantRequest
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청입니다", err)
+			return
+		}
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	pointConfig, err := h.pointConfigRepo.GetPointConfig()
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "포인트 설정 조회에 실패했습니다", err)
+		return
+	}
+
+	entries, err := h.repo.ListPending(gnudomain.AnniversaryEventCode2026, limit)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "미지급 이벤트 조회에 실패했습니다", err)
+		return
+	}
+
+	granted := 0
+	alreadyGranted := 0
+	failed := 0
+
+	for _, entry := range entries {
+		pointPoID, lookupErr := h.findExistingPointLog(entry.ID)
+		if lookupErr != nil {
+			failed++
+			continue
+		}
+		if pointPoID != 0 {
+			if err := h.repo.MarkGranted(entry.ID, pointPoID, time.Now()); err != nil {
+				failed++
+				continue
+			}
+			alreadyGranted++
+			continue
+		}
+
+		content := "다모앙 2주년 이벤트 포인트"
+		relID := strconv.FormatUint(entry.ID, 10)
+
+		if err := h.pointWriteRepo.AddPoint(
+			entry.MbID,
+			entry.PointAmount,
+			content,
+			anniversaryDrawRelTable,
+			relID,
+			anniversaryDrawRelAction,
+			pointConfig,
+		); err != nil {
+			failed++
+			continue
+		}
+
+		pointPoID, lookupErr = h.findExistingPointLog(entry.ID)
+		if lookupErr != nil || pointPoID == 0 {
+			failed++
+			continue
+		}
+		if err := h.repo.MarkGranted(entry.ID, pointPoID, time.Now()); err != nil {
+			failed++
+			continue
+		}
+		granted++
+	}
+
+	common.V2Success(c, gin.H{
+		"event_code":        gnudomain.AnniversaryEventCode2026,
+		"requested_limit":   limit,
+		"pending_fetched":   len(entries),
+		"granted":           granted,
+		"already_granted":   alreadyGranted,
+		"failed":            failed,
+		"grant_message_kst": "포인트는 KST 기준으로 순차 지급됩니다.",
+	})
+}
+
+func buildAnniversaryDrawResponse(entry *gnudomain.AnniversaryDrawEntry, alreadyParticipated bool) anniversaryDrawResponse {
+	resp := anniversaryDrawResponse{
+		EventCode:             gnudomain.AnniversaryEventCode2026,
+		Participated:          entry != nil,
+		AlreadyParticipated:   alreadyParticipated,
+		DeferredGrantMessage:  "포인트는 이벤트 종료 후 2026년 3월 31일 이후 순차 지급됩니다. Points will be granted after the event.",
+		GrantScheduledDateKST: "2026-03-31 KST",
+	}
+
+	if entry == nil {
+		return resp
+	}
+
+	resp.DrawResult = entry.DrawResult
+	resp.PointAmount = entry.PointAmount
+	createdAt := entry.CreatedAt.Format(time.RFC3339)
+	resp.CreatedAt = &createdAt
+	if entry.GrantedAt != nil {
+		grantedAt := entry.GrantedAt.Format(time.RFC3339)
+		resp.GrantedAt = &grantedAt
+	}
+	return resp
+}
+
+func pickAnniversaryReward() (anniversaryReward, error) {
+	var total int64
+	for _, reward := range anniversaryRewards {
+		total += reward.Weight
+	}
+
+	n, err := rand.Int(rand.Reader, big.NewInt(total))
+	if err != nil {
+		return anniversaryReward{}, err
+	}
+
+	cursor := n.Int64()
+	for _, reward := range anniversaryRewards {
+		if cursor < reward.Weight {
+			return reward, nil
+		}
+		cursor -= reward.Weight
+	}
+
+	return anniversaryRewards[len(anniversaryRewards)-1], nil
+}
+
+func (h *AnniversaryEventHandler) findExistingPointLog(entryID uint64) (int, error) {
+	var pointID int
+	err := h.db.Table("g5_point").
+		Select("po_id").
+		Where("po_rel_table = ? AND po_rel_id = ? AND po_rel_action = ?",
+			anniversaryDrawRelTable,
+			strconv.FormatUint(entryID, 10),
+			anniversaryDrawRelAction,
+		).
+		Order("po_id DESC").
+		Limit(1).
+		Scan(&pointID).Error
+	return pointID, err
+}

--- a/internal/migration/anniversary_draw.go
+++ b/internal/migration/anniversary_draw.go
@@ -1,0 +1,47 @@
+package migration
+
+import (
+	"fmt"
+	"log"
+
+	"gorm.io/gorm"
+)
+
+func CreateAnniversaryDrawEntriesTable(db *gorm.DB) error {
+	var count int64
+	db.Raw(`
+		SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_SCHEMA = DATABASE()
+		AND TABLE_NAME = 'event_anniversary_draw_entries'
+	`).Scan(&count)
+
+	if count > 0 {
+		log.Printf("[Migration] event_anniversary_draw_entries table already exists, skipping")
+		return nil
+	}
+
+	sql := `
+		CREATE TABLE event_anniversary_draw_entries (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			event_code VARCHAR(64) NOT NULL,
+			mb_id VARCHAR(64) NOT NULL,
+			draw_result VARCHAR(120) NOT NULL,
+			point_amount INT NOT NULL,
+			granted_at DATETIME NULL,
+			point_po_id INT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			UNIQUE KEY uk_event_member (event_code, mb_id),
+			KEY idx_event_granted (event_code, granted_at, id),
+			KEY idx_point_po_id (point_po_id)
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+	`
+
+	if err := db.Exec(sql).Error; err != nil {
+		return fmt.Errorf("failed to create event_anniversary_draw_entries table: %w", err)
+	}
+
+	log.Printf("[Migration] Created event_anniversary_draw_entries table")
+	return nil
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -38,6 +38,9 @@ func Run(db *gorm.DB) error {
 	if err := CreateAffiliateLinksTable(db); err != nil {
 		return err
 	}
+	if err := CreateAnniversaryDrawEntriesTable(db); err != nil {
+		return err
+	}
 	if err := FixListPageIndexes(db); err != nil {
 		return err
 	}

--- a/internal/repository/gnuboard/anniversary_draw_repo.go
+++ b/internal/repository/gnuboard/anniversary_draw_repo.go
@@ -1,0 +1,63 @@
+package gnuboard
+
+import (
+	"errors"
+	"time"
+
+	gnudomain "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+)
+
+type AnniversaryDrawRepository interface {
+	GetByMember(eventCode, mbID string) (*gnudomain.AnniversaryDrawEntry, error)
+	Create(entry *gnudomain.AnniversaryDrawEntry) error
+	ListPending(eventCode string, limit int) ([]gnudomain.AnniversaryDrawEntry, error)
+	MarkGranted(id uint64, pointPoID int, grantedAt time.Time) error
+}
+
+type anniversaryDrawRepository struct {
+	db *gorm.DB
+}
+
+func NewAnniversaryDrawRepository(db *gorm.DB) AnniversaryDrawRepository {
+	return &anniversaryDrawRepository{db: db}
+}
+
+func (r *anniversaryDrawRepository) GetByMember(eventCode, mbID string) (*gnudomain.AnniversaryDrawEntry, error) {
+	var entry gnudomain.AnniversaryDrawEntry
+	err := r.db.Where("event_code = ? AND mb_id = ?", eventCode, mbID).First(&entry).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func (r *anniversaryDrawRepository) Create(entry *gnudomain.AnniversaryDrawEntry) error {
+	return r.db.Create(entry).Error
+}
+
+func (r *anniversaryDrawRepository) ListPending(eventCode string, limit int) ([]gnudomain.AnniversaryDrawEntry, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+
+	var entries []gnudomain.AnniversaryDrawEntry
+	err := r.db.
+		Where("event_code = ? AND granted_at IS NULL", eventCode).
+		Order("id ASC").
+		Limit(limit).
+		Find(&entries).Error
+	return entries, err
+}
+
+func (r *anniversaryDrawRepository) MarkGranted(id uint64, pointPoID int, grantedAt time.Time) error {
+	return r.db.Model(&gnudomain.AnniversaryDrawEntry{}).
+		Where("id = ? AND granted_at IS NULL", id).
+		Updates(map[string]interface{}{
+			"granted_at":  grantedAt,
+			"point_po_id": pointPoID,
+		}).Error
+}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -66,6 +66,10 @@ type WriteRepository interface {
 	// Posts
 	FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	FindPostsByCategory(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, int64, error)
+	FindPostsHasNext(boardID string, page, limit int) ([]*gnuboard.G5Write, bool, error)
+	FindPostsByCategoryHasNext(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, bool, error)
+	FindPostsFilteredHasNext(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error)
+	FindPostsByCategoryFilteredHasNext(boardID string, category string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error)
 	FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsFiltered(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
 	SearchPosts(boardID string, searchField, searchQuery string, page, limit int) ([]*gnuboard.G5Write, int64, error)
@@ -210,6 +214,13 @@ func (r *writeRepository) getSortField(boardID string) string {
 // Beyond this offset, the deferred JOIN subquery still scans too many index rows.
 const maxPostOffset = 30000
 
+func trimHasNextPosts(posts []*gnuboard.G5Write, limit int) ([]*gnuboard.G5Write, bool) {
+	if len(posts) > limit {
+		return posts[:limit], true
+	}
+	return posts, false
+}
+
 // FindPosts retrieves posts (not comments) from a board with pagination.
 // Soft-deleted posts stay in the list so users can still trace their own activity.
 func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
@@ -270,6 +281,50 @@ func (r *writeRepository) FindPosts(boardID string, page, limit int) ([]*gnuboar
 	return posts, total, err
 }
 
+func (r *writeRepository) FindPostsHasNext(boardID string, page, limit int) ([]*gnuboard.G5Write, bool, error) {
+	var posts []*gnuboard.G5Write
+
+	offset := (page - 1) * limit
+	if offset > maxPostOffset {
+		offset = maxPostOffset
+	}
+	table := tableName(boardID)
+	orderClause := r.getSortField(boardID)
+	selectCols := postSelectColumns(boardID, "")
+	queryLimit := limit + 1
+
+	if orderClause == "wr_num, wr_reply" {
+		err := r.db.Raw(
+			fmt.Sprintf(
+				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
+				postSelectColumns(boardID, "t"), table, table,
+			),
+			queryLimit, offset,
+		).Scan(&posts).Error
+		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
+			err = r.db.Table(table).
+				Select(selectCols).
+				Where("wr_is_comment = 0").
+				Order(orderClause).
+				Offset(offset).
+				Limit(queryLimit).
+				Find(&posts).Error
+		}
+		trimmed, hasNext := trimHasNextPosts(posts, limit)
+		return trimmed, hasNext, err
+	}
+
+	err := r.db.Table(table).
+		Select(selectCols).
+		Where("wr_is_comment = 0").
+		Order(orderClause).
+		Offset(offset).
+		Limit(queryLimit).
+		Find(&posts).Error
+	trimmed, hasNext := trimHasNextPosts(posts, limit)
+	return trimmed, hasNext, err
+}
+
 // FindPostsByCategory retrieves posts filtered by ca_name (category) with pagination
 func (r *writeRepository) FindPostsByCategory(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, int64, error) {
 	var posts []*gnuboard.G5Write
@@ -280,8 +335,12 @@ func (r *writeRepository) FindPostsByCategory(boardID string, category string, p
 
 	baseWhere := "wr_is_comment = 0 AND ca_name = ?"
 
-	if err := r.db.Table(table).Where(baseWhere, category).Count(&total).Error; err != nil {
-		return nil, 0, err
+	total = r.getCachedPostCountByCategory(boardID, category)
+	if total == 0 {
+		if err := r.db.Table(table).Where(baseWhere, category).Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
+		r.setCachedPostCountByCategory(boardID, category, total)
 	}
 
 	orderClause := r.getSortField(boardID)
@@ -296,6 +355,31 @@ func (r *writeRepository) FindPostsByCategory(boardID string, category string, p
 		Find(&posts).Error
 
 	return posts, total, err
+}
+
+func (r *writeRepository) FindPostsByCategoryHasNext(boardID string, category string, page, limit int) ([]*gnuboard.G5Write, bool, error) {
+	var posts []*gnuboard.G5Write
+
+	offset := (page - 1) * limit
+	if offset > maxPostOffset {
+		offset = maxPostOffset
+	}
+	table := tableName(boardID)
+	baseWhere := "wr_is_comment = 0 AND ca_name = ?"
+	orderClause := r.getSortField(boardID)
+	selectCols := postSelectColumns(boardID, "")
+	queryLimit := limit + 1
+
+	err := r.db.Table(table).
+		Select(selectCols).
+		Where(baseWhere, category).
+		Order(orderClause).
+		Offset(offset).
+		Limit(queryLimit).
+		Find(&posts).Error
+
+	trimmed, hasNext := trimHasNextPosts(posts, limit)
+	return trimmed, hasNext, err
 }
 
 // FindPostsAfter retrieves posts using cursor pagination for the default gnuboard sort.
@@ -396,6 +480,80 @@ func (r *writeRepository) FindPostsFiltered(boardID string, page, limit int, exc
 		Find(&posts).Error
 
 	return posts, total, err
+}
+
+func (r *writeRepository) FindPostsFilteredHasNext(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error) {
+	if len(excludeMbIDs) == 0 {
+		return r.FindPostsHasNext(boardID, page, limit)
+	}
+
+	var posts []*gnuboard.G5Write
+	offset := (page - 1) * limit
+	if offset > maxPostOffset {
+		offset = maxPostOffset
+	}
+	table := tableName(boardID)
+	orderClause := r.getSortField(boardID)
+	selectCols := postSelectColumns(boardID, "")
+	queryLimit := limit + 1
+
+	if orderClause == "wr_num, wr_reply" {
+		err := r.db.Raw(
+			fmt.Sprintf(
+				"SELECT %s FROM `%s` t JOIN (SELECT wr_id FROM `%s` FORCE INDEX (idx_list_page) WHERE wr_is_comment = 0 AND mb_id NOT IN ? ORDER BY wr_num, wr_reply LIMIT ? OFFSET ?) ids ON t.wr_id = ids.wr_id ORDER BY t.wr_num, t.wr_reply",
+				postSelectColumns(boardID, "t"), table, table,
+			),
+			excludeMbIDs, queryLimit, offset,
+		).Scan(&posts).Error
+		if err != nil && strings.Contains(err.Error(), "idx_list_page") {
+			err = r.db.Table(table).
+				Select(selectCols).
+				Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
+				Order(orderClause).
+				Offset(offset).
+				Limit(queryLimit).
+				Find(&posts).Error
+		}
+		trimmed, hasNext := trimHasNextPosts(posts, limit)
+		return trimmed, hasNext, err
+	}
+
+	err := r.db.Table(table).
+		Select(selectCols).
+		Where("wr_is_comment = 0 AND mb_id NOT IN ?", excludeMbIDs).
+		Order(orderClause).
+		Offset(offset).
+		Limit(queryLimit).
+		Find(&posts).Error
+	trimmed, hasNext := trimHasNextPosts(posts, limit)
+	return trimmed, hasNext, err
+}
+
+func (r *writeRepository) FindPostsByCategoryFilteredHasNext(boardID string, category string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error) {
+	if len(excludeMbIDs) == 0 {
+		return r.FindPostsByCategoryHasNext(boardID, category, page, limit)
+	}
+
+	var posts []*gnuboard.G5Write
+	offset := (page - 1) * limit
+	if offset > maxPostOffset {
+		offset = maxPostOffset
+	}
+	table := tableName(boardID)
+	orderClause := r.getSortField(boardID)
+	selectCols := postSelectColumns(boardID, "")
+	queryLimit := limit + 1
+
+	err := r.db.Table(table).
+		Select(selectCols).
+		Where("wr_is_comment = 0 AND ca_name = ? AND mb_id NOT IN ?", category, excludeMbIDs).
+		Order(orderClause).
+		Offset(offset).
+		Limit(queryLimit).
+		Find(&posts).Error
+
+	trimmed, hasNext := trimHasNextPosts(posts, limit)
+	return trimmed, hasNext, err
 }
 
 // SearchPostsFiltered retrieves posts matching search criteria excluding specified members.
@@ -595,17 +753,36 @@ func (r *writeRepository) FindDeletedPosts(boardID string, page, limit int) ([]*
 }
 
 // postCountRedisKey returns the Redis key for post count cache
-func postCountRedisKey(boardID string) string {
-	return "postcount:" + boardID
+func postCountCacheKey(boardID string, category string) string {
+	if category == "" {
+		return boardID
+	}
+	return boardID + ":" + category
+}
+
+func postCountRedisKey(boardID string, category string) string {
+	return "postcount:" + postCountCacheKey(boardID, category)
+}
+
+func postCountRedisPrefix(boardID string) string {
+	return "postcount:" + boardID + ":"
+}
+
+func postCountMemoryKey(boardID string, category string) string {
+	return "count:" + postCountCacheKey(boardID, category)
 }
 
 // getCachedPostCount tries Redis first, then falls back to in-memory cache
 func (r *writeRepository) getCachedPostCount(boardID string) int64 {
+	return r.getCachedPostCountByCategory(boardID, "")
+}
+
+func (r *writeRepository) getCachedPostCountByCategory(boardID string, category string) int64 {
 	// Try Redis first (shared across all pods)
 	if r.redis != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		val, err := r.redis.Get(ctx, postCountRedisKey(boardID)).Result()
+		val, err := r.redis.Get(ctx, postCountRedisKey(boardID, category)).Result()
 		if err == nil {
 			if count, err := strconv.ParseInt(val, 10, 64); err == nil {
 				return count
@@ -614,7 +791,7 @@ func (r *writeRepository) getCachedPostCount(boardID string) int64 {
 	}
 
 	// Fallback to in-memory cache
-	cacheKey := "count:" + boardID
+	cacheKey := postCountMemoryKey(boardID, category)
 	if cached, ok := postCountCache.Load(cacheKey); ok {
 		if cc, ok2 := cached.(*cachedCount); ok2 && time.Now().Before(cc.expiresAt) {
 			return cc.total
@@ -625,17 +802,24 @@ func (r *writeRepository) getCachedPostCount(boardID string) int64 {
 
 // setCachedPostCount stores count in both Redis (shared) and in-memory (local fallback)
 func (r *writeRepository) setCachedPostCount(boardID string, total int64) {
+	r.setCachedPostCountByCategory(boardID, "", total)
+}
+
+func (r *writeRepository) setCachedPostCountByCategory(boardID string, category string, total int64) {
 	ttl := countCacheTTLForBoard(boardID)
 
 	// Store in Redis (shared across pods)
 	if r.redis != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		r.redis.Set(ctx, postCountRedisKey(boardID), total, ttl)
+		r.redis.Set(ctx, postCountRedisKey(boardID, category), total, ttl)
 	}
 
 	// Also store in local memory as fallback
-	postCountCache.Store("count:"+boardID, &cachedCount{total: total, expiresAt: time.Now().Add(ttl)})
+	postCountCache.Store(
+		postCountMemoryKey(boardID, category),
+		&cachedCount{total: total, expiresAt: time.Now().Add(ttl)},
+	)
 }
 
 // invalidatePostCount clears the cached post count for a board from both Redis and memory
@@ -644,16 +828,48 @@ func (r *writeRepository) invalidatePostCount(boardID string) {
 	if r.redis != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		r.redis.Del(ctx, postCountRedisKey(boardID))
+		r.redis.Del(ctx, postCountRedisKey(boardID, ""))
+
+		var cursor uint64
+		prefix := postCountRedisPrefix(boardID)
+		for {
+			keys, nextCursor, err := r.redis.Scan(ctx, cursor, prefix+"*", 100).Result()
+			if err != nil {
+				break
+			}
+			if len(keys) > 0 {
+				r.redis.Del(ctx, keys...)
+			}
+			cursor = nextCursor
+			if cursor == 0 {
+				break
+			}
+		}
 	}
 
 	// Invalidate in-memory
-	postCountCache.Delete("count:" + boardID)
+	postCountCache.Delete(postCountMemoryKey(boardID, ""))
+	prefix := postCountMemoryKey(boardID, "") + ":"
+	postCountCache.Range(func(key, _ any) bool {
+		keyStr, ok := key.(string)
+		if ok && strings.HasPrefix(keyStr, prefix) {
+			postCountCache.Delete(keyStr)
+		}
+		return true
+	})
 }
 
 // InvalidatePostCount clears the cached post count from in-memory cache (legacy, no Redis)
 func InvalidatePostCount(boardID string) {
-	postCountCache.Delete("count:" + boardID)
+	postCountCache.Delete(postCountMemoryKey(boardID, ""))
+	prefix := postCountMemoryKey(boardID, "") + ":"
+	postCountCache.Range(func(key, _ any) bool {
+		keyStr, ok := key.(string)
+		if ok && strings.HasPrefix(keyStr, prefix) {
+			postCountCache.Delete(keyStr)
+		}
+		return true
+	})
 }
 
 // CreatePost creates a new post

--- a/internal/repository/v2/advertiser_board_policy_repo.go
+++ b/internal/repository/v2/advertiser_board_policy_repo.go
@@ -1,0 +1,47 @@
+package v2
+
+import (
+	"errors"
+
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// AdvertiserBoardPolicyRepository handles advertiser board policy data access.
+type AdvertiserBoardPolicyRepository interface {
+	FindByBoardSlug(slug string) (*v2.V2AdvertiserBoardPolicy, error)
+	Upsert(policy *v2.V2AdvertiserBoardPolicy) error
+}
+
+type advertiserBoardPolicyRepository struct {
+	db *gorm.DB
+}
+
+func NewAdvertiserBoardPolicyRepository(db *gorm.DB) AdvertiserBoardPolicyRepository {
+	return &advertiserBoardPolicyRepository{db: db}
+}
+
+func (r *advertiserBoardPolicyRepository) FindByBoardSlug(slug string) (*v2.V2AdvertiserBoardPolicy, error) {
+	var policy v2.V2AdvertiserBoardPolicy
+	err := r.db.Where("board_id = ?", slug).First(&policy).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return &v2.V2AdvertiserBoardPolicy{
+			BoardID: slug,
+			Mode:    "shadow",
+			Enabled: false,
+		}, nil
+	}
+	return &policy, err
+}
+
+func (r *advertiserBoardPolicyRepository) Upsert(policy *v2.V2AdvertiserBoardPolicy) error {
+	var existing v2.V2AdvertiserBoardPolicy
+	err := r.db.Where("board_id = ?", policy.BoardID).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return r.db.Create(policy).Error
+	} else if err != nil {
+		return err
+	}
+
+	return r.db.Save(policy).Error
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -222,6 +222,19 @@ func SetupMyPage(router *gin.Engine, pointHandler *v2handler.PointHandler, expHa
 	my.GET("/stats", myPageHandler.GetBoardStats)
 }
 
+// SetupAnniversaryEvent configures anniversary event routes.
+func SetupAnniversaryEvent(router *gin.Engine, h *v2handler.AnniversaryEventHandler, jwtManager *jwt.Manager) {
+	auth := middleware.JWTAuth(jwtManager)
+
+	events := router.Group("/api/v1/events", auth)
+	events.GET("/anniversary-draw", h.GetStatus)
+	events.POST("/anniversary-draw", h.Participate)
+
+	admin := router.Group("/api/v1/admin/events")
+	admin.Use(auth, middleware.RequireAdmin())
+	admin.POST("/anniversary-draw/grant", h.AdminGrantPending)
+}
+
 // SetupMemberActivity configures public member activity route
 func SetupMemberActivity(router *gin.Engine, myPageHandler *handler.MyPageHandler) {
 	router.GET("/api/v1/members/:id/activity", myPageHandler.GetMemberActivity)

--- a/internal/service/advertiser_board_policy.go
+++ b/internal/service/advertiser_board_policy.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"gorm.io/gorm"
+)
+
+const AdvertiserPolicyModeShadow = "shadow"
+
+type advertiserPromotionRow struct {
+	PermissionGroup string `gorm:"column:permission_group"`
+}
+
+// AdvertiserBoardPolicyService evaluates board-specific advertiser policy.
+// The service is designed to be safe-by-default:
+// - no policy row => no effect
+// - disabled policy => no effect
+// - current rollout uses shadow mode only
+type AdvertiserBoardPolicyService struct {
+	db   *gorm.DB
+	repo v2repo.AdvertiserBoardPolicyRepository
+}
+
+func NewAdvertiserBoardPolicyService(db *gorm.DB, repo v2repo.AdvertiserBoardPolicyRepository) *AdvertiserBoardPolicyService {
+	return &AdvertiserBoardPolicyService{db: db, repo: repo}
+}
+
+func (s *AdvertiserBoardPolicyService) EvaluateWrite(boardSlug, memberID string) (*v2domain.V2AdvertiserBoardPolicy, *WriteRestrictionResult, error) {
+	policy, err := s.repo.FindByBoardSlug(boardSlug)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load advertiser board policy: %w", err)
+	}
+
+	if policy == nil || !policy.Enabled {
+		return policy, nil, nil
+	}
+
+	if !policy.AllowActiveAdvertiserWrite {
+		return policy, &WriteRestrictionResult{
+			CanWrite: false,
+			Reason:   "광고주 정책상 글쓰기가 허용되지 않습니다.",
+		}, nil
+	}
+
+	promotion, err := s.findActivePromotion(memberID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load active promotion: %w", err)
+	}
+	if promotion == nil {
+		return policy, &WriteRestrictionResult{
+			CanWrite: false,
+			Reason:   "활성 광고주만 글을 작성할 수 있습니다.",
+		}, nil
+	}
+
+	dailyLimit := policy.DailyPostLimit
+	if dailyLimit <= 0 {
+		dailyLimit = permissionGroupDailyLimit(promotion.PermissionGroup)
+	}
+
+	if dailyLimit <= 0 {
+		return policy, &WriteRestrictionResult{CanWrite: true, Remaining: -1, DailyLimit: 0}, nil
+	}
+
+	todayCount, err := countTodayPostsForBoard(s.db, boardSlug, memberID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("count advertiser daily posts: %w", err)
+	}
+
+	if todayCount >= dailyLimit {
+		return policy, &WriteRestrictionResult{
+			CanWrite:   false,
+			Remaining:  0,
+			DailyLimit: dailyLimit,
+			Reason:     fmt.Sprintf("오늘 %d개까지 작성 가능합니다. (이미 %d개 작성)", dailyLimit, todayCount),
+		}, nil
+	}
+
+	return policy, &WriteRestrictionResult{
+		CanWrite:   true,
+		Remaining:  dailyLimit - todayCount,
+		DailyLimit: dailyLimit,
+	}, nil
+}
+
+func (s *AdvertiserBoardPolicyService) findActivePromotion(memberID string) (*advertiserPromotionRow, error) {
+	if memberID == "" {
+		return nil, nil
+	}
+
+	kst := time.FixedZone("KST", 9*60*60)
+	today := time.Now().In(kst).Format("2006-01-02")
+
+	var row advertiserPromotionRow
+	err := s.db.Table("promotions").
+		Select("permission_group").
+		Where("member_id = ? AND is_active = ? AND start_date <= ? AND end_date >= ?", memberID, true, today, today).
+		Limit(1).
+		Take(&row).Error
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func permissionGroupDailyLimit(group string) int {
+	switch strings.ToLower(strings.TrimSpace(group)) {
+	case "three":
+		return 3
+	case "two":
+		return 2
+	case "one", "":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func countTodayPostsForBoard(db *gorm.DB, boardSlug, memberID string) (int, error) {
+	tableName := fmt.Sprintf("g5_write_%s", boardSlug)
+	kst := time.FixedZone("KST", 9*60*60)
+	today := time.Now().In(kst).Format("2006-01-02")
+
+	var count int64
+	err := db.Table(tableName).
+		Where("mb_id = ? AND DATE(wr_datetime) = ? AND wr_is_comment = 0 AND (wr_deleted_at IS NULL OR wr_deleted_at = '0000-00-00 00:00:00')", memberID, today).
+		Count(&count).Error
+	if err != nil {
+		return 0, err
+	}
+	return int(count), nil
+}

--- a/internal/service/board_write_restriction_test.go
+++ b/internal/service/board_write_restriction_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestBoardWriteRestrictionShadowPolicyDoesNotOverrideBaseDecision(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	if err := db.AutoMigrate(&v2domain.V2BoardExtendedSettings{}, &v2domain.V2AdvertiserBoardPolicy{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+
+	if err := db.Exec(`
+		CREATE TABLE promotions (
+			member_id TEXT,
+			is_active BOOLEAN,
+			start_date TEXT,
+			end_date TEXT,
+			permission_group TEXT
+		)
+	`).Error; err != nil {
+		t.Fatalf("create promotions: %v", err)
+	}
+
+	if err := db.Exec(`
+		CREATE TABLE g5_write_promotion (
+			mb_id TEXT,
+			wr_datetime DATETIME,
+			wr_is_comment INTEGER,
+			wr_deleted_at DATETIME
+		)
+	`).Error; err != nil {
+		t.Fatalf("create g5_write_promotion: %v", err)
+	}
+
+	settingsRepo := v2repo.NewBoardExtendedSettingsRepository(db)
+	if err := settingsRepo.Upsert(&v2domain.V2BoardExtendedSettings{
+		BoardID:  "promotion",
+		Settings: `{"writing":{"restrictedUsers":true,"allowedMembersOne":"legacy-only"}}`,
+	}); err != nil {
+		t.Fatalf("seed settings: %v", err)
+	}
+
+	policyRepo := v2repo.NewAdvertiserBoardPolicyRepository(db)
+	if err := policyRepo.Upsert(&v2domain.V2AdvertiserBoardPolicy{
+		BoardID:                    "promotion",
+		Enabled:                    true,
+		Mode:                       AdvertiserPolicyModeShadow,
+		AllowActiveAdvertiserWrite: true,
+	}); err != nil {
+		t.Fatalf("seed policy: %v", err)
+	}
+
+	today := time.Now().Format("2006-01-02")
+	if err := db.Exec(`
+		INSERT INTO promotions (member_id, is_active, start_date, end_date, permission_group)
+		VALUES (?, 1, ?, ?, 'one')
+	`, "ad-1", today, today).Error; err != nil {
+		t.Fatalf("seed promotion: %v", err)
+	}
+
+	svc := NewBoardWriteRestrictionService(db, settingsRepo)
+	svc.SetAdvertiserPolicyService(NewAdvertiserBoardPolicyService(db, policyRepo))
+
+	got, err := svc.Check("promotion", "ad-1", 5)
+	if err != nil {
+		t.Fatalf("check restriction: %v", err)
+	}
+
+	if got.CanWrite {
+		t.Fatalf("expected base restriction to remain denied in shadow mode")
+	}
+	if got.Reason != "허용된 회원만 글을 작성할 수 있습니다." {
+		t.Fatalf("unexpected reason: %s", got.Reason)
+	}
+}


### PR DESCRIPTION
## 요약
- free/hello 목록에 hasNext 기반 조회 추가
- category/blocked 조합도 count 없이 limit+1 조회 적용
- 2주년 이벤트 및 정책 경로 포함한 현재 빌드 가능 상태 반영

## 검증
- go test ./internal/repository/gnuboard/...
- go build ./...
- go build ./cmd/api