### PR TITLE
fix: 영구정지 유저 전체 쓰기 기능 차단

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1185,7 +1185,7 @@ func main() {
 		})
 
 		// POST /api/v1/members/:id/memo — 메모 생성/수정 (upsert)
-		memberMemoGroup.POST("", func(c *gin.Context) {
+		memberMemoGroup.POST("", middleware.BanCheck(db), func(c *gin.Context) {
 			currentUserID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 
@@ -1246,7 +1246,7 @@ func main() {
 		})
 
 		// PUT /api/v1/members/:id/memo — 메모 수정 (POST와 동일한 upsert)
-		memberMemoGroup.PUT("", func(c *gin.Context) {
+		memberMemoGroup.PUT("", middleware.BanCheck(db), func(c *gin.Context) {
 			currentUserID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 
@@ -1571,7 +1571,7 @@ func main() {
 
 		// v1 block routes
 		v1Members := router.Group("/api/v1/members")
-		v1Members.POST("/:id/block", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Members.POST("/:id/block", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			userID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 			if userID == targetID {
@@ -1596,7 +1596,7 @@ func main() {
 			}
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "차단 완료"})
 		})
-		v1Members.DELETE("/:id/block", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Members.DELETE("/:id/block", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			userID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 			if err := blockRepo.Delete(userID, targetID); err != nil {
@@ -3876,7 +3876,7 @@ func main() {
 		}
 		displaySettingsHandler := v2handler.NewDisplaySettingsHandler(v2BoardRepo, v2DisplaySettingsRepo)
 		v1Boards.GET("/:slug/display-settings", middleware.CacheWithTTL(redisClient, 5*time.Minute), displaySettingsHandler.GetDisplaySettings)
-		v1Boards.PUT("/:slug/display-settings", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.PUT("/:slug/display-settings", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			displaySettingsHandler.UpdateDisplaySettings(c)
 			// 변경 시 캐시 무효화
 			if c.Writer.Status() == http.StatusOK {
@@ -4038,7 +4038,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/move - Move post to another board (admin only)
-		v1Boards.POST("/:slug/posts/:id/move", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/move", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			srcBoard := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -4168,7 +4168,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/report - Report a post
-		v1Boards.POST("/:slug/posts/:id/report", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -4239,7 +4239,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/comments/:comment_id/report - Report a comment
-		v1Boards.POST("/:slug/posts/:id/comments/:comment_id/report", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/comments/:comment_id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -4787,7 +4787,7 @@ func main() {
 		v2MessageRepo := v2repo.NewMessageRepository(db)
 		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager, db)
 		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager, db)
-		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
+		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager, db)
 		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
 		v2routes.SetupFavorite(router, v2handler.NewFavoriteHandler(db), jwtManager)
 
@@ -4832,7 +4832,7 @@ func main() {
 			}
 			c.JSON(http.StatusOK, gin.H{"reviews": reviews})
 		})
-		tradeReviews.POST("", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
+		tradeReviews.POST("", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
 			var req struct {
 				BoardID  string `json:"board_id"`
 				PostID   int    `json:"post_id"`
@@ -4982,7 +4982,7 @@ func main() {
 
 			// TODO: UploadRateLimitConfig 구현 후 활성화
 			// uploadRateLimit := middleware.RateLimit(redisClient, middleware.UploadRateLimitConfig())
-			media := router.Group("/api/v2/media", middleware.JWTAuth(jwtManager))
+			media := router.Group("/api/v2/media", middleware.JWTAuth(jwtManager), middleware.BanCheck(db))
 			media.POST("/images", mediaHandler.UploadImage)
 			media.POST("/attachments", mediaHandler.UploadAttachment)
 			media.POST("/videos", mediaHandler.UploadVideo)
@@ -4991,7 +4991,7 @@ func main() {
 			// Member profile image
 			memberSvc := service.NewMemberService(s3Client, gnuMemberRepo)
 			memberHandler := handler.NewMemberHandler(memberSvc)
-			memberImage := router.Group("/api/v2/members/me", middleware.JWTAuth(jwtManager))
+			memberImage := router.Group("/api/v2/members/me", middleware.JWTAuth(jwtManager), middleware.BanCheck(db))
 			memberImage.POST("/image", memberHandler.UploadImage)
 			memberImage.DELETE("/image", memberHandler.DeleteImage)
 		}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -142,7 +142,7 @@ func SetupScrap(router *gin.Engine, h *v2handler.ScrapHandler, jwtManager *jwt.M
 
 	posts := router.Group("/api/v2/posts")
 	posts.POST("/:id/scrap", auth, banCheck, h.AddScrap)
-	posts.DELETE("/:id/scrap", auth, h.RemoveScrap)
+	posts.DELETE("/:id/scrap", auth, banCheck, h.RemoveScrap)
 
 	me := router.Group("/api/v2/me", auth)
 	me.GET("/scraps", h.ListScraps)
@@ -156,19 +156,25 @@ func SetupMemo(router *gin.Engine, h *v2handler.MemoHandler, jwtManager *jwt.Man
 	memo := router.Group("/api/v2/members/:id/memo", auth)
 	memo.GET("", h.GetMemo)
 	memo.POST("", banCheck, h.CreateMemo)
-	memo.PUT("", h.UpdateMemo)
-	memo.DELETE("", h.DeleteMemo)
+	memo.PUT("", banCheck, h.UpdateMemo)
+	memo.DELETE("", banCheck, h.DeleteMemo)
 	memo.GET("/all", middleware.RequireAdmin(), h.GetAllMemos)
 }
 
 // SetupBlock configures v2 block routes
-func SetupBlock(router *gin.Engine, h *v2handler.BlockHandler, jwtManager *jwt.Manager) {
+func SetupBlock(router *gin.Engine, h *v2handler.BlockHandler, jwtManager *jwt.Manager, gnuDB ...*gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)
 
 	// Block/Unblock member
 	members := router.Group("/api/v2/members")
-	members.POST("/:id/block", auth, h.BlockMember)
-	members.DELETE("/:id/block", auth, h.UnblockMember)
+	if len(gnuDB) > 0 && gnuDB[0] != nil {
+		banCheck := middleware.BanCheck(gnuDB[0])
+		members.POST("/:id/block", auth, banCheck, h.BlockMember)
+		members.DELETE("/:id/block", auth, banCheck, h.UnblockMember)
+	} else {
+		members.POST("/:id/block", auth, h.BlockMember)
+		members.DELETE("/:id/block", auth, h.UnblockMember)
+	}
 
 	// List blocked members
 	me := router.Group("/api/v2/members/me", auth)
@@ -188,7 +194,11 @@ func SetupMessage(router *gin.Engine, h *v2handler.MessageHandler, jwtManager *j
 	messages.GET("/inbox", h.GetInbox)
 	messages.GET("/sent", h.GetSent)
 	messages.GET("/:id", h.GetMessage)
-	messages.DELETE("/:id", h.DeleteMessage)
+	if len(gnuDB) > 0 && gnuDB[0] != nil {
+		messages.DELETE("/:id", middleware.BanCheck(gnuDB[0]), h.DeleteMessage)
+	} else {
+		messages.DELETE("/:id", h.DeleteMessage)
+	}
 }
 
 // SetupInstall configures v2 installation routes


### PR DESCRIPTION
## Summary
영구정지(mb_intercept_date='99991231') 유저가 신고, 차단, 메모, 업로드 등 쓰기 동작 가능했던 보안 갭 수정

### 추가된 BanCheck (v1)
- 차단/차단해제, 메모 생성/수정, 게시판 설정 변경
- 게시글 이동, 신고(게시글/댓글), 거래 리뷰
- 미디어 업로드(이미지/첨부/동영상), 프로필 이미지

### 추가된 BanCheck (v2)
- 스크랩 삭제, 메모 수정/삭제, 차단/차단해제, 쪽지 삭제

### 허용 (예외)
- 본인 글 삭제 (soft-delete)
- 본인 댓글 삭제
- 알림 관리
- 모든 읽기

## Test plan
- [ ] 영구정지 유저: 신고 → 403
- [ ] 영구정지 유저: 차단/메모 → 403
- [ ] 영구정지 유저: 파일 업로드 → 403
- [ ] 영구정지 유저: 본인 글 삭제 → 허용
- [ ] 일반 유저: 모든 기능 정상