### PR TITLE
Normalize legacy media URLs to CDN

### DIFF
--- a/internal/handler/v1/transform.go
+++ b/internal/handler/v1/transform.go
@@ -154,6 +154,10 @@ func normalizeMediaContent(raw string, _ ...string) string {
 
 func rewriteLegacyCDNHost(raw, cdnURL string) string {
 	replacements := [][2]string{
+		{"https://damoang.net/data/", cdnURL + "/data/"},
+		{"http://damoang.net/data/", cdnURL + "/data/"},
+		{"https://www.damoang.net/data/", cdnURL + "/data/"},
+		{"http://www.damoang.net/data/", cdnURL + "/data/"},
 		{"https://s3.damoang.net/data/", cdnURL + "/data/"},
 		{"http://s3.damoang.net/data/", cdnURL + "/data/"},
 		{"https://cdn.damoang.net/data/", cdnURL + "/data/"},


### PR DESCRIPTION
## Summary
- rewrite damoang.net and www.damoang.net legacy /data URLs to CDN_URL
- keep backend media URL normalization aligned with the web CDN path rules

## Verification
- go test ./internal/handler/v1/...