### PR TITLE
내글 조회에서 is_public 필터 제거

### DIFF
--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -531,7 +531,6 @@ func (r *myPageRepository) FindPublicPostsByMember(mbID string, limit int) ([]gn
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 1
-		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,
@@ -578,7 +577,6 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 		   FROM member_activity_feed
 		  WHERE member_id = ?
 		    AND activity_type = 2
-		    AND (is_public = 1 OR is_deleted = 1)
 		  ORDER BY source_created_at DESC, id DESC
 		  LIMIT ?`,
 		mbID, limit,


### PR DESCRIPTION
## Summary
- #8878 '내글'에 검색 비활성화 게시판 글이 안 보이는 버그 수정
- `member_activity_feed` 조회 시 `is_public=1` 조건 제거
- 본인 글/댓글은 게시판 검색 설정과 무관하게 모두 표시

## Test plan
- [ ] `go build ./...` 통과
- [ ] '내글'에서 모든 게시판의 본인 글 표시 확인