### PR TITLE
fix: mb_intercept_date varchar(8) 잘림 버그 (15명 영향)

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -454,7 +454,7 @@ func applyUserRestriction(tx *gorm.DB, targetMbID, disciplineType string, discip
 		if disciplineDays == 9999 {
 			restrictionEndDate = "99991231"
 		} else {
-			restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("2006-01-02 15:04:05")
+			restrictionEndDate = now.AddDate(0, 0, disciplineDays).Format("20060102")
 		}
 		if err := tx.Table("g5_member").Where("mb_id = ?", targetMbID).
 			Update("mb_intercept_date", restrictionEndDate).Error; err != nil {

--- a/internal/handler/admin_member_handler.go
+++ b/internal/handler/admin_member_handler.go
@@ -283,7 +283,7 @@ func (h *AdminMemberHandler) UpdateMember(c *gin.Context) {
 // BanMember handles POST /api/v1/admin/members/:id/ban
 func (h *AdminMemberHandler) BanMember(c *gin.Context) {
 	mbID := c.Param("mbId")
-	now := time.Now().Format("2006-01-02")
+	now := time.Now().Format("20060102")
 	if err := h.db.Model(&gnuboard.G5Member{}).Where("mb_id = ?", mbID).Update("mb_intercept_date", now).Error; err != nil {
 		common.V2ErrorResponse(c, http.StatusInternalServerError, "차단 실패", err)
 		return


### PR DESCRIPTION
## 심각 버그
report_process.go가 '2006-01-02 15:04:05' (19자)를 varchar(8)에 저장
→ '2026-04-'로 잘림 → 파싱 불가 → 영구 차단

## 수정
- report_process.go: `20060102` 형식 (8자)
- admin_member_handler.go: `20060102` 형식 (8자)

## 데이터 복구
15명 수동 복구 완료 (만료 8명 해제, 진행중 7명 올바른 날짜로)