### PR TITLE
fix: 징계 로그 API 메모 필드 제거

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -280,7 +280,6 @@ func (h *DisciplineLogHandler) GetList(c *gin.Context) {
 			PenaltyDateTo:   penaltyDateTo,
 			ViolationTypes:  data.SgTypes,
 			ViolationTitles: titles,
-			Memo:            data.Content,
 		})
 	}
 
@@ -345,7 +344,6 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		PenaltyDateTo:   penaltyDateTo,
 		ViolationTypes:  violations,
 		ReportedItems:   reportedItems,
-		Memo:            data.Content,
 		CreatedBy:       post.MbID,
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
 	}


### PR DESCRIPTION
징계 상세/목록 API에서 내부용 memo 필드를 응답에서 제거. AI가 잘못 참조한 메모 내용이 공개되는 문제 방지.