### PR TITLE
golangci-lint 타임아웃 10분으로 확대

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 version: "2"
 run:
+  timeout: 10m
   tests: true
 output:
   formats:


### PR DESCRIPTION
## Summary
- 프로젝트 규모 증가로 golangci-lint 기본 5분 타임아웃 초과
- CI에서 `The operation was canceled` 에러 발생 (메모리 avg 2.5GB, max 3.1GB)
- `.golangci.yml`에 `timeout: 10m` 추가

## Test plan
- [ ] CI golangci-lint 정상 완료 확인