### PR TITLE
삭제된 글도 신고 가능하도록 수정

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4019,8 +4019,8 @@ func main() {
 				return
 			}
 
-			// 게시글 존재 확인 & 작성자 조회
-			post, err := gnuWriteRepo.FindPostByID(slug, postID)
+			// 게시글 존재 확인 & 작성자 조회 (삭제된 글도 신고 가능)
+			post, err := gnuWriteRepo.FindPostByIDIncludeDeleted(slug, postID)
 			if err != nil {
 				c.JSON(http.StatusNotFound, gin.H{"success": false, "error": "게시글을 찾을 수 없습니다"})
 				return


### PR DESCRIPTION
## Summary
- 신고 API에서 `FindPostByID` → `FindPostByIDIncludeDeleted`로 변경
- 기존: 삭제된 글 신고 시 404 반환 (wr_deleted_at IS NULL 조건)
- 변경: 삭제된 글도 조회하여 신고 처리 가능

## Test plan
- [ ] 삭제된 글에서 신고 → 정상 처리
- [ ] 일반 글 신고 → 기존과 동일
- [ ] 자기 글 신고 → 여전히 차단