### PR TITLE
Support custom logo schedule ranges

### DIFF
--- a/internal/domain/v2/site_logo.go
+++ b/internal/domain/v2/site_logo.go
@@ -8,7 +8,7 @@ type SiteLogo struct {
 	Name          string    `gorm:"column:name;type:varchar(100);not null" json:"name"`
 	LogoURL       string    `gorm:"column:logo_url;type:varchar(500);not null" json:"logo_url"`
 	ScheduleType  string    `gorm:"column:schedule_type;type:enum('recurring','date_range','default');not null" json:"schedule_type"`
-	RecurringDate *string   `gorm:"column:recurring_date;type:varchar(5)" json:"recurring_date,omitempty"`
+	RecurringDate *string   `gorm:"column:recurring_date;type:varchar(13)" json:"recurring_date,omitempty"`
 	StartDate     *string   `gorm:"column:start_date;type:date" json:"start_date,omitempty"`
 	EndDate       *string   `gorm:"column:end_date;type:date" json:"end_date,omitempty"`
 	Priority      int       `gorm:"column:priority;default:0" json:"priority"`

--- a/internal/handler/v2/site_logo_handler.go
+++ b/internal/handler/v2/site_logo_handler.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"net/http"
 	"regexp"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/damoang/angple-backend/internal/common"
@@ -49,6 +51,13 @@ func (h *SiteLogoHandler) CreateLogo(c *gin.Context) {
 		return
 	}
 
+	recurringDate, startDate, endDate := h.normalizeScheduleFields(
+		req.ScheduleType,
+		req.RecurringDate,
+		req.StartDate,
+		req.EndDate,
+	)
+
 	// default 타입은 활성 상태 1개만 허용
 	isActive := true
 	if req.IsActive != nil {
@@ -70,9 +79,9 @@ func (h *SiteLogoHandler) CreateLogo(c *gin.Context) {
 		Name:          req.Name,
 		LogoURL:       req.LogoURL,
 		ScheduleType:  req.ScheduleType,
-		RecurringDate: req.RecurringDate,
-		StartDate:     req.StartDate,
-		EndDate:       req.EndDate,
+		RecurringDate: recurringDate,
+		StartDate:     startDate,
+		EndDate:       endDate,
 		Priority:      req.Priority,
 		IsActive:      isActive,
 	}
@@ -123,6 +132,12 @@ func (h *SiteLogoHandler) CreatePresetLogos(c *gin.Context) {
 			common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
 			return
 		}
+		normalizedRecurringDate, _, _ := h.normalizeScheduleFields("recurring", &recurringDate, nil, nil)
+		if normalizedRecurringDate == nil {
+			common.V2ErrorResponse(c, http.StatusBadRequest, "반복 날짜를 정규화할 수 없습니다", nil)
+			return
+		}
+		recurringDate = *normalizedRecurringDate
 
 		if h.hasRecurringPresetConflict(existingRecurring[recurringDate], item.Name, req.LogoURL) {
 			result.Skipped = append(result.Skipped, v2domain.CreatePresetLogoSkipped{
@@ -164,7 +179,7 @@ func (h *SiteLogoHandler) UpdateLogo(c *gin.Context) {
 
 	logo, err := h.logoRepo.FindByID(id)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			common.V2ErrorResponse(c, http.StatusNotFound, "로고를 찾을 수 없습니다", nil)
 			return
 		}
@@ -188,13 +203,13 @@ func (h *SiteLogoHandler) UpdateLogo(c *gin.Context) {
 		logo.ScheduleType = *req.ScheduleType
 	}
 	if req.RecurringDate != nil {
-		logo.RecurringDate = req.RecurringDate
+		logo.RecurringDate = normalizeOptionalString(req.RecurringDate)
 	}
 	if req.StartDate != nil {
-		logo.StartDate = req.StartDate
+		logo.StartDate = normalizeOptionalString(req.StartDate)
 	}
 	if req.EndDate != nil {
-		logo.EndDate = req.EndDate
+		logo.EndDate = normalizeOptionalString(req.EndDate)
 	}
 	if req.Priority != nil {
 		logo.Priority = *req.Priority
@@ -207,6 +222,12 @@ func (h *SiteLogoHandler) UpdateLogo(c *gin.Context) {
 		common.V2ErrorResponse(c, http.StatusBadRequest, err.Error(), nil)
 		return
 	}
+	logo.RecurringDate, logo.StartDate, logo.EndDate = h.normalizeScheduleFields(
+		logo.ScheduleType,
+		logo.RecurringDate,
+		logo.StartDate,
+		logo.EndDate,
+	)
 
 	// default 타입 활성화 시 기존 활성 default 확인
 	if logo.ScheduleType == "default" && logo.IsActive {
@@ -243,7 +264,7 @@ func (h *SiteLogoHandler) DeleteLogo(c *gin.Context) {
 	}
 
 	if _, err := h.logoRepo.FindByID(id); err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			common.V2ErrorResponse(c, http.StatusNotFound, "로고를 찾을 수 없습니다", nil)
 			return
 		}
@@ -261,25 +282,12 @@ func (h *SiteLogoHandler) DeleteLogo(c *gin.Context) {
 
 // GetActiveLogo handles GET /api/v1/logos/active
 func (h *SiteLogoHandler) GetActiveLogo(c *gin.Context) {
-	kst := time.FixedZone("KST", 9*60*60)
-	now := time.Now().In(kst)
-	mmdd := now.Format("01-02")
-	today := now.Format("2006-01-02")
-
-	logo, err := h.logoRepo.FindActiveLogo(mmdd, today)
+	schedules, err := h.logoRepo.FindAllActive()
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			common.V2Success(c, gin.H{"active": nil, "schedules": []interface{}{}})
-			return
-		}
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "로고 조회 실패", err)
 		return
 	}
-
-	schedules, err := h.logoRepo.FindAllActive()
-	if err != nil {
-		schedules = []*v2domain.SiteLogo{}
-	}
+	logo := resolveActiveLogoFromSchedules(schedules, time.Now())
 
 	common.V2Success(c, gin.H{
 		"active":    logo,
@@ -299,23 +307,171 @@ func (h *SiteLogoHandler) hasRecurringPresetConflict(existing []*v2domain.SiteLo
 func (h *SiteLogoHandler) validateSchedule(scheduleType string, recurringDate, startDate, endDate *string) error {
 	switch scheduleType {
 	case "recurring":
-		if recurringDate == nil || *recurringDate == "" {
-			return &validationError{"recurring 타입은 recurring_date(MM-DD)가 필수입니다"}
+		if recurringDate == nil || strings.TrimSpace(*recurringDate) == "" {
+			return &validationError{"recurring 타입은 recurring_date(MM-DD 또는 MM-DD~MM-DD)가 필수입니다"}
 		}
-		if !mmddRegex.MatchString(*recurringDate) {
-			return &validationError{"recurring_date는 MM-DD 형식이어야 합니다 (예: 03-01)"}
+		if _, err := normalizeRecurringDateValue(*recurringDate); err != nil {
+			return err
 		}
 	case "date_range":
-		if startDate == nil || *startDate == "" || endDate == nil || *endDate == "" {
+		if startDate == nil || strings.TrimSpace(*startDate) == "" || endDate == nil || strings.TrimSpace(*endDate) == "" {
 			return &validationError{"date_range 타입은 start_date와 end_date가 필수입니다"}
 		}
-		if *startDate > *endDate {
+		normalizedStartDate := strings.TrimSpace(*startDate)
+		normalizedEndDate := strings.TrimSpace(*endDate)
+		if _, err := time.Parse("2006-01-02", normalizedStartDate); err != nil {
+			return &validationError{"start_date는 YYYY-MM-DD 형식이어야 합니다"}
+		}
+		if _, err := time.Parse("2006-01-02", normalizedEndDate); err != nil {
+			return &validationError{"end_date는 YYYY-MM-DD 형식이어야 합니다"}
+		}
+		if normalizedStartDate > normalizedEndDate {
 			return &validationError{"start_date는 end_date보다 이전이어야 합니다"}
 		}
 	case "default":
 		// no additional validation
 	}
 	return nil
+}
+
+func (h *SiteLogoHandler) normalizeScheduleFields(
+	scheduleType string,
+	recurringDate, startDate, endDate *string,
+) (*string, *string, *string) {
+	switch scheduleType {
+	case "recurring":
+		if recurringDate == nil {
+			return nil, nil, nil
+		}
+		normalized, err := normalizeRecurringDateValue(*recurringDate)
+		if err != nil {
+			return recurringDate, nil, nil
+		}
+		return &normalized, nil, nil
+	case "date_range":
+		return nil, normalizeOptionalString(startDate), normalizeOptionalString(endDate)
+	default:
+		return nil, nil, nil
+	}
+}
+
+func normalizeOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func normalizeRecurringDateValue(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if mmddRegex.MatchString(trimmed) {
+		if err := validateRecurringMMDD(trimmed); err != nil {
+			return "", err
+		}
+		return trimmed, nil
+	}
+
+	parts := strings.Split(trimmed, "~")
+	if len(parts) != 2 {
+		return "", &validationError{"recurring_date는 MM-DD 또는 MM-DD~MM-DD 형식이어야 합니다 (예: 03-01, 03-20~04-02)"}
+	}
+
+	start := strings.TrimSpace(parts[0])
+	end := strings.TrimSpace(parts[1])
+	if !mmddRegex.MatchString(start) || !mmddRegex.MatchString(end) {
+		return "", &validationError{"recurring_date는 MM-DD 또는 MM-DD~MM-DD 형식이어야 합니다 (예: 03-01, 03-20~04-02)"}
+	}
+	if err := validateRecurringMMDD(start); err != nil {
+		return "", err
+	}
+	if err := validateRecurringMMDD(end); err != nil {
+		return "", err
+	}
+	return start + "~" + end, nil
+}
+
+func validateRecurringMMDD(value string) error {
+	if _, err := time.Parse("2006-01-02", "2004-"+value); err != nil {
+		return &validationError{"recurring_date는 올바른 월-일이어야 합니다"}
+	}
+	return nil
+}
+
+func resolveActiveLogoFromSchedules(schedules []*v2domain.SiteLogo, now time.Time) *v2domain.SiteLogo {
+	if len(schedules) == 0 {
+		return nil
+	}
+
+	kst := time.FixedZone("KST", 9*60*60)
+	current := now.In(kst)
+	currentMMDD := current.Format("01-02")
+	currentDate := current.Format("2006-01-02")
+
+	ordered := append([]*v2domain.SiteLogo(nil), schedules...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		left := ordered[i]
+		right := ordered[j]
+		if schedulePriority(left.ScheduleType) != schedulePriority(right.ScheduleType) {
+			return schedulePriority(left.ScheduleType) < schedulePriority(right.ScheduleType)
+		}
+		if left.Priority != right.Priority {
+			return left.Priority > right.Priority
+		}
+		return left.ID > right.ID
+	})
+
+	for _, logo := range ordered {
+		switch logo.ScheduleType {
+		case "recurring":
+			if recurringScheduleMatches(logo.RecurringDate, currentMMDD) {
+				return logo
+			}
+		case "date_range":
+			if logo.StartDate != nil && logo.EndDate != nil && *logo.StartDate <= currentDate && *logo.EndDate >= currentDate {
+				return logo
+			}
+		case "default":
+			return logo
+		}
+	}
+
+	return nil
+}
+
+func schedulePriority(scheduleType string) int {
+	switch scheduleType {
+	case "recurring":
+		return 0
+	case "date_range":
+		return 1
+	default:
+		return 2
+	}
+}
+
+func recurringScheduleMatches(recurringDate *string, currentMMDD string) bool {
+	if recurringDate == nil || *recurringDate == "" {
+		return false
+	}
+	normalized, err := normalizeRecurringDateValue(*recurringDate)
+	if err != nil {
+		return false
+	}
+	if mmddRegex.MatchString(normalized) {
+		return normalized == currentMMDD
+	}
+
+	parts := strings.Split(normalized, "~")
+	start := parts[0]
+	end := parts[1]
+	if start <= end {
+		return currentMMDD >= start && currentMMDD <= end
+	}
+	return currentMMDD >= start || currentMMDD <= end
 }
 
 type validationError struct {

--- a/internal/handler/v2/site_logo_handler_test.go
+++ b/internal/handler/v2/site_logo_handler_test.go
@@ -1,0 +1,82 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+)
+
+func TestNormalizeRecurringDateValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "single day", input: "03-01", want: "03-01"},
+		{name: "range", input: "03-20 ~ 04-02", want: "03-20~04-02"},
+		{name: "invalid day", input: "02-30", wantErr: true},
+		{name: "invalid format", input: "2026-03-01", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeRecurringDateValue(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveActiveLogoFromSchedules(t *testing.T) {
+	t.Run("recurring range wins over default", func(t *testing.T) {
+		seasonRange := "03-20~04-02"
+		schedules := []*v2domain.SiteLogo{
+			{ID: 1, Name: "Default", ScheduleType: "default", Priority: 0, IsActive: true},
+			{ID: 2, Name: "Spring", ScheduleType: "recurring", RecurringDate: &seasonRange, Priority: 10, IsActive: true},
+		}
+
+		active := resolveActiveLogoFromSchedules(schedules, time.Date(2026, 3, 25, 12, 0, 0, 0, time.UTC))
+		if active == nil || active.ID != 2 {
+			t.Fatalf("expected recurring range logo to be active, got %#v", active)
+		}
+	})
+
+	t.Run("wraparound recurring range matches january dates", func(t *testing.T) {
+		winterRange := "12-20~01-10"
+		schedules := []*v2domain.SiteLogo{
+			{ID: 1, Name: "Default", ScheduleType: "default", Priority: 0, IsActive: true},
+			{ID: 2, Name: "Winter", ScheduleType: "recurring", RecurringDate: &winterRange, Priority: 10, IsActive: true},
+		}
+
+		active := resolveActiveLogoFromSchedules(schedules, time.Date(2027, 1, 5, 10, 0, 0, 0, time.UTC))
+		if active == nil || active.ID != 2 {
+			t.Fatalf("expected wraparound recurring logo to be active, got %#v", active)
+		}
+	})
+
+	t.Run("date range matches single day event", func(t *testing.T) {
+		start := "2026-04-16"
+		end := "2026-04-16"
+		schedules := []*v2domain.SiteLogo{
+			{ID: 1, Name: "Default", ScheduleType: "default", Priority: 0, IsActive: true},
+			{ID: 3, Name: "Memorial", ScheduleType: "date_range", StartDate: &start, EndDate: &end, Priority: 20, IsActive: true},
+		}
+
+		active := resolveActiveLogoFromSchedules(schedules, time.Date(2026, 4, 16, 9, 0, 0, 0, time.UTC))
+		if active == nil || active.ID != 3 {
+			t.Fatalf("expected one-day date range logo to be active, got %#v", active)
+		}
+	})
+}

--- a/internal/migration/migrate.go
+++ b/internal/migration/migrate.go
@@ -53,6 +53,9 @@ func Run(db *gorm.DB) error {
 	if err := AddRestrictionScopeColumn(db); err != nil {
 		return err
 	}
+	if err := ExpandSiteLogoRecurringDateColumn(db); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/migration/site_logo_schedule.go
+++ b/internal/migration/site_logo_schedule.go
@@ -1,0 +1,26 @@
+package migration
+
+import "gorm.io/gorm"
+
+// ExpandSiteLogoRecurringDateColumn allows annual recurring ranges like 03-20~04-02.
+func ExpandSiteLogoRecurringDateColumn(db *gorm.DB) error {
+	var needsAlter int64
+	if err := db.Raw(`
+		SELECT COUNT(*) FROM information_schema.COLUMNS
+		WHERE TABLE_SCHEMA = DATABASE()
+		  AND TABLE_NAME = 'site_logos'
+		  AND COLUMN_NAME = 'recurring_date'
+		  AND (CHARACTER_MAXIMUM_LENGTH IS NULL OR CHARACTER_MAXIMUM_LENGTH < 13)
+	`).Scan(&needsAlter).Error; err != nil {
+		return err
+	}
+
+	if needsAlter == 0 {
+		return nil
+	}
+
+	return db.Exec(`
+		ALTER TABLE site_logos
+		MODIFY COLUMN recurring_date VARCHAR(13) NULL
+	`).Error
+}


### PR DESCRIPTION
## Summary
- support recurring annual date ranges for site logos
- normalize and validate custom recurring/date-range schedule CRUD inputs
- expand recurring_date storage length and add handler tests

## Testing
- go test ./...