### PR TITLE
fix: 검색 형태소 분리 방지 — phrase 매칭으로 변경 (#11791)

### DIFF
--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -178,7 +178,7 @@ func (s *SearchService) SearchPosts(ctx context.Context, keyword, boardID string
 			"multi_match": map[string]interface{}{
 				"query":  keyword,
 				"fields": []string{"title^3", "content", "author"},
-				"type":   "best_fields",
+				"type":   "phrase",
 			},
 		},
 	}
@@ -226,7 +226,7 @@ func (s *SearchService) SearchPosts(ctx context.Context, keyword, boardID string
 func (s *SearchService) SearchComments(ctx context.Context, keyword, boardID string, page, perPage int) (*es.SearchResponse, error) {
 	must := []map[string]interface{}{
 		{
-			"match": map[string]interface{}{
+			"match_phrase": map[string]interface{}{
 				"content": map[string]interface{}{
 					"query":    keyword,
 					"analyzer": "korean",


### PR DESCRIPTION
## Summary
- SearchPosts: `multi_match` type `best_fields` → `phrase`로 변경
- SearchComments: `match` → `match_phrase`로 변경
- nori_tokenizer가 "난가"를 "난"+"가"로 분리하여 "엄청난 가치"가 결과에 포함되던 문제 수정

## Test plan
- [ ] "난가" 검색 시 "엄청난 가치" 미포함
- [ ] "난가" 검색 시 실제 "난가" 포함 글은 정상 출력
- [ ] 일반 검색어 회귀 테스트 (예: "다모앙", "리뷰" 등)