### PR TITLE
XP 기본 활성화 + 삭제글 태그 정리

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -739,6 +739,7 @@ func main() {
 		v2Handler.SetNotiPreferenceRepository(gnurepo.NewNotiPreferenceRepository(db))
 		v2Handler.SetGnuDB(db)
 		v2Handler.SetBlockRepository(v2repo.NewBlockRepository(db))
+		v2Handler.SetTagRepository(gnurepo.NewTagRepository(db))
 
 		// XP: DI into V2Handler (set after expRepo is created below)
 

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -3,6 +3,7 @@ package v2
 import (
 	"fmt"
 	"log"
+	"math"
 	"net/http"
 	"slices"
 	"strconv"
@@ -608,7 +609,9 @@ func (h *V2Handler) DeletePost(c *gin.Context) {
 	// 태그 로그 삭제 (삭제된 글의 태그가 검색에 잔존하지 않도록)
 	if h.tagRepo != nil {
 		boTable := fmt.Sprintf("g5_write_%s", slug)
-		_ = h.tagRepo.DeletePostTags(boTable, int(id)) //nolint:errcheck
+		if id <= math.MaxInt32 {
+			_ = h.tagRepo.DeletePostTags(boTable, int(id)) //nolint:errcheck
+		}
 	}
 
 	common.V2Success(c, gin.H{"message": "삭제 완료"})

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -34,6 +34,7 @@ type V2Handler struct {
 	gnuPointWriteRepo v2repo.GnuboardPointWriteRepository
 	pointConfigRepo   v2repo.PointConfigRepository
 	blockRepo         v2repo.BlockRepository
+	tagRepo           gnurepo.TagRepository
 }
 
 // NewV2Handler creates a new V2Handler
@@ -96,6 +97,11 @@ func (h *V2Handler) SetPointConfigRepository(repo v2repo.PointConfigRepository) 
 // SetBlockRepository sets the block repository for filtering blocked users
 func (h *V2Handler) SetBlockRepository(repo v2repo.BlockRepository) {
 	h.blockRepo = repo
+}
+
+// SetTagRepository sets the tag repository for tag cleanup on post deletion
+func (h *V2Handler) SetTagRepository(repo gnurepo.TagRepository) {
+	h.tagRepo = repo
 }
 
 // getBlockedUserIDs returns blocked user IDs (as uint64) for the given mb_id
@@ -598,6 +604,13 @@ func (h *V2Handler) DeletePost(c *gin.Context) {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시글 삭제 실패", err)
 		return
 	}
+
+	// 태그 로그 삭제 (삭제된 글의 태그가 검색에 잔존하지 않도록)
+	if h.tagRepo != nil {
+		boTable := fmt.Sprintf("g5_write_%s", slug)
+		_ = h.tagRepo.DeletePostTags(boTable, int(id)) //nolint:errcheck
+	}
+
 	common.V2Success(c, gin.H{"message": "삭제 완료"})
 }
 

--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -34,8 +34,8 @@ type XPConfig struct {
 	WriteXP        int  `json:"write_xp"`        // XP granted per post (default: 100)
 	CommentXP      int  `json:"comment_xp"`      // XP granted per comment (default: 50)
 	LoginEnabled   bool `json:"login_enabled"`   // Enable login XP (default: true)
-	WriteEnabled   bool `json:"write_enabled"`   // Enable write XP (default: false)
-	CommentEnabled bool `json:"comment_enabled"` // Enable comment XP (default: false)
+	WriteEnabled   bool `json:"write_enabled"`   // Enable write XP (default: true)
+	CommentEnabled bool `json:"comment_enabled"` // Enable comment XP (default: true)
 	XPBasePoint    int  `json:"xp_base_point"`   // Base XP per level step (default: 1000, nariya xp_point)
 	XPRate         int  `json:"xp_rate"`         // Level growth rate (default: 2, nariya xp_rate)
 	MaxLevel       int  `json:"max_level"`       // Maximum level cap (default: 5000, nariya xp_max)
@@ -48,8 +48,8 @@ func DefaultXPConfig() *XPConfig {
 		WriteXP:        100,
 		CommentXP:      50,
 		LoginEnabled:   true,
-		WriteEnabled:   false,
-		CommentEnabled: false,
+		WriteEnabled:   true,
+		CommentEnabled: true,
 		XPBasePoint:    1000,
 		XPRate:         2,
 		MaxLevel:       5000,


### PR DESCRIPTION
## Summary
- **#9082**: `DefaultXPConfig()`에서 `WriteEnabled`, `CommentEnabled`가 `false`여서 글 작성/댓글 시 XP 미지급 → `true`로 변경
- **#9150**: `DeletePost` 시 `tagRepo.DeletePostTags()` 호출하여 삭제된 글의 태그 로그 정리

## Test plan
- [ ] dev에서 글 작성 후 `g5_na_xp` 테이블에 XP 로그 생성 확인
- [ ] dev에서 글 삭제 후 `g5_na_tag_log`에서 해당 태그 레코드 삭제 확인