### PR TITLE
feat: 게시판 summary 응답 범위 확대

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1679,8 +1679,6 @@ func main() {
 		v1Boards.GET("/:slug/posts", func(c *gin.Context) {
 			slug := c.Param("slug")
 			ctx := c.Request.Context()
-			summaryMode := c.Query("summary") == "1" && (slug == "free" || slug == "hello")
-
 			page, err2 := strconv.Atoi(c.DefaultQuery("page", "1"))
 			if err2 != nil || page < 1 {
 				page = 1
@@ -1699,6 +1697,7 @@ func main() {
 			sortBy := c.Query("sort")       // search sort: "relevance" or default (date)
 			category := c.Query("category") // category filter (ca_name)
 			isSearching := sfl != "" && stx != ""
+			summaryMode := c.Query("summary") == "1" && !isSearching
 
 			// Get blocked user IDs (skip for admins)
 			var blockedIDs []string


### PR DESCRIPTION
## 변경 내용
- 게시판 목록 API의 summary=1 경량 응답을 free/hello 한정에서 검색이 아닌 전체 게시판 목록으로 확대

## 응답 크기 비교
- /api/v1/boards/{board}/posts?summary=1: free/hello 한정 -> 검색이 아닌 전체 게시판 목록
- 목록 응답에서 상세 전용 필드와 파일 썸네일 enrichment를 건너뛰는 경로를 더 넓게 사용

## 검증
- go build ./...