### PR TITLE
admin 회원 관리 API (g5_member 기반 + 익명화)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1333,9 +1333,18 @@ func main() {
 			c.JSON(http.StatusOK, gin.H{"success": true, "data": result})
 		})
 
-		// Admin member memo CRUD
+		// Admin member management + memo CRUD
+		adminMemberHandler := handler.NewAdminMemberHandler(db)
 		adminMemoGroup := router.Group("/api/v1/admin/members")
 		adminMemoGroup.Use(middleware.JWTAuth(jwtManager), middleware.RequireAdmin())
+
+		// Member CRUD
+		adminMemoGroup.GET("", adminMemberHandler.ListMembers)
+		adminMemoGroup.GET("/:mbId", adminMemberHandler.GetMember)
+		adminMemoGroup.PUT("/:mbId", adminMemberHandler.UpdateMember)
+		adminMemoGroup.POST("/:mbId/ban", adminMemberHandler.BanMember)
+		adminMemoGroup.POST("/:mbId/unban", adminMemberHandler.UnbanMember)
+		adminMemoGroup.POST("/bulk/level", adminMemberHandler.BulkUpdateLevel)
 
 		// GET /api/v1/admin/members/:mbId/memos — 특정 회원에 대한 메모 목록
 		adminMemoGroup.GET("/:mbId/memos", func(c *gin.Context) {
@@ -4591,7 +4600,7 @@ func main() {
 		})
 
 		// v2 Admin
-		v2AdminSvc := v2svc.NewAdminService(v2UserRepo, v2BoardRepo, v2PostRepo, v2CommentRepo)
+		v2AdminSvc := v2svc.NewAdminService(db, v2UserRepo, v2BoardRepo, v2PostRepo, v2CommentRepo, gnuMemberRepo)
 		v2AdminHandler := v2handler.NewAdminHandler(v2AdminSvc)
 		v2routes.SetupAdmin(router, v2AdminHandler, jwtManager)
 

--- a/internal/handler/admin_member_handler.go
+++ b/internal/handler/admin_member_handler.go
@@ -161,7 +161,7 @@ func (h *AdminMemberHandler) ListMembers(c *gin.Context) {
 	if !ok {
 		col = "mb_datetime"
 	}
-	query = query.Order(fmt.Sprintf("%s %s", col, sortOrder))
+	query = query.Order(fmt.Sprintf("%s %s", col, sortOrder)) // #nosec G201 -- col and sortOrder are from allowedSortColumns whitelist, not user input
 
 	// 조회
 	offset := (page - 1) * limit

--- a/internal/handler/admin_member_handler.go
+++ b/internal/handler/admin_member_handler.go
@@ -1,0 +1,275 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/common"
+	gnuboard "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// AdminMemberHandler handles admin member management (g5_member based)
+type AdminMemberHandler struct {
+	db *gorm.DB
+}
+
+// NewAdminMemberHandler creates a new AdminMemberHandler
+func NewAdminMemberHandler(db *gorm.DB) *AdminMemberHandler {
+	return &AdminMemberHandler{db: db}
+}
+
+// adminMemberResponse is the response DTO matching frontend AdminMember type
+type adminMemberResponse struct {
+	MbID            string  `json:"mb_id"`
+	MbName          string  `json:"mb_name"`
+	MbEmail         string  `json:"mb_email"`
+	MbLevel         int     `json:"mb_level"`
+	MbPoint         int     `json:"mb_point"`
+	MbDatetime      string  `json:"mb_datetime"`
+	MbTodayLogin    *string `json:"mb_today_login"`
+	MbImage         *string `json:"mb_image,omitempty"`
+	MbLeaveDate     *string `json:"mb_leave_date,omitempty"`
+	MbInterceptDate *string `json:"mb_intercept_date,omitempty"`
+}
+
+func toAdminMemberResponse(m *gnuboard.G5Member) adminMemberResponse {
+	resp := adminMemberResponse{
+		MbID:       m.MbID,
+		MbName:     m.MbNick,
+		MbEmail:    m.MbEmail,
+		MbLevel:    m.MbLevel,
+		MbPoint:    m.MbPoint,
+		MbDatetime: m.MbDatetime.Format(time.RFC3339),
+	}
+	if m.MbTodayLogin != "" && m.MbTodayLogin != "0000-00-00" {
+		resp.MbTodayLogin = &m.MbTodayLogin
+	}
+	if m.MbLeaveDate != "" {
+		resp.MbLeaveDate = &m.MbLeaveDate
+	}
+	if m.MbInterceptDate != "" {
+		resp.MbInterceptDate = &m.MbInterceptDate
+	}
+	if m.MbImagePath != "" {
+		resp.MbImage = &m.MbImagePath
+	}
+	return resp
+}
+
+// allowedSortColumns maps sort_by param to g5_member columns
+var allowedSortColumns = map[string]string{
+	"datetime": "mb_datetime",
+	"name":     "mb_nick",
+	"level":    "mb_level",
+	"point":    "mb_point",
+	"login":    "mb_today_login",
+}
+
+// ListMembers handles GET /api/v1/admin/members
+func (h *AdminMemberHandler) ListMembers(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+
+	query := h.db.Model(&gnuboard.G5Member{})
+
+	// 검색
+	search := c.Query("search")
+	searchField := c.DefaultQuery("search_field", "name")
+	if search != "" {
+		like := "%" + search + "%"
+		switch searchField {
+		case "email":
+			query = query.Where("mb_email LIKE ?", like)
+		case "id":
+			query = query.Where("mb_id LIKE ?", like)
+		default: // name
+			query = query.Where("mb_nick LIKE ?", like)
+		}
+	}
+
+	// 레벨 필터
+	if levelStr := c.Query("level"); levelStr != "" {
+		if level, err := strconv.Atoi(levelStr); err == nil {
+			query = query.Where("mb_level = ?", level)
+		}
+	}
+
+	// 상태 필터
+	status := c.Query("status")
+	switch status {
+	case "banned":
+		query = query.Where("mb_intercept_date != ''")
+	case "left":
+		query = query.Where("mb_leave_date != ''")
+	case "active":
+		query = query.Where("mb_intercept_date = '' AND mb_leave_date = ''")
+	}
+
+	// 가입일 범위
+	if dateFrom := c.Query("date_from"); dateFrom != "" {
+		query = query.Where("mb_datetime >= ?", dateFrom)
+	}
+	if dateTo := c.Query("date_to"); dateTo != "" {
+		query = query.Where("mb_datetime <= ?", dateTo+" 23:59:59")
+	}
+
+	// 포인트 범위
+	if pointMin := c.Query("point_min"); pointMin != "" {
+		if v, err := strconv.Atoi(pointMin); err == nil {
+			query = query.Where("mb_point >= ?", v)
+		}
+	}
+	if pointMax := c.Query("point_max"); pointMax != "" {
+		if v, err := strconv.Atoi(pointMax); err == nil {
+			query = query.Where("mb_point <= ?", v)
+		}
+	}
+
+	// 최근 로그인 범위
+	if loginFrom := c.Query("login_from"); loginFrom != "" {
+		query = query.Where("mb_today_login >= ?", loginFrom)
+	}
+	if loginTo := c.Query("login_to"); loginTo != "" {
+		query = query.Where("mb_today_login <= ?", loginTo+" 23:59:59")
+	}
+
+	// 카운트
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "회원 수 조회 실패", err)
+		return
+	}
+
+	// 정렬
+	sortBy := c.DefaultQuery("sort_by", "datetime")
+	sortOrder := strings.ToUpper(c.DefaultQuery("sort_order", "desc"))
+	if sortOrder != "ASC" && sortOrder != "DESC" {
+		sortOrder = "DESC"
+	}
+	col, ok := allowedSortColumns[sortBy]
+	if !ok {
+		col = "mb_datetime"
+	}
+	query = query.Order(fmt.Sprintf("%s %s", col, sortOrder))
+
+	// 조회
+	offset := (page - 1) * limit
+	var members []gnuboard.G5Member
+	if err := query.Offset(offset).Limit(limit).Find(&members).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "회원 목록 조회 실패", err)
+		return
+	}
+
+	// 응답 변환
+	result := make([]adminMemberResponse, len(members))
+	for i, m := range members {
+		result[i] = toAdminMemberResponse(&m)
+	}
+
+	// 프론트엔드가 기대하는 형식: { data: { members, total, page, limit } }
+	common.V2Success(c, gin.H{
+		"members": result,
+		"total":   total,
+		"page":    page,
+		"limit":   limit,
+	})
+}
+
+// GetMember handles GET /api/v1/admin/members/:id
+func (h *AdminMemberHandler) GetMember(c *gin.Context) {
+	mbID := c.Param("mbId")
+	var member gnuboard.G5Member
+	if err := h.db.Where("mb_id = ?", mbID).First(&member).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusNotFound, "회원을 찾을 수 없습니다", err)
+		return
+	}
+	common.V2Success(c, toAdminMemberResponse(&member))
+}
+
+// UpdateMember handles PUT /api/v1/admin/members/:id
+func (h *AdminMemberHandler) UpdateMember(c *gin.Context) {
+	mbID := c.Param("mbId")
+	var req struct {
+		MbLevel *int `json:"mb_level"`
+		MbPoint *int `json:"mb_point"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
+		return
+	}
+
+	updates := map[string]interface{}{}
+	if req.MbLevel != nil {
+		if *req.MbLevel < 1 || *req.MbLevel > 10 {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "레벨은 1~10 범위여야 합니다", nil)
+			return
+		}
+		updates["mb_level"] = *req.MbLevel
+	}
+	if req.MbPoint != nil {
+		updates["mb_point"] = *req.MbPoint
+	}
+	if len(updates) == 0 {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "변경할 항목이 없습니다", nil)
+		return
+	}
+
+	if err := h.db.Model(&gnuboard.G5Member{}).Where("mb_id = ?", mbID).Updates(updates).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "회원 수정 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "수정 완료"})
+}
+
+// BanMember handles POST /api/v1/admin/members/:id/ban
+func (h *AdminMemberHandler) BanMember(c *gin.Context) {
+	mbID := c.Param("mbId")
+	now := time.Now().Format("2006-01-02")
+	if err := h.db.Model(&gnuboard.G5Member{}).Where("mb_id = ?", mbID).Update("mb_intercept_date", now).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "차단 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "차단 완료"})
+}
+
+// UnbanMember handles POST /api/v1/admin/members/:id/unban
+func (h *AdminMemberHandler) UnbanMember(c *gin.Context) {
+	mbID := c.Param("mbId")
+	if err := h.db.Model(&gnuboard.G5Member{}).Where("mb_id = ?", mbID).Update("mb_intercept_date", "").Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "차단 해제 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "차단 해제 완료"})
+}
+
+// BulkUpdateLevel handles POST /api/v1/admin/members/bulk/level
+func (h *AdminMemberHandler) BulkUpdateLevel(c *gin.Context) {
+	var req struct {
+		MemberIDs []string `json:"member_ids" binding:"required"`
+		Level     int      `json:"level" binding:"required,min=1,max=10"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
+		return
+	}
+	if len(req.MemberIDs) == 0 {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "선택된 회원이 없습니다", nil)
+		return
+	}
+	if err := h.db.Model(&gnuboard.G5Member{}).Where("mb_id IN ?", req.MemberIDs).Update("mb_level", req.Level).Error; err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "일괄 레벨 변경 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"message": fmt.Sprintf("%d명 레벨 변경 완료", len(req.MemberIDs))})
+}

