### PR TITLE
feat(v2): add /api/v2/devices endpoint for FCM token registration

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4780,15 +4780,17 @@ func main() {
 		adminSettingsHandler := v2handler.NewAdminSettingsHandler(db)
 		v2routes.SetupAdminSettings(router, adminSettingsHandler, jwtManager)
 
-		// v2 Scrap, Memo, Block, Message
+		// v2 Scrap, Memo, Block, Message, Devices (FCM)
 		v2ScrapRepo := v2repo.NewScrapRepository(db)
 		v2MemoRepo := v2repo.NewMemoRepository(db)
 		v2BlockRepo := v2repo.NewBlockRepository(db)
 		v2MessageRepo := v2repo.NewMessageRepository(db)
+		v2DeviceRepo := v2repo.NewDeviceRepository(db)
 		v2routes.SetupScrap(router, v2handler.NewScrapHandler(v2ScrapRepo), jwtManager, db)
 		v2routes.SetupMemo(router, v2handler.NewMemoHandler(v2MemoRepo), jwtManager, db)
 		v2routes.SetupBlock(router, v2handler.NewBlockHandler(v2BlockRepo, cacheService), jwtManager)
 		v2routes.SetupMessage(router, v2handler.NewMessageHandler(v2MessageRepo), jwtManager, db)
+		v2routes.SetupDevices(router, v2handler.NewDeviceHandler(v2DeviceRepo), jwtManager)
 		v2routes.SetupFavorite(router, v2handler.NewFavoriteHandler(db), jwtManager)
 
 		// v1 message routes (uses g5_memo table directly)

--- a/internal/domain/v2/device.go
+++ b/internal/domain/v2/device.go
@@ -1,0 +1,16 @@
+package v2
+
+import "time"
+
+// V2Device represents a registered push notification device for a user.
+type V2Device struct {
+	ID         uint64    `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
+	UserID     uint64    `gorm:"column:user_id;not null;index" json:"user_id"`
+	Token      string    `gorm:"column:token;type:varchar(255);not null;uniqueIndex" json:"token"`
+	Platform   string    `gorm:"column:platform;type:varchar(16);not null" json:"platform"`
+	AppVersion string    `gorm:"column:app_version;type:varchar(32)" json:"app_version,omitempty"`
+	CreatedAt  time.Time `gorm:"column:created_at;autoCreateTime" json:"created_at"`
+	UpdatedAt  time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updated_at"`
+}
+
+func (V2Device) TableName() string { return "v2_devices" }

--- a/internal/handler/v2/device_handler.go
+++ b/internal/handler/v2/device_handler.go
@@ -1,0 +1,93 @@
+package v2
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	v2domain "github.com/damoang/angple-backend/internal/domain/v2"
+	"github.com/damoang/angple-backend/internal/middleware"
+	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	"github.com/gin-gonic/gin"
+)
+
+// DeviceHandler handles v2 device (FCM token) endpoints
+type DeviceHandler struct {
+	deviceRepo v2repo.DeviceRepository
+}
+
+// NewDeviceHandler creates a new DeviceHandler
+func NewDeviceHandler(deviceRepo v2repo.DeviceRepository) *DeviceHandler {
+	return &DeviceHandler{deviceRepo: deviceRepo}
+}
+
+// RegisterDevice handles POST /api/v2/devices
+// Registers (or updates) the FCM token for the authenticated user.
+func (h *DeviceHandler) RegisterDevice(c *gin.Context) {
+	userID, err := strconv.ParseUint(middleware.GetUserID(c), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", err)
+		return
+	}
+
+	var req struct {
+		Token      string `json:"token" binding:"required"`
+		Platform   string `json:"platform" binding:"required,oneof=ios android"`
+		AppVersion string `json:"app_version"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "요청 형식이 올바르지 않습니다", err)
+		return
+	}
+
+	device := &v2domain.V2Device{
+		UserID:     userID,
+		Token:      req.Token,
+		Platform:   req.Platform,
+		AppVersion: req.AppVersion,
+	}
+	if err := h.deviceRepo.Upsert(device); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "디바이스 등록 실패", err)
+		return
+	}
+	common.V2Created(c, device)
+}
+
+// UnregisterDevice handles DELETE /api/v2/devices/:token
+// Removes the FCM token (called on logout).
+func (h *DeviceHandler) UnregisterDevice(c *gin.Context) {
+	userID, err := strconv.ParseUint(middleware.GetUserID(c), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", err)
+		return
+	}
+
+	token := c.Param("token")
+	if token == "" {
+		common.V2ErrorResponse(c, http.StatusBadRequest, "token이 필요합니다", nil)
+		return
+	}
+
+	if err := h.deviceRepo.DeleteByUserAndToken(userID, token); err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "디바이스 삭제 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"message": "디바이스 삭제 완료"})
+}
+
+// ListDevices handles GET /api/v2/devices
+// Returns devices owned by the authenticated user (debug/UX use).
+func (h *DeviceHandler) ListDevices(c *gin.Context) {
+	userID, err := strconv.ParseUint(middleware.GetUserID(c), 10, 64)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", err)
+		return
+	}
+
+	devices, err := h.deviceRepo.ListByUser(userID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "디바이스 조회 실패", err)
+		return
+	}
+	common.V2Success(c, devices)
+}

--- a/internal/repository/v2/device_repo.go
+++ b/internal/repository/v2/device_repo.go
@@ -1,0 +1,52 @@
+package v2
+
+import (
+	"errors"
+
+	v2 "github.com/damoang/angple-backend/internal/domain/v2"
+	"gorm.io/gorm"
+)
+
+// DeviceRepository v2 device (FCM token) data access
+type DeviceRepository interface {
+	Upsert(device *v2.V2Device) error
+	DeleteByUserAndToken(userID uint64, token string) error
+	ListByUser(userID uint64) ([]v2.V2Device, error)
+}
+
+type deviceRepository struct {
+	db *gorm.DB
+}
+
+// NewDeviceRepository creates a new v2 DeviceRepository
+func NewDeviceRepository(db *gorm.DB) DeviceRepository {
+	return &deviceRepository{db: db}
+}
+
+// Upsert inserts a new device or updates the existing row that owns the token.
+// Tokens are globally unique, so a token re-used across users is reassigned to
+// the new user (covers logout-on-A then login-on-B on the same device).
+func (r *deviceRepository) Upsert(device *v2.V2Device) error {
+	var existing v2.V2Device
+	result := r.db.Where("token = ?", device.Token).First(&existing)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return r.db.Create(device).Error
+	}
+	if result.Error != nil {
+		return result.Error
+	}
+	existing.UserID = device.UserID
+	existing.Platform = device.Platform
+	existing.AppVersion = device.AppVersion
+	return r.db.Save(&existing).Error
+}
+
+func (r *deviceRepository) DeleteByUserAndToken(userID uint64, token string) error {
+	return r.db.Where("user_id = ? AND token = ?", userID, token).Delete(&v2.V2Device{}).Error
+}
+
+func (r *deviceRepository) ListByUser(userID uint64) ([]v2.V2Device, error) {
+	var devices []v2.V2Device
+	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&devices).Error
+	return devices, err
+}

--- a/internal/routes/v2/routes.go
+++ b/internal/routes/v2/routes.go
@@ -175,6 +175,16 @@ func SetupBlock(router *gin.Engine, h *v2handler.BlockHandler, jwtManager *jwt.M
 	me.GET("/blocks", h.ListBlocks)
 }
 
+// SetupDevices configures v2 device (FCM push token) routes
+func SetupDevices(router *gin.Engine, h *v2handler.DeviceHandler, jwtManager *jwt.Manager) {
+	auth := middleware.JWTAuth(jwtManager)
+
+	devices := router.Group("/api/v2/devices", auth)
+	devices.POST("", h.RegisterDevice)
+	devices.GET("", h.ListDevices)
+	devices.DELETE("/:token", h.UnregisterDevice)
+}
+
 // SetupMessage configures v2 message routes
 func SetupMessage(router *gin.Engine, h *v2handler.MessageHandler, jwtManager *jwt.Manager, gnuDB ...*gorm.DB) {
 	auth := middleware.JWTAuth(jwtManager)

--- a/migration/006_devices.down.sql
+++ b/migration/006_devices.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS v2_devices;

--- a/migration/006_devices.up.sql
+++ b/migration/006_devices.up.sql
@@ -1,0 +1,13 @@
+-- FCM 푸시 알림용 디바이스 토큰 저장 (다모앙 모바일 앱 v1.0)
+CREATE TABLE IF NOT EXISTS v2_devices (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT UNSIGNED NOT NULL,
+    token VARCHAR(255) NOT NULL,
+    platform VARCHAR(16) NOT NULL,
+    app_version VARCHAR(32) NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_token (token),
+    KEY idx_user_id (user_id),
+    KEY idx_platform (platform)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary

다모앙 모바일 앱 v1.0의 FCM 푸시 알림을 위해 디바이스 토큰 등록/해제 엔드포인트를 추가합니다.

- `POST /api/v2/devices` — 인증된 사용자의 FCM 토큰 등록 (Upsert)
- `DELETE /api/v2/devices/:token` — 로그아웃 시 토큰 해제
- `GET /api/v2/devices` — 본인 디바이스 목록 (디버그/UX용)

모두 JWT 인증 필요.

## 변경 사항

- migration `006_devices.up.sql` / `down.sql` — `v2_devices` 테이블
  - PK id, FK user_id (인덱스), token (UNIQUE), platform, app_version, timestamps
- domain `internal/domain/v2/device.go` — `V2Device` 구조체
- repository `internal/repository/v2/device_repo.go` — `DeviceRepository` 인터페이스 + GORM 구현
  - `Upsert`는 token 기준으로 행을 reassign합니다 — 같은 디바이스에서 A로 로그아웃 후 B로 로그인하면 B로 owner가 옮겨갑니다
- handler `internal/handler/v2/device_handler.go` — 3개 엔드포인트
- routes `internal/routes/v2/routes.go` — `SetupDevices` 함수
- `cmd/api/main.go` — 인스턴스화 + `SetupDevices` 등록

## API 스펙

\`\`\`http
POST /api/v2/devices
Authorization: Bearer <jwt>
Content-Type: application/json

{ "token": "...fcm token...", "platform": "ios", "app_version": "1.0.0" }
\`\`\`

응답 201:
\`\`\`json
{ "success": true, "data": { "id": 1, "user_id": 42, "token": "...", "platform": "ios", "app_version": "1.0.0", "created_at": "...", "updated_at": "..." } }
\`\`\`

## Test plan

- [ ] 로컬 dev 환경에서 마이그레이션 적용 (`make dev` 또는 재시작 시 자동)
- [ ] curl로 POST /api/v2/devices 200/201 응답 확인
- [ ] 동일 token 재등록 시 행 1개만 유지되는지 (Upsert)
- [ ] 다른 user가 같은 token 등록 시 owner가 reassign 되는지
- [ ] DELETE /api/v2/devices/:token 200 + DB 삭제 확인
- [ ] GET /api/v2/devices 본인 디바이스만 반환되는지
- [ ] 인증 없이 호출 시 401
- [ ] platform이 ios/android 외 값일 때 400