### PR TITLE
feat: 위키 백링크 시스템 + 편집 요약 필드

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -730,6 +730,11 @@ func main() {
 		// 리비전
 		v2RevisionRepo := v2repo.NewRevisionRepository(db)
 
+		// 위키 백링크
+		wikiBacklinkRepo := v2repo.NewWikiBacklinkRepository(db)
+		_ = wikiBacklinkRepo.AutoMigrate()
+		wikiHandler := v2handler.NewWikiHandler(wikiBacklinkRepo)
+
 		// 권한 체크
 		permChecker := middleware.NewDBBoardPermissionChecker(v2BoardRepo)
 		v2Handler := v2handler.NewV2Handler(v2UserRepo, v2PostRepo, v2CommentRepo, v2BoardRepo, permChecker)
@@ -745,6 +750,10 @@ func main() {
 
 		v2routes.Setup(router, v2Handler, jwtManager, permChecker, db)
 		v2routes.SetupAdminPosts(router, v2Handler, jwtManager)
+
+		// 위키 API 라우트
+		v2Api := router.Group("/api/v2")
+		v2Api.GET("/posts/:id/backlinks", wikiHandler.GetBacklinks)
 
 		// MyPage routes (point, exp, posts, comments, stats)
 		v2ExpRepo := v2repo.NewExpRepository(db)
@@ -2555,6 +2564,33 @@ func main() {
 				})
 			}
 
