### PR TITLE
fix: BanCheck 비게시판 라우트 올바르게 처리

### DIFF
--- a/internal/middleware/ban_check.go
+++ b/internal/middleware/ban_check.go
@@ -117,7 +117,7 @@ func BanCheckScoped(gnuDB *gorm.DB, scope string) gin.HandlerFunc {
 
 		// User is currently banned — only promotion and claim boards are allowed
 		slug := c.Param("slug")
-		if slug == promotionBoardSlug || slug == claimBoardSlug {
+		if slug != "" && (slug == promotionBoardSlug || slug == claimBoardSlug) {
 			c.Next()
 			return
 		}


### PR DESCRIPTION
## Summary
BanCheck 미들웨어의 promotion/claim 예외 처리에서 slug가 빈 문자열일 때 조건 추가.

비게시판 라우트(block, memo, media 등)에서 slug가 없으면 예외 없이 제재 유저를 차단.
기존에는 빈 문자열이 `""!= "promotion"` → 차단은 되지만 의도가 불명확했음.

`slug != ""` 조건 추가로 명확하게 처리.

Fixes #11740

## Test plan
- [ ] 제재 유저: block/memo/media → 403
- [ ] 일반 유저: block/memo/media → 정상
- [ ] 제재 유저: promotion/claim 글쓰기 → 허용