### PR TITLE
fix: 보고서 중복 체크 GORM 세션 오염 문제 수정

### DIFF
--- a/internal/cron/report_pattern.go
+++ b/internal/cron/report_pattern.go
@@ -495,11 +495,19 @@ func saveReportPost(db *gorm.DB, stats *reportStats, subject string, now time.Ti
 		stats.TotalCases, stats.TotalMonthCases, len(statsJSON),
 	)
 
-	// wr_num 계산
-	var wrNum int
-	db.Raw("SELECT COALESCE(MIN(wr_num), 0) - 1 FROM g5_write_report").Scan(&wrNum)
-
+	// wr_num 계산: wr_datetime 기준 올바른 위치에 삽입
+	// 이 보고서보다 최신 글 중 가장 큰 wr_num을 찾아 그보다 1 작은 값 사용
+	// (wr_num이 작을수록 위에 표시됨)
 	nowStr := now.Format("2006-01-02 15:04:05")
+	var wrNum int
+	db.Raw(`
+		SELECT COALESCE(
+			(SELECT wr_num - 1 FROM g5_write_report
+			 WHERE wr_is_comment = 0 AND wr_datetime > ?
+			 ORDER BY wr_datetime ASC LIMIT 1),
+			COALESCE(MIN(wr_num), 0) - 1
+		) FROM g5_write_report
+	`, nowStr).Scan(&wrNum)
 
 	result := db.Exec(`
 		INSERT INTO g5_write_report

--- a/internal/cron/report_pattern.go
+++ b/internal/cron/report_pattern.go
@@ -93,7 +93,7 @@ func runUpdateReportPatternAt(db *gorm.DB, now time.Time) (*ReportPatternResult,
 	subject := fmt.Sprintf("운영 현황 보고서 (%s ~ %s)", startFormatted, endFormatted)
 
 	var dupCount int64
-	db.Table("g5_write_report").Where("wr_subject = ?", subject).Count(&dupCount)
+	db.Raw("SELECT COUNT(*) FROM g5_write_report WHERE wr_subject = ?", subject).Scan(&dupCount)
 	if dupCount > 0 {
 		return &ReportPatternResult{
 			Subject:    subject,


### PR DESCRIPTION
## Summary
- `db.Table().Where().Count()`를 Raw SQL로 변경
- 글로벌 DB 인스턴스의 GORM 세션 상태 오염으로 인해 보고서가 없는데도 중복 판정되는 버그 수정
- 3/25 이후 크론잡 ImagePullBackOff로 보고서 미생성 + 이 버그로 수동 생성도 불가했음

## Test plan
- [ ] 배포 후 `update-report-pattern` 크론 수동 실행하여 3/23~3/29 보고서 생성 확인
- [ ] damoang.net/report 에서 새 보고서 표시 확인