### PR TITLE
fix: 쪽지 알림 필터 누락 + 중복 체크 개선 (#11827)

### DIFF
--- a/internal/repository/gnuboard/noti_repo.go
+++ b/internal/repository/gnuboard/noti_repo.go
@@ -125,11 +125,11 @@ func (r *notiRepository) Create(noti *Notification) error {
 	return r.db.Create(noti).Error
 }
 
-// Exists checks if a duplicate notification already exists
+// Exists checks if a duplicate unread notification already exists
 func (r *notiRepository) Exists(mbID, boTable string, wrID int, fromCase, relMbID string) (bool, error) {
 	var count int64
 	err := r.db.Model(&Notification{}).
-		Where("mb_id = ? AND bo_table = ? AND wr_id = ? AND ph_from_case = ? AND rel_mb_id = ?", mbID, boTable, wrID, fromCase, relMbID).
+		Where("mb_id = ? AND bo_table = ? AND wr_id = ? AND ph_from_case = ? AND rel_mb_id = ? AND ph_readed = 'N'", mbID, boTable, wrID, fromCase, relMbID).
 		Count(&count).Error
 	return count > 0, err
 }
@@ -146,6 +146,8 @@ func (r *notiRepository) GetGroupedNotifications(mbID string, page, limit int, f
 		fromCaseFilter = "AND ph_from_case = 'good'"
 	case "mention":
 		fromCaseFilter = "AND ph_from_case = 'mention'"
+	case "memo":
+		fromCaseFilter = "AND ph_from_case = 'memo'"
 	case "system":
 		fromCaseFilter = "AND ph_from_case IN ('write', 'inquire', 'answer')"
 	}


### PR DESCRIPTION
## Summary
- 알림 그룹 조회(GetGroupedNotifications)에 `memo` 필터 타입 추가 — 프론트에서 `type=memo` 필터링 가능
- `Exists` 중복 체크를 미읽음(`ph_readed='N'`)만 확인하도록 변경 — 읽은 알림이 있어도 새 쪽지 알림 생성 가능

## Test plan
- [ ] 쪽지 발송 → `g5_na_noti`에 `ph_from_case='memo'` 알림 생성 확인
- [ ] 같은 사람이 쪽지 2회 발송 → 첫 번째 읽은 후 두 번째도 알림 생성되는지 확인
- [ ] 알림 드롭다운에서 쪽지 알림이 Mail 아이콘 + 오렌지색으로 표시되는지 확인