### PR TITLE
fix: verify-canary 게이트에 build skipped 조건 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -262,6 +262,7 @@ jobs:
 
   verify-canary:
     needs: [resolve-release, build, deploy-canary]
+    if: always() && needs.resolve-release.result == 'success' && needs.deploy-canary.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## 변경 사항

`verify-canary` job에 `if` 조건 추가:

```yaml
if: always() && needs.resolve-release.result == 'success' && needs.deploy-canary.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
```

## 배경

기존 SHA 프로모션(`release_mode: promote`) 시 `build` job이 skipped되면 `verify-canary`가 실행되지 않아 배포 파이프라인이 중단되는 문제가 있었습니다.

이 조건을 추가하면 build가 skipped인 경우에도 resolve-release와 deploy-canary가 성공했다면 verify-canary가 정상 진행됩니다.

## 수정 파일
- `.github/workflows/deploy.yml` (1줄 추가)