### PR TITLE
fix(telemetry): OTLP gRPC WithInsecure() 적용 — trace 수집 복구

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
-	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/sqlite v1.6.0
@@ -121,6 +120,7 @@ require (
 	golang.org/x/tools v0.43.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -13,8 +13,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Init initializes OpenTelemetry tracing with OTLP gRPC exporter.
@@ -40,7 +38,7 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (shutdown fun
 
 	exporter, err := otlptracegrpc.New(ctx,
 		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		otlptracegrpc.WithInsecure(),
 		otlptracegrpc.WithTimeout(5*time.Second),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

PR #426 운영 flag ON 후 **trace 0건 수집** 문제 발견. gRPC exporter가 TLS를 시도하여 Collector에 미도달.

## 원인
\`WithDialOption(grpc.WithTransportCredentials(insecure.NewCredentials()))\` 은 OTLP SDK가 TLS를 비활성화하는 방식이 아님. 전용 \`WithInsecure()\` 옵션 필요.

## 증거
- OTel Collector 지표: \`otelcol_receiver_accepted_spans\` = 1 (과거 샘플 테스트 1건만)
- Backend pod: OTEL_ENABLED=true, DNS resolve OK, 하지만 Collector로 연결 못함
- Backend 에러 로그 무 → TCP/TLS handshake 사일런트 실패

## Fix
- \`otlptracegrpc.WithInsecure()\` 명시 옵션 사용
- \`grpc\`, \`grpc/credentials/insecure\` import 제거

## Test plan
- [x] \`make build-api\` 통과
- [ ] 배포 후 \`OTEL_ENABLED=true\` 재시도
- [ ] 2분 내 otelcol_receiver_accepted_spans 증가 확인
- [ ] otel.traces ClickHouse 에 ServiceName='damoang-api' 저장 확인
- [ ] Grafana api-overview 대시보드에 p95 latency 표시 확인

## Rollback
Feature flag OFF 유지 (기본값 OFF) → 이 PR 자체는 flag OFF일 땐 동작 변경 0.