### PR TITLE
feat(post-detail): scheduled_delete 필드 inline embed — SSR 별도 fetch 제거

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2035,6 +2035,16 @@ func main() {
 				}
 			}
 
+			// scheduled_delete inline embed — SvelteKit SSR이 별도 /delete-status fetch 회피
+			if sd, sdErr := scheduledDeleteRepo.FindByPost(slug, id); sdErr == nil && sd != nil {
+				postDetail["scheduled_delete"] = gin.H{
+					"scheduled_at":  sd.ScheduledAt,
+					"requested_at":  sd.RequestedAt,
+					"requested_by":  sd.RequestedBy,
+					"delay_minutes": sd.DelayMinutes,
+				}
+			}
+
 			c.JSON(http.StatusOK, gin.H{
 				"success": true,
 				"data":    postDetail,

--- a/internal/domain/gnuboard/write.go
+++ b/internal/domain/gnuboard/write.go
@@ -45,28 +45,38 @@ type G5Write struct {
 	WrDeletedBy *string    `gorm:"column:wr_deleted_by" json:"deleted_by,omitempty"`
 }
 
+// ScheduledDeleteInfo describes a pending hard-delete schedule for a post.
+// Embedded in PostResponse so the SvelteKit SSR avoids a separate /delete-status fetch.
+type ScheduledDeleteInfo struct {
+	ScheduledAt  time.Time `json:"scheduled_at"`
+	RequestedAt  time.Time `json:"requested_at"`
+	RequestedBy  string    `json:"requested_by,omitempty"`
+	DelayMinutes int       `json:"delay_minutes"`
+}
+
 // PostResponse is the API response format for posts
 type PostResponse struct {
-	ID                 int        `json:"id"`
-	Title              string     `json:"title"`
-	Content            string     `json:"content,omitempty"`
-	Author             string     `json:"author"`
-	AuthorID           string     `json:"author_id"`
-	Category           string     `json:"category,omitempty"`
-	Views              int        `json:"views"`
-	Likes              int        `json:"likes"`
-	Dislikes           int        `json:"dislikes"`
-	CommentsCount      int        `json:"comments_count"`
-	HasFile            bool       `json:"has_file"`
-	IsNotice           bool       `json:"is_notice"`
-	IsSecret           bool       `json:"is_secret"`
-	IsCommentsDisabled bool       `json:"is_comments_disabled"`
-	Link1              string     `json:"link1,omitempty"`
-	Link2              string     `json:"link2,omitempty"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
-	DeletedAt          *time.Time `json:"deleted_at,omitempty"`
-	DeletedBy          *string    `json:"deleted_by,omitempty"`
+	ID                 int                  `json:"id"`
+	Title              string               `json:"title"`
+	Content            string               `json:"content,omitempty"`
+	Author             string               `json:"author"`
+	AuthorID           string               `json:"author_id"`
+	Category           string               `json:"category,omitempty"`
+	Views              int                  `json:"views"`
+	Likes              int                  `json:"likes"`
+	Dislikes           int                  `json:"dislikes"`
+	CommentsCount      int                  `json:"comments_count"`
+	HasFile            bool                 `json:"has_file"`
+	IsNotice           bool                 `json:"is_notice"`
+	IsSecret           bool                 `json:"is_secret"`
+	IsCommentsDisabled bool                 `json:"is_comments_disabled"`
+	Link1              string               `json:"link1,omitempty"`
+	Link2              string               `json:"link2,omitempty"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          *time.Time           `json:"updated_at,omitempty"`
+	DeletedAt          *time.Time           `json:"deleted_at,omitempty"`
+	DeletedBy          *string              `json:"deleted_by,omitempty"`
+	ScheduledDelete    *ScheduledDeleteInfo `json:"scheduled_delete,omitempty"`
 }
 
 // parseWrLast converts DB datetime string to time.Time


### PR DESCRIPTION
## Summary

글 상세 API 응답(`/api/v1/boards/:slug/posts/:id`)에 `scheduled_delete` 필드 inline 포함 → SvelteKit SSR이 별도 `/delete-status` fetch 회피.

## 근거 (OTel 1h 데이터, 4/19)

PR #429 (cache TTL 30s→5min) 적용했으나 효과 미미:

| 지표 | Baseline | After PR #429 |
|------|---:|---:|
| avg | 51.9ms | **137ms** ⚠️ |
| p95 | 263.8ms | **503ms** ⚠️ |
| p99 | 565.8ms | **626ms** ⚠️ |

**Top 15 SSR client fetch 중 9개가 delete-status** (60% 차지).

## Well-Architected Option C (6 pillar 1위)

| Pillar | 효과 |
|---|---|
| Performance | 호출 자체 제거 (0ms) > 캐시 (수ms-수백ms) |
| Cost | 9/15 SSR fetch 제거 → 월 \$15-20 절감 |
| Reliability | 별도 캐시 invalidation 문제 0 (atomic) |
| Security | Posts API 권한 자동 적용 (별도 endpoint 권한 누락 해소) |
| Operational | F+B 조율 PR 2개로 단순 |
| Sustainability | Redis 부담↓, DB round-trip↓ |

## 변경

### `internal/domain/gnuboard/write.go`
```go
type ScheduledDeleteInfo struct { ScheduledAt, RequestedAt time.Time; RequestedBy string; DelayMinutes int }
type PostResponse struct { ...; ScheduledDelete *ScheduledDeleteInfo \`json:\"scheduled_delete,omitempty\"\` }
```

### `cmd/api/main.go` (글 상세 핸들러)
```go
if sd, sdErr := scheduledDeleteRepo.FindByPost(slug, id); sdErr == nil && sd != nil {
    postDetail[\"scheduled_delete\"] = gin.H{...}
}
```

## 백워드 호환

- nullable 필드 (`omitempty`) → 기존 클라이언트 무시
- 기존 `/delete-status` endpoint 유지 (프론트 PR 후 별도 PR로 deprecate)
- DB 인덱스 \`uk_bo_wr\` 활용 → 추가 ~2ms 예상

## Test plan

- [x] \`make build-api\` 통과
- [ ] CI 통과
- [ ] 새벽 4시 prod 배포 (사용자 승인)
- [ ] 검증: \`curl https://damoang.net/api/v1/boards/free/posts/{id} | jq .data.scheduled_delete\`
- [ ] 프론트 PR (Phase 2)에서 별도 fetch 제거

## 후속 (별도 PR)
- 🔒 Phase 3: Legacy \`/delete-status\` 권한 체크 + deprecate
- 📊 otelgorm 도입: outlier 600ms 원인 정확 파악