### PR TITLE
댓글 삭제 시 comment_count 차감

### DIFF
--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -1043,6 +1043,12 @@ func (h *V2Handler) DeleteComment(c *gin.Context) {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "댓글 삭제 실패", err)
 		return
 	}
+
+	// 원글의 comment_count 차감
+	if comment.PostID > 0 {
+		h.postRepo.DecrementCommentCount(comment.PostID)
+	}
+
 	common.V2Success(c, gin.H{"message": "삭제 완료"})
 }
 

--- a/internal/repository/v2/post_repo.go
+++ b/internal/repository/v2/post_repo.go
@@ -23,6 +23,7 @@ type PostRepository interface {
 	Restore(id uint64) error
 	PermanentDelete(id uint64) error
 	IncrementViewCount(id uint64) error
+	DecrementCommentCount(id uint64)
 	Count() (int64, error)
 	CountSince(since time.Time) (int64, error)
 }
@@ -193,6 +194,12 @@ func (r *postRepository) Delete(id uint64) error {
 func (r *postRepository) IncrementViewCount(id uint64) error {
 	return r.db.Model(&v2.V2Post{}).Where("id = ?", id).
 		UpdateColumn("view_count", gorm.Expr("view_count + 1")).Error
+}
+
+// DecrementCommentCount decreases the comment_count of a post by 1 (floor 0)
+func (r *postRepository) DecrementCommentCount(id uint64) {
+	r.db.Model(&v2.V2Post{}).Where("id = ? AND comment_count > 0", id).
+		UpdateColumn("comment_count", gorm.Expr("comment_count - 1")) //nolint:errcheck
 }
 
 func (r *postRepository) Count() (int64, error) {


### PR DESCRIPTION
## Summary
- **#8888**: 댓글 soft delete 후 원글의 `comment_count`를 차감하지 않아 삭제된 댓글도 카운트에 포함되던 문제 수정
- `PostRepository.DecrementCommentCount()` 추가 (`comment_count > 0` 체크로 음수 방지)
- `DeleteComment` 핸들러에서 삭제 후 호출

## Test plan
- [ ] 댓글 삭제 후 게시글의 댓글 수가 1 감소하는지
- [ ] 댓글이 0개인 글에서 삭제 시 음수가 되지 않는지