### PR TITLE
fix(telemetry): OTel resource schema URL 충돌 해결

### DIFF
--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -45,14 +45,13 @@ func Init(ctx context.Context, serviceName, serviceVersion string) (shutdown fun
 		return nil, fmt.Errorf("otel exporter: %w", err)
 	}
 
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
 			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion(serviceVersion),
 			semconv.DeploymentEnvironment(envOr("DEPLOYMENT_ENV", "prd")),
 		),
+		resource.WithHost(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("otel resource: %w", err)


### PR DESCRIPTION
resource.Merge() schema 1.40 vs 1.26 충돌 → resource.New() 사용. 운영 검증 완료 (24 spans 수집 확인).