+			// 위키 백링크 갱신
+			if wikiBacklinkRepo != nil {
+				go func(postID int, content string) {
+					links := v2svc.ParseWikiLinks(content)
+					if len(links) > 0 {
+						var backlinks []*v2domain.WikiBacklink
+						for _, link := range links {
+							// 대상 문서를 제목으로 검색
+							var targetID uint64
+							db.Table("v2_posts").
+								Select("id").
+								Where("title = ? AND deleted_at IS NULL", link.Text).
+								Limit(1).
+								Scan(&targetID)
+
+							backlinks = append(backlinks, &v2domain.WikiBacklink{
+								SourcePostID: safeIntToUint64(postID),
+								TargetPostID: targetID,
+								LinkText:     link.Text,
+								IsBroken:     targetID == 0,
+							})
+						}
+						_ = wikiBacklinkRepo.ReplaceBacklinks(safeIntToUint64(postID), backlinks)
+					}
+				}(post.WrID, post.WrContent)
+			}
+
 			// 태그 저장 (g5_na_tag / g5_na_tag_log)
 			if len(req.Tags) > 0 {
 				if err := gnuTagRepo.SetPostTags(slug, post.WrID, req.Tags, mbID); err != nil {
@@ -3067,6 +3103,29 @@ func main() {
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 수정 실패"})
 				return
+			}
+
+			// 위키 백링크 갱신 (수정 시)
+			if wikiBacklinkRepo != nil && req.Content != nil {
+				go func(pid int, content string) {
+					links := v2svc.ParseWikiLinks(content)
+					var backlinks []*v2domain.WikiBacklink
+					for _, link := range links {
+						var targetID uint64
+						db.Table("v2_posts").
+							Select("id").
+							Where("title = ? AND deleted_at IS NULL", link.Text).
+							Limit(1).
+							Scan(&targetID)
+						backlinks = append(backlinks, &v2domain.WikiBacklink{
+							SourcePostID: safeIntToUint64(pid),
+							TargetPostID: targetID,
+							LinkText:     link.Text,
+							IsBroken:     targetID == 0,
+						})
+					}
+					_ = wikiBacklinkRepo.ReplaceBacklinks(safeIntToUint64(pid), backlinks)
+				}(postID, *req.Content)
 			}
 
 			// 태그 업데이트 (tags 필드가 전송된 경우)

--- a/internal/domain/v2/revision.go
+++ b/internal/domain/v2/revision.go
@@ -12,6 +12,7 @@ type V2ContentRevision struct {
 	Content      string    `gorm:"column:content;type:mediumtext" json:"content"`
 	EditedBy     uint64    `gorm:"column:edited_by" json:"edited_by"`
 	EditedByName string    `gorm:"column:edited_by_name;type:varchar(100)" json:"edited_by_name"`
+	EditSummary  string    `gorm:"column:edit_summary;type:varchar(200)" json:"edit_summary"`
 	EditedAt     time.Time `gorm:"column:edited_at;autoCreateTime" json:"edited_at"`
 }
 

--- a/internal/domain/v2/wiki.go
+++ b/internal/domain/v2/wiki.go
@@ -1,0 +1,15 @@
+package v2
+
+import "time"
+
+// WikiBacklink 위키 문서 간 [[링크]] 역참조 관계
+type WikiBacklink struct {
+	ID           uint64    `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	SourcePostID uint64    `gorm:"column:source_post_id;index:idx_wiki_bl_source;uniqueIndex:idx_wiki_bl_unique" json:"source_post_id"`
+	TargetPostID uint64    `gorm:"column:target_post_id;index:idx_wiki_bl_target;uniqueIndex:idx_wiki_bl_unique" json:"target_post_id"`
+	LinkText     string    `gorm:"column:link_text;type:varchar(255)" json:"link_text"`
+	IsBroken     bool      `gorm:"column:is_broken;default:false" json:"is_broken"`
+	CreatedAt    time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+}
+
+func (WikiBacklink) TableName() string { return "wiki_backlinks" }

--- a/internal/handler/v2/wiki_handler.go
+++ b/internal/handler/v2/wiki_handler.go
@@ -1,0 +1,40 @@
+package v2
+
+import (
+	"net/http"
+	"strconv"
+
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/gin-gonic/gin"
+)
+
+// WikiHandler 위키 관련 API 핸들러
+type WikiHandler struct {
+	backlinkRepo *v2repo.WikiBacklinkRepository
+}
+
+// NewWikiHandler 위키 핸들러 생성
+func NewWikiHandler(backlinkRepo *v2repo.WikiBacklinkRepository) *WikiHandler {
+	return &WikiHandler{backlinkRepo: backlinkRepo}
+}
+
+// GetBacklinks 특정 게시글을 참조하는 백링크 목록 조회
+// GET /api/v2/posts/:id/backlinks
+func (h *WikiHandler) GetBacklinks(c *gin.Context) {
+	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid post ID"})
+		return
+	}
+
+	backlinks, err := h.backlinkRepo.FindByTargetID(postID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch backlinks"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    backlinks,
+	})
+}

--- a/internal/repository/v2/wiki_backlink_repo.go
+++ b/internal/repository/v2/wiki_backlink_repo.go
@@ -1,0 +1,61 @@
+package v2
+
+import (
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+type WikiBacklinkRepository struct {
+	db *gorm.DB
+}
+
+func NewWikiBacklinkRepository(db *gorm.DB) *WikiBacklinkRepository {
+	return &WikiBacklinkRepository{db: db}
+}
+
+// AutoMigrate wiki_backlinks 테이블 생성
+func (r *WikiBacklinkRepository) AutoMigrate() error {
+	return r.db.AutoMigrate(&v2.WikiBacklink{})
+}
+
+// Create 백링크 생성
+func (r *WikiBacklinkRepository) Create(backlink *v2.WikiBacklink) error {
+	return r.db.Create(backlink).Error
+}
+
+// DeleteBySourceID 특정 문서의 모든 백링크 삭제 (재계산 전)
+func (r *WikiBacklinkRepository) DeleteBySourceID(sourcePostID uint64) error {
+	return r.db.Where("source_post_id = ?", sourcePostID).Delete(&v2.WikiBacklink{}).Error
+}
+
+// FindByTargetID 특정 문서를 참조하는 모든 백링크 조회
+func (r *WikiBacklinkRepository) FindByTargetID(targetPostID uint64) ([]*v2.WikiBacklink, error) {
+	var backlinks []*v2.WikiBacklink
+	err := r.db.Where("target_post_id = ?", targetPostID).
+		Order("created_at DESC").
+		Find(&backlinks).Error
+	return backlinks, err
+}
+
+// FindBySourceID 특정 문서에서 참조하는 모든 백링크 조회
+func (r *WikiBacklinkRepository) FindBySourceID(sourcePostID uint64) ([]*v2.WikiBacklink, error) {
+	var backlinks []*v2.WikiBacklink
+	err := r.db.Where("source_post_id = ?", sourcePostID).
+		Find(&backlinks).Error
+	return backlinks, err
+}
+
+// ReplaceBacklinks 특정 문서의 백링크를 전부 교체 (삭제 후 일괄 삽입)
+func (r *WikiBacklinkRepository) ReplaceBacklinks(sourcePostID uint64, backlinks []*v2.WikiBacklink) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// 기존 백링크 삭제
+		if err := tx.Where("source_post_id = ?", sourcePostID).Delete(&v2.WikiBacklink{}).Error; err != nil {
+			return err
+		}
+		// 새 백링크 삽입
+		if len(backlinks) > 0 {
+			return tx.Create(&backlinks).Error
+		}
+		return nil
+	})
+}

--- a/internal/service/v2/wiki_link_parser.go
+++ b/internal/service/v2/wiki_link_parser.go
@@ -1,0 +1,30 @@
+package v2
+
+import "regexp"
+
+var wikiLinkPattern = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+
+// WikiLinkRef 파싱된 위키 링크 참조
+type WikiLinkRef struct {
+	Text string // [[문서명]]에서 "문서명" 부분
+}
+
+// ParseWikiLinks HTML 콘텐츠에서 [[위키링크]]를 추출합니다.
+func ParseWikiLinks(content string) []WikiLinkRef {
+	matches := wikiLinkPattern.FindAllStringSubmatch(content, -1)
+	seen := make(map[string]bool)
+	var refs []WikiLinkRef
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		text := match[1]
+		if seen[text] {
+			continue
+		}
+		seen[text] = true
+		refs = append(refs, WikiLinkRef{Text: text})
+	}
+	return refs
+}


### PR DESCRIPTION
## Summary
- WikiBacklink 도메인 모델 (source ↔ target 역참조)
- WikiBacklinkRepository (CRUD + ReplaceBacklinks 트랜잭션)
- WikiHandler (GET /api/v2/posts/:id/backlinks)
- ParseWikiLinks: [[위키링크]] 정규식 파서
- V2ContentRevision에 edit_summary 칼럼 추가
- post 생성/수정 시 [[링크]] 파싱 → wiki_backlinks 자동 갱신

## Test plan
- [ ] wiki_backlinks 테이블 자동 생성 확인
- [ ] GET /api/v2/posts/:id/backlinks 정상 응답
- [ ] 게시글 작성 시 [[문서명]] 포함 → 백링크 테이블 갱신
- [ ] go build 성공