### PR TITLE
fix: 프로필 activity limit 20→50 (#11797)

### DIFF
--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -173,8 +173,8 @@ func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
 	if limit < 1 {
 		limit = 1
 	}
-	if limit > 20 {
-		limit = 20
+	if limit > 50 {
+		limit = 50
 	}
 
 	// 1. Try Redis cache (DB 0 queries on hit)


### PR DESCRIPTION
프로필 GetMemberActivity API limit max 20→50 확장. 배포: 금요일 새벽, canary.damoang.net 사전 확인.