### PR TITLE
fix: 징계 로그 중복 생성 방지 (cron 레이스 컨디션 수정)

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -155,6 +155,17 @@ func processReportGroup(db *gorm.DB, group *singoReportGroup, now time.Time) err
 	isBulk := len(items) > 1
 
 	return db.Transaction(func(tx *gorm.DB) error {
+		// 레이스 컨디션 방지: 트랜잭션 안에서 미처리 건 재확인 (FOR UPDATE 잠금)
+		var unprocessedCount int64
+		tx.Raw(`
+			SELECT COUNT(*) FROM g5_na_singo
+			WHERE target_mb_id = ? AND admin_approved = 1 AND processed = 0
+			FOR UPDATE
+		`, targetMbID).Scan(&unprocessedCount)
+		if unprocessedCount == 0 {
+			return nil // 이미 다른 실행에서 처리됨
+		}
+
 		// 2-1. 징계 로그 게시글 작성
 		var wrID int
 		if isMergedDiscipline {
@@ -320,7 +331,7 @@ func createDisciplineLogPost(
 ) (int, error) {
 	// 다음 wr_id 조회
 	var maxWrID int
-	tx.Raw("SELECT COALESCE(MAX(wr_id), 0) FROM g5_write_disciplinelog").Scan(&maxWrID)
+	tx.Raw("SELECT COALESCE(MAX(wr_id), 0) FROM g5_write_disciplinelog FOR UPDATE").Scan(&maxWrID)
 	wrID := maxWrID + 1
 
 	// penalty_type 변환


### PR DESCRIPTION
## Summary
- cron이 승인된 신고를 처리할 때 동일 신고에 대해 징계 로그가 중복 생성되는 레이스 컨디션 수정
- `processReportGroup` 트랜잭션 시작 직후 `SELECT ... FOR UPDATE`로 미처리 건 재확인하여 이미 처리된 경우 스킵
- `createDisciplineLogPost`의 `MAX(wr_id)` 조회에 `FOR UPDATE` 잠금 추가하여 동시 INSERT 시 wr_id 충돌 방지

## 원인
- 그룹 조회(SELECT)가 트랜잭션 밖에서 실행되고, 실제 처리(INSERT/UPDATE)는 트랜잭션 안에서 실행
- 같은 신고가 두 번 처리되어 discipline_log_id 2개가 1초 차이로 생성됨

## Test plan
- [ ] `go build ./...` 빌드 확인
- [ ] 승인된 신고가 있는 상태에서 cron 두 번 연속 호출 시 징계로그 1건만 생성되는지 확인