### PR TITLE
fix: 린트 에러 수정 (goconst, gocyclo)

### DIFF
--- a/internal/middleware/rate_limit.go
+++ b/internal/middleware/rate_limit.go
@@ -27,7 +27,7 @@ func init() {
 
 // isInternalIP checks if the IP is localhost or K8s internal
 func isInternalIP(ip string) bool {
-	if ip == "127.0.0.1" || ip == "::1" {
+	if ip == localhostIPv4 || ip == localhostIPv6 {
 		return true
 	}
 	parsed := net.ParseIP(ip)

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -344,6 +344,7 @@ func (w *WriteAfterWorker) handleAffiliateEvent(event gnudomain.WriteAfterEvent)
 	return nil
 }
 
+//nolint:gocyclo // Notification routing for post creation is branching-heavy business logic and stays explicit on purpose.
 func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 	if w.cacheService != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
## Summary
- `rate_limit.go`: `"127.0.0.1"` 문자열 → 기존 상수 `localhostIPv4` 사용 (goconst)
- `write_after_worker.go`: `handlePostCreated` nolint:gocyclo 추가 (handleCommentCreated와 동일 패턴)

## Test plan
- [ ] CI lint 통과 확인