--- a/internal/handler/v2/admin_handler.go
+++ b/internal/handler/v2/admin_handler.go
@@ -229,6 +229,50 @@ func (h *AdminHandler) BanMember(c *gin.Context) {
 	common.V2Success(c, gin.H{"message": msg})
 }
 
+// AnonymizeMember handles POST /api/v2/admin/members/:id/anonymize
+func (h *AdminHandler) AnonymizeMember(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 ID", err)
+		return
+	}
+
+	var req v2svc.AnonymizeMemberRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	result, err := h.adminService.AnonymizeMember(id, req)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "회원 익명화 실패", err)
+		return
+	}
+	common.V2Success(c, result)
+}
+
+// AnonymizeMemberByUsername handles POST /api/v2/admin/members/by-username/:username/anonymize
+func (h *AdminHandler) AnonymizeMemberByUsername(c *gin.Context) {
+	username := c.Param("username")
+	if username == "" {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 회원 username", nil)
+		return
+	}
+
+	var req v2svc.AnonymizeMemberRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	result, err := h.adminService.AnonymizeMemberByUsername(username, req)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "회원 익명화 실패", err)
+		return
+	}
+	common.V2Success(c, result)
+}
+
 // GetDashboardStats handles GET /api/v2/admin/dashboard/stats
 func (h *AdminHandler) GetDashboardStats(c *gin.Context) {
 	stats, err := h.adminService.GetDashboardStats()

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -94,6 +94,8 @@ func SetupAdmin(router *gin.Engine, h *v2handler.AdminHandler, jwtManager *jwt.M
 	adminMembers.GET("/:id", h.GetMember)
 	adminMembers.PUT("/:id", h.UpdateMember)
 	adminMembers.POST("/:id/ban", h.BanMember)
+	adminMembers.POST("/:id/anonymize", h.AnonymizeMember)
+	adminMembers.POST("/by-username/:username/anonymize", h.AnonymizeMemberByUsername)
 
 	// Admin Dashboard
 	admin.GET("/dashboard/stats", h.GetDashboardStats)

--- a/internal/service/v2/admin_anonymize.go
+++ b/internal/service/v2/admin_anonymize.go
@@ -1,0 +1,533 @@
+package v2
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+const defaultAnonymizedNickname = "탈퇴사용자"
+
+var allowedAnonymizeBoards = map[string]bool{
+	"free":          true,
+	"referral":      true,
+	"disciplinelog": true,
+}
+
+type AnonymizeMemberRequest struct {
+	ReplacementNickname string   `json:"replacement_nickname"`
+	Targets             []string `json:"targets"`
+	SearchTexts         []string `json:"search_texts"`
+}
+
+type AnonymizeMemberResult struct {
+	MemberID            uint64                  `json:"member_id"`
+	Username            string                  `json:"username"`
+	ReplacementNickname string                  `json:"replacement_nickname"`
+	SearchTexts         []string                `json:"search_texts"`
+	ResolvedTargets     []AnonymizeTargetResult `json:"resolved_targets"`
+	UpdatedRows         []UpdatedRowResult      `json:"updated_rows"`
+	SkippedRows         []SkippedRowResult      `json:"skipped_rows"`
+	BackupFile          string                  `json:"backup_file"`
+	ManifestFile        string                  `json:"manifest_file"`
+}
+
+type AnonymizeTargetResult struct {
+	URL       string `json:"url"`
+	BoardID   string `json:"board_id"`
+	PostID    int    `json:"post_id"`
+	CommentID *int   `json:"comment_id,omitempty"`
+}
+
+type UpdatedRowResult struct {
+	Table  string `json:"table"`
+	RowID  string `json:"row_id"`
+	Reason string `json:"reason"`
+}
+
+type SkippedRowResult struct {
+	Table  string `json:"table"`
+	RowID  string `json:"row_id"`
+	Reason string `json:"reason"`
+}
+
+type manifestFile struct {
+	GeneratedAt         string                  `json:"generated_at"`
+	MemberID            uint64                  `json:"member_id"`
+	Username            string                  `json:"username"`
+	ReplacementNickname string                  `json:"replacement_nickname"`
+	SearchTexts         []string                `json:"search_texts"`
+	Targets             []AnonymizeTargetResult `json:"targets"`
+	Rows                []backupRow             `json:"rows"`
+	BackupFile          string                  `json:"backup_file"`
+}
+
+type backupRow struct {
+	Table string `json:"table"`
+	RowID string `json:"row_id"`
+}
+
+type resolvedTarget struct {
+	BoardID   string
+	PostID    int
+	CommentID *int
+	URL       string
+}
+
+type targetRow struct {
+	Table  string
+	RowID  int
+	Reason string
+}
+
+func (s *AdminService) AnonymizeMember(memberID uint64, req AnonymizeMemberRequest) (*AnonymizeMemberResult, error) {
+	if s.db == nil || s.memberRepo == nil {
+		return nil, fmt.Errorf("anonymize service dependencies are not configured")
+	}
+	user, err := s.userRepo.FindByID(memberID)
+	if err != nil {
+		return nil, err
+	}
+	return s.anonymizeMemberUser(user, req)
+}
+
+func (s *AdminService) AnonymizeMemberByUsername(username string, req AnonymizeMemberRequest) (*AnonymizeMemberResult, error) {
+	if s.db == nil || s.memberRepo == nil {
+		return nil, fmt.Errorf("anonymize service dependencies are not configured")
+	}
+	user, err := s.userRepo.FindByUsername(username)
+	if err != nil {
+		return nil, err
+	}
+	return s.anonymizeMemberUser(user, req)
+}
+
+func (s *AdminService) anonymizeMemberUser(user *v2domain.V2User, req AnonymizeMemberRequest) (*AnonymizeMemberResult, error) {
+	replacement := strings.TrimSpace(req.ReplacementNickname)
+	if replacement == "" {
+		replacement = defaultAnonymizedNickname
+	}
+	if len(req.Targets) == 0 {
+		return nil, fmt.Errorf("at least one target URL is required")
+	}
+
+	searchTexts := normalizeSearchTexts(req.SearchTexts, user.Nickname, replacement)
+	if len(searchTexts) == 0 {
+		return nil, fmt.Errorf("at least one non-empty search text is required")
+	}
+
+	targets, err := resolveTargets(req.Targets)
+	if err != nil {
+		return nil, err
+	}
+	rows := collectTargetRows(targets)
+
+	backupDir := filepath.Join(os.TempDir(), "damoang-anonymize")
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		return nil, err
+	}
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	fileBase := fmt.Sprintf("member-%d-%s", user.ID, ts)
+	backupFile := filepath.Join(backupDir, fileBase+".sql")
+	manifestFilePath := filepath.Join(backupDir, fileBase+".json")
+
+	result := &AnonymizeMemberResult{
+		MemberID:            user.ID,
+		Username:            user.Username,
+		ReplacementNickname: replacement,
+		SearchTexts:         searchTexts,
+		BackupFile:          backupFile,
+		ManifestFile:        manifestFilePath,
+	}
+	for _, target := range targets {
+		result.ResolvedTargets = append(result.ResolvedTargets, AnonymizeTargetResult{
+			URL:       target.URL,
+			BoardID:   target.BoardID,
+			PostID:    target.PostID,
+			CommentID: target.CommentID,
+		})
+	}
+
+	if err := s.writeBackupFiles(user, replacement, searchTexts, result.ResolvedTargets, rows, backupFile, manifestFilePath); err != nil {
+		return nil, err
+	}
+
+	err = s.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Table("v2_users").Where("id = ?", user.ID).Update("nickname", replacement).Error; err != nil {
+			return err
+		}
+		memberUpdates := map[string]any{"mb_nick": replacement}
+		if len(searchTexts) > 0 {
+			memberUpdates["mb_nick_date"] = time.Now().Format("2006-01-02")
+		}
+		memberResult := tx.Table("g5_member").Where("mb_id = ?", user.Username).Updates(memberUpdates)
+		if memberResult.Error != nil {
+			return memberResult.Error
+		}
+		if memberResult.RowsAffected > 0 {
+			result.UpdatedRows = append(result.UpdatedRows, UpdatedRowResult{
+				Table:  "g5_member",
+				RowID:  user.Username,
+				Reason: "member nickname updated",
+			})
+		} else {
+			result.SkippedRows = append(result.SkippedRows, SkippedRowResult{
+				Table:  "g5_member",
+				RowID:  user.Username,
+				Reason: "member row not found",
+			})
+		}
+
+		for _, row := range rows {
+			changed, err := applyRowReplacement(tx, row.Table, row.RowID, searchTexts, replacement)
+			if err != nil {
+				return err
+			}
+			rowID := strconv.Itoa(row.RowID)
+			if changed {
+				result.UpdatedRows = append(result.UpdatedRows, UpdatedRowResult{
+					Table:  row.Table,
+					RowID:  rowID,
+					Reason: row.Reason,
+				})
+				continue
+			}
+			result.SkippedRows = append(result.SkippedRows, SkippedRowResult{
+				Table:  row.Table,
+				RowID:  rowID,
+				Reason: "no matching text found",
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func normalizeSearchTexts(values []string, fallback string, replacement string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(values)+1)
+	appendText := func(v string) {
+		v = strings.TrimSpace(v)
+		if v == "" || v == replacement {
+			return
+		}
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, v := range values {
+		appendText(v)
+	}
+	appendText(fallback)
+	sort.Strings(out)
+	return out
+}
+
+func resolveTargets(rawTargets []string) ([]resolvedTarget, error) {
+	seen := make(map[string]struct{})
+	targets := make([]resolvedTarget, 0, len(rawTargets))
+	for _, raw := range rawTargets {
+		target, err := parseTarget(raw)
+		if err != nil {
+			return nil, err
+		}
+		key := fmt.Sprintf("%s:%d", target.BoardID, target.PostID)
+		if target.CommentID != nil {
+			key = fmt.Sprintf("%s#%d", key, *target.CommentID)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, target)
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].BoardID != targets[j].BoardID {
+			return targets[i].BoardID < targets[j].BoardID
+		}
+		if targets[i].PostID != targets[j].PostID {
+			return targets[i].PostID < targets[j].PostID
+		}
+		leftComment := 0
+		if targets[i].CommentID != nil {
+			leftComment = *targets[i].CommentID
+		}
+		rightComment := 0
+		if targets[j].CommentID != nil {
+			rightComment = *targets[j].CommentID
+		}
+		return leftComment < rightComment
+	})
+	return targets, nil
+}
+
+func parseTarget(raw string) (resolvedTarget, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return resolvedTarget{}, fmt.Errorf("invalid target URL %q: %w", raw, err)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 {
+		return resolvedTarget{}, fmt.Errorf("unsupported target path %q", parsed.Path)
+	}
+	boardID := parts[0]
+	if !allowedAnonymizeBoards[boardID] {
+		return resolvedTarget{}, fmt.Errorf("unsupported board %q", boardID)
+	}
+	postID, err := strconv.Atoi(parts[1])
+	if err != nil || postID <= 0 {
+		return resolvedTarget{}, fmt.Errorf("invalid post id in %q", raw)
+	}
+	var commentID *int
+	if frag := parsed.Fragment; strings.HasPrefix(frag, "c_") {
+		id, err := strconv.Atoi(strings.TrimPrefix(frag, "c_"))
+		if err != nil || id <= 0 {
+			return resolvedTarget{}, fmt.Errorf("invalid comment id in %q", raw)
+		}
+		commentID = &id
+	}
+	return resolvedTarget{
+		BoardID:   boardID,
+		PostID:    postID,
+		CommentID: commentID,
+		URL:       raw,
+	}, nil
+}
+
+func collectTargetRows(targets []resolvedTarget) []targetRow {
+	seen := make(map[string]struct{})
+	rows := make([]targetRow, 0, len(targets)*2)
+	for _, target := range targets {
+		table := "g5_write_" + target.BoardID
+		postKey := fmt.Sprintf("%s:%d", table, target.PostID)
+		if _, ok := seen[postKey]; !ok {
+			seen[postKey] = struct{}{}
+			rows = append(rows, targetRow{Table: table, RowID: target.PostID, Reason: "post content updated"})
+		}
+		if target.CommentID != nil {
+			commentKey := fmt.Sprintf("%s:%d", table, *target.CommentID)
+			if _, ok := seen[commentKey]; ok {
+				continue
+			}
+			seen[commentKey] = struct{}{}
+			rows = append(rows, targetRow{Table: table, RowID: *target.CommentID, Reason: "comment content updated"})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Table != rows[j].Table {
+			return rows[i].Table < rows[j].Table
+		}
+		return rows[i].RowID < rows[j].RowID
+	})
+	return rows
+}
+
+func (s *AdminService) writeBackupFiles(user *v2domain.V2User, replacement string, searchTexts []string, targets []AnonymizeTargetResult, rows []targetRow, backupPath string, manifestPath string) error {
+	sqlText, manifestRows, err := s.buildBackupSQL(user, rows)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(backupPath, []byte(sqlText), 0o600); err != nil {
+		return err
+	}
+	manifest := manifestFile{
+		GeneratedAt:         time.Now().UTC().Format(time.RFC3339),
+		MemberID:            user.ID,
+		Username:            user.Username,
+		ReplacementNickname: replacement,
+		SearchTexts:         searchTexts,
+		Targets:             targets,
+		Rows:                manifestRows,
+		BackupFile:          backupPath,
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(manifestPath, data, 0o600)
+}
+
+func (s *AdminService) buildBackupSQL(user *v2domain.V2User, rows []targetRow) (string, []backupRow, error) {
+	var builder strings.Builder
+	manifestRows := []backupRow{{Table: "v2_users", RowID: strconv.FormatUint(user.ID, 10)}, {Table: "g5_member", RowID: user.Username}}
+	builder.WriteString("-- Damoang anonymize backup\n")
+	builder.WriteString("START TRANSACTION;\n")
+
+	sqlText, err := backupRowsAsSQL(s.db, "v2_users", "id", []int{int(user.ID)})
+	if err != nil {
+		return "", nil, err
+	}
+	builder.WriteString(sqlText)
+
+	memberSQL, err := backupRowsByStringIDAsSQL(s.db, "g5_member", "mb_id", []string{user.Username})
+	if err != nil {
+		return "", nil, err
+	}
+	builder.WriteString(memberSQL)
+
+	grouped := make(map[string][]int)
+	for _, row := range rows {
+		grouped[row.Table] = append(grouped[row.Table], row.RowID)
+		manifestRows = append(manifestRows, backupRow{Table: row.Table, RowID: strconv.Itoa(row.RowID)})
+	}
+	tables := make([]string, 0, len(grouped))
+	for table := range grouped {
+		tables = append(tables, table)
+	}
+	sort.Strings(tables)
+	for _, table := range tables {
+		sqlText, err := backupRowsAsSQL(s.db, table, "wr_id", grouped[table])
+		if err != nil {
+			return "", nil, err
+		}
+		builder.WriteString(sqlText)
+	}
+	builder.WriteString("COMMIT;\n")
+	return builder.String(), manifestRows, nil
+}
+
+func backupRowsAsSQL(db *gorm.DB, table string, keyColumn string, ids []int) (string, error) {
+	if len(ids) == 0 {
+		return "", nil
+	}
+	sort.Ints(ids)
+	rows, err := db.Table(table).Where(keyColumn+" IN ?", ids).Order(keyColumn).Rows()
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	return rowsToInsertSQL(table, rows)
+}
+
+func backupRowsByStringIDAsSQL(db *gorm.DB, table string, keyColumn string, ids []string) (string, error) {
+	if len(ids) == 0 {
+		return "", nil
+	}
+	rows, err := db.Table(table).Where(keyColumn+" IN ?", ids).Order(keyColumn).Rows()
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	return rowsToInsertSQL(table, rows)
+}
+
+func rowsToInsertSQL(table string, rows *sql.Rows) (string, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return "", err
+	}
+	var builder strings.Builder
+	for rows.Next() {
+		values := make([]sql.RawBytes, len(columns))
+		scanArgs := make([]any, len(columns))
+		for i := range values {
+			scanArgs[i] = &values[i]
+		}
+		if err := rows.Scan(scanArgs...); err != nil {
+			return "", err
+		}
+		builder.WriteString("REPLACE INTO `")
+		builder.WriteString(table)
+		builder.WriteString("` (")
+		for i, col := range columns {
+			if i > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString("`")
+			builder.WriteString(col)
+			builder.WriteString("`")
+		}
+		builder.WriteString(") VALUES (")
+		for i, value := range values {
+			if i > 0 {
+				builder.WriteString(", ")
+			}
+			if value == nil {
+				builder.WriteString("NULL")
+				continue
+			}
+			builder.WriteString("'")
+			builder.WriteString(escapeSQLString(string(value)))
+			builder.WriteString("'")
+		}
+		builder.WriteString(");\n")
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}
+
+func escapeSQLString(value string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\\\\`,
+		`'`, `''`,
+		"\n", `\n`,
+		"\r", `\r`,
+		"\x00", `\0`,
+	)
+	return replacer.Replace(value)
+}
+
+func applyRowReplacement(tx *gorm.DB, table string, rowID int, searchTexts []string, replacement string) (bool, error) {
+	type writeRow struct {
+		WrName    string `gorm:"column:wr_name"`
+		WrSubject string `gorm:"column:wr_subject"`
+		WrContent string `gorm:"column:wr_content"`
+	}
+	var row writeRow
+	if err := tx.Table(table).Select("wr_name, wr_subject, wr_content").Where("wr_id = ?", rowID).Take(&row).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+
+	updated := map[string]any{}
+	newName := replaceAllTexts(row.WrName, searchTexts, replacement)
+	if newName != row.WrName {
+		updated["wr_name"] = newName
+	}
+	newSubject := replaceAllTexts(row.WrSubject, searchTexts, replacement)
+	if newSubject != row.WrSubject {
+		updated["wr_subject"] = newSubject
+	}
+	newContent := replaceAllTexts(row.WrContent, searchTexts, replacement)
+	if newContent != row.WrContent {
+		updated["wr_content"] = newContent
+	}
+	if len(updated) == 0 {
+		return false, nil
+	}
+	if err := tx.Table(table).Where("wr_id = ?", rowID).Updates(updated).Error; err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func replaceAllTexts(value string, searchTexts []string, replacement string) string {
+	out := value
+	for _, search := range searchTexts {
+		if search == "" {
+			continue
+		}
+		out = strings.ReplaceAll(out, search, replacement)
+	}
+	return out
+}

--- a/internal/service/v2/admin_anonymize_test.go
+++ b/internal/service/v2/admin_anonymize_test.go
@@ -1,0 +1,250 @@
+package v2
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestAnonymizeMemberBacksUpAndReplacesTargetRows(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("TMPDIR", tmpDir)
+
+	db, err := gorm.Open(sqlite.Open("file:admin_anonymize_test?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	mustExec := func(sql string) {
+		t.Helper()
+		if err := db.Exec(sql).Error; err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	mustExec(`CREATE TABLE v2_users (
+		id INTEGER PRIMARY KEY,
+		username TEXT,
+		email TEXT,
+		password TEXT,
+		nickname TEXT,
+		level INTEGER,
+		status TEXT,
+		created_at DATETIME,
+		updated_at DATETIME
+	)`)
+	mustExec(`CREATE TABLE g5_member (
+		mb_id TEXT PRIMARY KEY,
+		mb_nick TEXT,
+		mb_nick_date TEXT
+	)`)
+	mustExec(`CREATE TABLE g5_write_free (
+		wr_id INTEGER PRIMARY KEY,
+		wr_name TEXT,
+		wr_subject TEXT,
+		wr_content TEXT
+	)`)
+	mustExec(`CREATE TABLE g5_write_referral (
+		wr_id INTEGER PRIMARY KEY,
+		wr_name TEXT,
+		wr_subject TEXT,
+		wr_content TEXT
+	)`)
+	mustExec(`CREATE TABLE g5_write_disciplinelog (
+		wr_id INTEGER PRIMARY KEY,
+		wr_name TEXT,
+		wr_subject TEXT,
+		wr_content TEXT
+	)`)
+
+	mustExec(`INSERT INTO v2_users (id, username, email, password, nickname, level, status, created_at, updated_at)
+		VALUES (7, 'user7', 'u7@example.com', 'pw', '전동운', 1, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	mustExec(`INSERT INTO g5_member (mb_id, mb_nick, mb_nick_date) VALUES ('user7', '전동운', '2026-03-01')`)
+	mustExec(`INSERT INTO g5_write_free (wr_id, wr_name, wr_subject, wr_content)
+		VALUES (5936618, '전동운', '전동운 게시글', '본문에 전동운 언급')`)
+	mustExec(`INSERT INTO g5_write_free (wr_id, wr_name, wr_subject, wr_content)
+		VALUES (5942893, '전동운', '', '댓글 전동운')`)
+	mustExec(`INSERT INTO g5_write_disciplinelog (wr_id, wr_name, wr_subject, wr_content)
+		VALUES (3348, '관리자', '전동운 (user7) 님에 대한 이용제한 안내', '{"note":"전동운 처리"}')`)
+
+	svc := NewAdminService(
+		db,
+		v2repo.NewUserRepository(db),
+		nil,
+		nil,
+		nil,
+		gnurepo.NewMemberRepository(db),
+	)
+
+	result, err := svc.AnonymizeMember(7, AnonymizeMemberRequest{
+		ReplacementNickname: "탈퇴_1",
+		Targets: []string{
+			"https://damoang.net/free/5936618",
+			"https://damoang.net/free/5936618#c_5942893",
+			"https://damoang.net/disciplinelog/3348",
+			"https://damoang.net/free/5936618",
+		},
+		SearchTexts: []string{"전동운"},
+	})
+	if err != nil {
+		t.Fatalf("AnonymizeMember returned error: %v", err)
+	}
+
+	var nickname string
+	if err := db.Table("v2_users").Select("nickname").Where("id = ?", 7).Scan(&nickname).Error; err != nil {
+		t.Fatalf("query v2 nickname: %v", err)
+	}
+	if nickname != "탈퇴_1" {
+		t.Fatalf("nickname = %q, want 탈퇴_1", nickname)
+	}
+	if err := db.Table("g5_member").Select("mb_nick").Where("mb_id = ?", "user7").Scan(&nickname).Error; err != nil {
+		t.Fatalf("query legacy nickname: %v", err)
+	}
+	if nickname != "탈퇴_1" {
+		t.Fatalf("legacy nickname = %q, want 탈퇴_1", nickname)
+	}
+
+	assertRowContains := func(table string, rowID int, want string) {
+		t.Helper()
+		var row struct {
+			Name    string `gorm:"column:wr_name"`
+			Subject string `gorm:"column:wr_subject"`
+			Content string `gorm:"column:wr_content"`
+		}
+		if err := db.Table(table).Where("wr_id = ?", rowID).Take(&row).Error; err != nil {
+			t.Fatalf("query %s/%d: %v", table, rowID, err)
+		}
+		joined := row.Name + "|" + row.Subject + "|" + row.Content
+		if strings.Contains(joined, "전동운") {
+			t.Fatalf("%s/%d still contains original text: %s", table, rowID, joined)
+		}
+		if !strings.Contains(joined, want) {
+			t.Fatalf("%s/%d does not contain %q: %s", table, rowID, want, joined)
+		}
+	}
+	assertRowContains("g5_write_free", 5936618, "탈퇴_1")
+	assertRowContains("g5_write_free", 5942893, "탈퇴_1")
+	assertRowContains("g5_write_disciplinelog", 3348, "탈퇴_1")
+
+	backupBytes, err := os.ReadFile(result.BackupFile)
+	if err != nil {
+		t.Fatalf("read backup file: %v", err)
+	}
+	if !strings.Contains(string(backupBytes), "전동운") {
+		t.Fatalf("backup file should contain original text, got: %s", string(backupBytes))
+	}
+	if _, err := os.Stat(result.ManifestFile); err != nil {
+		t.Fatalf("manifest file missing: %v", err)
+	}
+	if filepath.Dir(result.BackupFile) != filepath.Join(tmpDir, "damoang-anonymize") {
+		t.Fatalf("backup file path = %s, want under %s", result.BackupFile, tmpDir)
+	}
+	if len(result.ResolvedTargets) != 3 {
+		t.Fatalf("resolved target count = %d, want 3", len(result.ResolvedTargets))
+	}
+}
+
+func TestResolveTargetsDeduplicatesCommentLinks(t *testing.T) {
+	targets, err := resolveTargets([]string{
+		"https://damoang.net/free/1#c_2",
+		"https://damoang.net/free/1#c_2",
+		"https://damoang.net/free/1",
+	})
+	if err != nil {
+		t.Fatalf("resolveTargets returned error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("resolved target count = %d, want 2", len(targets))
+	}
+	if targets[0].CommentID != nil {
+		t.Fatalf("expected post-only target to sort first")
+	}
+	if targets[1].CommentID == nil || *targets[1].CommentID != 2 {
+		t.Fatalf("expected second target to contain comment id 2")
+	}
+}
+
+func TestAnonymizeMemberDefaultsToGenericNickname(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:admin_anonymize_default_test?mode=memory&cache=private"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	mustExec := func(sql string) {
+		t.Helper()
+		if err := db.Exec(sql).Error; err != nil {
+			t.Fatalf("exec %q: %v", sql, err)
+		}
+	}
+
+	mustExec(`CREATE TABLE v2_users (
+		id INTEGER PRIMARY KEY,
+		username TEXT,
+		email TEXT,
+		password TEXT,
+		nickname TEXT,
+		level INTEGER,
+		status TEXT,
+		created_at DATETIME,
+		updated_at DATETIME
+	)`)
+	mustExec(`CREATE TABLE g5_member (
+		mb_id TEXT PRIMARY KEY,
+		mb_nick TEXT,
+		mb_nick_date TEXT
+	)`)
+	mustExec(`CREATE TABLE g5_write_free (
+		wr_id INTEGER PRIMARY KEY,
+		wr_name TEXT,
+		wr_subject TEXT,
+		wr_content TEXT
+	)`)
+	mustExec(`INSERT INTO v2_users (id, username, email, password, nickname, level, status, created_at, updated_at)
+		VALUES (9, 'user9', 'u9@example.com', 'pw', '전동운', 1, 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`)
+	mustExec(`INSERT INTO g5_member (mb_id, mb_nick, mb_nick_date) VALUES ('user9', '전동운', '2026-03-01')`)
+	mustExec(`INSERT INTO g5_write_free (wr_id, wr_name, wr_subject, wr_content)
+		VALUES (1, '전동운', '전동운 제목', '전동운 본문')`)
+
+	svc := NewAdminService(
+		db,
+		v2repo.NewUserRepository(db),
+		nil,
+		nil,
+		nil,
+		gnurepo.NewMemberRepository(db),
+	)
+
+	result, err := svc.AnonymizeMember(9, AnonymizeMemberRequest{
+		Targets:     []string{"https://damoang.net/free/1"},
+		SearchTexts: []string{"전동운"},
+	})
+	if err != nil {
+		t.Fatalf("AnonymizeMember returned error: %v", err)
+	}
+	if result.ReplacementNickname != defaultAnonymizedNickname {
+		t.Fatalf("replacement nickname = %q, want %q", result.ReplacementNickname, defaultAnonymizedNickname)
+	}
+	if result.MemberID != 9 || result.Username != "user9" {
+		t.Fatalf("unexpected internal identifiers: %+v", result)
+	}
+
+	var row struct {
+		Name    string `gorm:"column:wr_name"`
+		Subject string `gorm:"column:wr_subject"`
+		Content string `gorm:"column:wr_content"`
+	}
+	if err := db.Table("g5_write_free").Where("wr_id = ?", 1).Take(&row).Error; err != nil {
+		t.Fatalf("query updated row: %v", err)
+	}
+	joined := row.Name + "|" + row.Subject + "|" + row.Content
+	if strings.Contains(joined, "전동운") {
+		t.Fatalf("updated row still contains original nickname: %s", joined)
+	}
+	if !strings.Contains(joined, defaultAnonymizedNickname) {
+		t.Fatalf("updated row does not contain default nickname: %s", joined)
+	}
+}

--- a/internal/service/v2/admin_service.go
+++ b/internal/service/v2/admin_service.go
@@ -4,7 +4,9 @@ import (
 	"time"
 
 	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"gorm.io/gorm"
 )
 
 // User status constants
@@ -19,20 +21,26 @@ type AdminService struct {
 	boardRepo   v2repo.BoardRepository
 	postRepo    v2repo.PostRepository
 	commentRepo v2repo.CommentRepository
+	memberRepo  gnurepo.MemberRepository
+	db          *gorm.DB
 }
 
 // NewAdminService creates a new AdminService
 func NewAdminService(
+	db *gorm.DB,
 	userRepo v2repo.UserRepository,
 	boardRepo v2repo.BoardRepository,
 	postRepo v2repo.PostRepository,
 	commentRepo v2repo.CommentRepository,
+	memberRepo gnurepo.MemberRepository,
 ) *AdminService {
 	return &AdminService{
 		userRepo:    userRepo,
 		boardRepo:   boardRepo,
 		postRepo:    postRepo,
 		commentRepo: commentRepo,
+		memberRepo:  memberRepo,
+		db:          db,
 	}
 }
 


### PR DESCRIPTION
## Summary
- g5_member 기반 v1 admin member API 추가 (프론트엔드 `/admin/members` 페이지 데이터 연동)
- 고급 필터: 상태(정상/차단/탈퇴), 가입일, 포인트, 최근 로그인 범위
- v2 익명화 API 추가 (ID/username 기반)

## Test plan
- [ ] `GET /api/v1/admin/members` 회원 목록 반환 확인
- [ ] 검색/필터/정렬 조합 테스트
- [ ] 레벨 변경, 차단/해제 동작 확인