### PR TITLE
게시판별 XP 설정 지원

### DIFF
--- a/internal/domain/gnuboard/board.go
+++ b/internal/domain/gnuboard/board.go
@@ -26,6 +26,8 @@ type G5Board struct {
 	BoUseSearch     int    `gorm:"column:bo_use_search" json:"bo_use_search"`
 	BoWritePoint    int    `gorm:"column:bo_write_point" json:"bo_write_point"`
 	BoCommentPoint  int    `gorm:"column:bo_comment_point" json:"bo_comment_point"`
+	BoWriteXP       int    `gorm:"column:bo_write_xp;default:100" json:"bo_write_xp"`
+	BoCommentXP     int    `gorm:"column:bo_comment_xp;default:50" json:"bo_comment_xp"`
 	BoReadPoint     int    `gorm:"column:bo_read_point" json:"bo_read_point"`
 	BoDownloadPoint int    `gorm:"column:bo_download_point" json:"bo_download_point"`
 	BoUseGood       int    `gorm:"column:bo_use_good" json:"bo_use_good"`
@@ -71,6 +73,8 @@ type BoardResponse struct {
 	CategoryList  string `json:"category_list"`
 	WritePoint    int    `json:"write_point"`
 	CommentPoint  int    `json:"comment_point"`
+	WriteXP       int    `json:"write_xp"`
+	CommentXP     int    `json:"comment_xp"`
 	ReadPoint     int    `json:"read_point"`
 	DownloadPoint int    `json:"download_point"`
 	UseGood       bool   `json:"use_good"`
@@ -100,6 +104,8 @@ type AdminBoardResponse struct {
 	DownloadLevel int    `json:"download_level"`
 	WritePoint    int    `json:"write_point"`
 	CommentPoint  int    `json:"comment_point"`
+	WriteXP       int    `json:"write_xp"`
+	CommentXP     int    `json:"comment_xp"`
 	ReadPoint     int    `json:"read_point"`
 	DownloadPoint int    `json:"download_point"`
 	UseCategory   int    `json:"use_category"`
@@ -137,6 +143,8 @@ func (b *G5Board) ToAdminResponse() AdminBoardResponse {
 		DownloadLevel: b.BoDownloadLevel,
 		WritePoint:    b.BoWritePoint,
 		CommentPoint:  b.BoCommentPoint,
+		WriteXP:       b.BoWriteXP,
+		CommentXP:     b.BoCommentXP,
 		ReadPoint:     b.BoReadPoint,
 		DownloadPoint: b.BoDownloadPoint,
 		UseCategory:   b.BoUseCategory,
@@ -175,6 +183,8 @@ func (b *G5Board) ToResponse() BoardResponse {
 		CategoryList:  b.BoCategoryList,
 		WritePoint:    b.BoWritePoint,
 		CommentPoint:  b.BoCommentPoint,
+		WriteXP:       b.BoWriteXP,
+		CommentXP:     b.BoCommentXP,
 		ReadPoint:     b.BoReadPoint,
 		DownloadPoint: b.BoDownloadPoint,
 		UseGood:       b.BoUseGood == 1,

--- a/internal/domain/v2/models.go
+++ b/internal/domain/v2/models.go
@@ -46,6 +46,8 @@ type V2Board struct {
 	// 포인트 설정 (양수=지급, 음수=차감)
 	WritePoint    int       `gorm:"column:write_point;default:0" json:"write_point"`
 	CommentPoint  int       `gorm:"column:comment_point;default:0" json:"comment_point"`
+	WriteXP       int       `gorm:"column:write_xp;default:100" json:"write_xp"`
+	CommentXP     int       `gorm:"column:comment_xp;default:50" json:"comment_xp"`
 	DownloadPoint int       `gorm:"column:download_point;default:0" json:"download_point"`
 	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
 	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -453,11 +453,12 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 		}
 	}
 
-	// 경험치 부여 (비동기, best-effort)
+	// 경험치 부여 (비동기, best-effort) — 게시판별 XP 사용
 	if h.expRepo != nil {
 		mbID := middleware.GetUserID(c)
 		tableName := fmt.Sprintf("v2_posts_%s", slug)
 		wrID := fmt.Sprintf("%d", post.ID)
+		boardWriteXP := board.WriteXP
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -465,10 +466,17 @@ func (h *V2Handler) CreatePost(c *gin.Context) {
 				}
 			}()
 			xpConfig, err := h.expRepo.GetXPConfig()
-			if err != nil || xpConfig == nil || !xpConfig.WriteEnabled || xpConfig.WriteXP <= 0 {
+			if err != nil || xpConfig == nil || !xpConfig.WriteEnabled {
 				return
 			}
-			result, err := h.expRepo.AddExp(mbID, xpConfig.WriteXP, "글쓰기", tableName, wrID, "@write")
+			xpAmount := boardWriteXP
+			if xpAmount <= 0 {
+				xpAmount = xpConfig.WriteXP // 게시판 설정 없으면 전역 기본값
+			}
+			if xpAmount <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpAmount, "글쓰기", tableName, wrID, "@write")
 			if err != nil {
 				log.Printf("[xp] write XP grant failed for %s: %v", mbID, err)
 				return
@@ -937,11 +945,12 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 		go h.createCommentNotification(slug, postID, comment, mbID, authorName)
 	}
 
-	// 경험치 부여 (비동기, best-effort)
+	// 경험치 부여 (비동기, best-effort) — 게시판별 XP 사용
 	// 30일 이전 글에 달린 댓글은 XP 미부여 (스팸 방지)
 	if h.expRepo != nil && !isOldPost {
 		tableName := fmt.Sprintf("v2_comments_%s", slug)
 		wrID := fmt.Sprintf("%d", comment.ID)
+		boardCommentXP := board.CommentXP
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -949,10 +958,17 @@ func (h *V2Handler) CreateComment(c *gin.Context) {
 				}
 			}()
 			xpConfig, err := h.expRepo.GetXPConfig()
-			if err != nil || xpConfig == nil || !xpConfig.CommentEnabled || xpConfig.CommentXP <= 0 {
+			if err != nil || xpConfig == nil || !xpConfig.CommentEnabled {
 				return
 			}
-			result, err := h.expRepo.AddExp(mbID, xpConfig.CommentXP, "댓글 작성", tableName, wrID, "@comment")
+			xpAmount := boardCommentXP
+			if xpAmount <= 0 {
+				xpAmount = xpConfig.CommentXP
+			}
+			if xpAmount <= 0 {
+				return
+			}
+			result, err := h.expRepo.AddExp(mbID, xpAmount, "댓글 작성", tableName, wrID, "@comment")
 			if err != nil {
 				log.Printf("[xp] comment XP grant failed for %s: %v", mbID, err)
 				return

--- a/tests/integration/v2_api_test.go
+++ b/tests/integration/v2_api_test.go
@@ -69,6 +69,7 @@ func (s *V2APISuite) SetupSuite() {
 			comment_level INTEGER DEFAULT 1, upload_level INTEGER DEFAULT 1,
 			download_level INTEGER DEFAULT 1,
 			write_point INTEGER DEFAULT 0, comment_point INTEGER DEFAULT 0,
+			write_xp INTEGER DEFAULT 100, comment_xp INTEGER DEFAULT 50,
 			download_point INTEGER DEFAULT 0,
 			created_at DATETIME, updated_at DATETIME)`,
 		`CREATE TABLE IF NOT EXISTS v2_posts (


### PR DESCRIPTION
## Summary
- `g5_board`, `v2_boards` 테이블에 `bo_write_xp`, `bo_comment_xp` 컬럼 추가 (기본값 100/50)
- Board 도메인 모델(gnuboard + v2) 및 DTO에 XP 필드 반영
- `CreatePost`, `CreateComment` 핸들러에서 전역 XP 대신 게시판별 XP 사용
- 게시판 XP가 0이면 전역 기본값(`xp_config`)으로 fallback

## DB Migration
```sql
ALTER TABLE g5_board ADD COLUMN bo_write_xp INT NOT NULL DEFAULT 100 AFTER bo_comment_point, ADD COLUMN bo_comment_xp INT NOT NULL DEFAULT 50 AFTER bo_write_xp;
ALTER TABLE v2_boards ADD COLUMN write_xp INT NOT NULL DEFAULT 100 AFTER comment_point, ADD COLUMN comment_xp INT NOT NULL DEFAULT 50 AFTER write_xp;
```

## Test plan
- [ ] 글 작성 시 해당 게시판의 `bo_write_xp` 값만큼 XP 부여
- [ ] 댓글 작성 시 해당 게시판의 `bo_comment_xp` 값만큼 XP 부여
- [ ] XP가 0인 게시판에서는 전역 기본값 사용