### PR TITLE
go vet 에러 수정: SetAdvertiserPolicyService 추가

### DIFF
--- a/internal/service/board_write_restriction.go
+++ b/internal/service/board_write_restriction.go
@@ -47,6 +47,12 @@ type WriteRestrictionResult struct {
 type BoardWriteRestrictionService struct {
 	db                   *gorm.DB
 	extendedSettingsRepo v2repo.BoardExtendedSettingsRepository
+	advertiserPolicySvc  *AdvertiserBoardPolicyService
+}
+
+// SetAdvertiserPolicyService sets the advertiser policy service for shadow-mode comparison.
+func (s *BoardWriteRestrictionService) SetAdvertiserPolicyService(svc *AdvertiserBoardPolicyService) {
+	s.advertiserPolicySvc = svc
 }
 
 // NewBoardWriteRestrictionService creates a new BoardWriteRestrictionService.


### PR DESCRIPTION
## Summary
- `board_write_restriction_test.go:73`에서 호출하는 `SetAdvertiserPolicyService` 미정의 → go vet 실패
- 구조체에 `advertiserPolicySvc` 필드 + setter 메서드 추가
- CI 2시간째 반복 실패하던 go vet 에러 해소

## Test plan
- [ ] `go vet` 통과
- [ ] `go build ./...` 통과