### PR TITLE
이용제한 backfill 날짜 varchar(8) 잘림 버그 수정

### DIFF
--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -62,7 +62,7 @@ func BanCheckScoped(gnuDB *gorm.DB, scope string) gin.HandlerFunc {
 			fallbackErr := gnuDB.Raw(
 				`SELECT CASE
 						WHEN penalty_period = -1 THEN '99991231'
-						ELSE DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y-%m-%d %H:%i:%s')
+						ELSE DATE_FORMAT(DATE_ADD(penalty_date_from, INTERVAL penalty_period DAY), '%Y%m%d')
 					END
 				 FROM g5_da_member_discipline
 				 WHERE penalty_mb_id = ?


### PR DESCRIPTION
## Summary
- `ban_check.go`에서 mb_intercept_date backfill 시 datetime(19자) → varchar(8)에 저장하여 날짜가 잘리는 버그
- `DATE_FORMAT('%Y-%m-%d %H:%i:%s')` → `DATE_FORMAT('%Y%m%d')` 변경
- 기존 잘린 7건 DB에서 수동 복구 완료

## Root Cause
`mb_intercept_date`는 그누보드 `varchar(8)` 컬럼 (YYYYMMDD 형식)
backfill SQL이 `'%Y-%m-%d %H:%i:%s'` (19자)로 생성하여 8자에서 잘림
→ `2026-03-27 09:00:01` → `2026-03-` (해제 불가)

## Test plan
- [ ] 이용제한 설정 후 mb_intercept_date가 YYYYMMDD 형식으로 저장되는지 확인
- [ ] 기간 만료 후 자동 해제 정상 동작 확인