### PR TITLE
fix: block/unblock에서 BanCheck 제거 (긴급)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1571,7 +1571,7 @@ func main() {
 
 		// v1 block routes
 		v1Members := router.Group("/api/v1/members")
-		v1Members.POST("/:id/block", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
+		v1Members.POST("/:id/block", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
 			userID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 			if userID == targetID {
@@ -1596,7 +1596,7 @@ func main() {
 			}
 			c.JSON(http.StatusOK, gin.H{"success": true, "message": "차단 완료"})
 		})
-		v1Members.DELETE("/:id/block", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
+		v1Members.DELETE("/:id/block", middleware.JWTAuth(jwtManager), func(c *gin.Context) {
 			userID := middleware.GetUserID(c)
 			targetID := c.Param("id")
 			if err := blockRepo.Delete(userID, targetID); err != nil {
@@ -4787,7 +4787,7 @@ func main() {
 		v2MessageRepo := v2repo.NewMessageRepository(db)
 		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager, db)
 		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager, db)
-		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager, db)
+		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
 		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
 		v2routes.SetupFavorite(router, v2handler.NewFavoriteHandler(db), jwtManager)
 

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -165,16 +165,10 @@ func SetupMemo(router *gin.Engine, h *v2handler.MemoHandler, jwtManager *jwt.Man
 func SetupBlock(router *gin.Engine, h *v2handler.BlockHandler, jwtManager *jwt.Manager, gnuDB ...*gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)
 
-	// Block/Unblock member
+	// Block/Unblock member — BanCheck 제외 (차단은 쓰기 제한과 무관)
 	members := router.Group("/api/v2/members")
-	if len(gnuDB) > 0 && gnuDB[0] != nil {
-		banCheck := middleware.BanCheck(gnuDB[0])
-		members.POST("/:id/block", auth, banCheck, h.BlockMember)
-		members.DELETE("/:id/block", auth, banCheck, h.UnblockMember)
-	} else {
-		members.POST("/:id/block", auth, h.BlockMember)
-		members.DELETE("/:id/block", auth, h.UnblockMember)
-	}
+	members.POST("/:id/block", auth, h.BlockMember)
+	members.DELETE("/:id/block", auth, h.UnblockMember)
 
 	// List blocked members
 	me := router.Group("/api/v2/members/me", auth)


### PR DESCRIPTION
## Summary
BanCheck 미들웨어가 block/unblock 라우트에 잘못 추가되어 차단 기능이 깨짐.
차단은 쓰기 제한과 무관한 기능이므로 BanCheck 제거.

Fixes #11740

## Test plan
- [ ] 일반 유저: 차단/차단해제 정상 동작
- [ ] 차단한 회원 댓글이 안 보이는지