### PR TITLE
fix(security): /delete-status 권한 체크 추가 + deprecation 마크

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3868,7 +3868,11 @@ func main() {
 		})
 
 		// GET /api/v1/boards/:slug/posts/:id/delete-status - Check scheduled delete status
-		v1Boards.GET("/:slug/posts/:id/delete-status", middleware.CacheWithTTL(redisClient, 5*time.Minute), func(c *gin.Context) {
+		// DEPRECATED: SvelteKit SSR이 더 이상 이 endpoint를 호출하지 않음 (PR #1243).
+		// Posts API 응답의 inline `scheduled_delete` 필드를 사용 (PR #430).
+		// 이 endpoint는 backward 호환을 위해 유지되며 ~2026-10에 제거 예정.
+		// 캐시 제거: 응답이 사용자 권한별로 다르므로 공유 캐시 사용 불가 (PII 보호).
+		v1Boards.GET("/:slug/posts/:id/delete-status", func(c *gin.Context) {
 			slug := c.Param("slug")
 			wrID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -3877,8 +3881,20 @@ func main() {
 			}
 
 			sd, err := scheduledDeleteRepo.FindByPost(slug, wrID)
-			if err != nil {
+			if err != nil || sd == nil {
 				c.JSON(http.StatusOK, gin.H{"success": true, "scheduled": false})
+				return
+			}
+
+			// 권한 체크: 예약 요청자 본인 또는 관리자만 상세 정보 노출
+			// 비본인은 boolean만 반환 (다른 유저의 삭제 예약 시점/요청자 PII 차단)
+			currentUserID := middleware.GetUserID(c)
+			currentUserLevel := middleware.GetUserLevel(c)
+			isRequester := currentUserID != "" && currentUserID == sd.RequestedBy
+			isAdmin := currentUserLevel >= 10
+
+			if !isRequester && !isAdmin {
+				c.JSON(http.StatusOK, gin.H{"success": true, "scheduled": true})
 				return
 			}
 


### PR DESCRIPTION
## Summary

`/api/v1/boards/:slug/posts/:id/delete-status` 권한 체크 추가 + deprecation 마크 + 캐시 제거.

## 보안 취약점 (수정 전)

- **누구나** 모든 글의 삭제 예약 시점/요청자 조회 가능
- 공유 Redis 캐시(5min) 사용 — 사용자 권한별 응답 분리 불가
- PR #429에서 TTL 늘렸지만 보안 문제는 미해결

## 변경

- ✅ **권한 체크**: 예약 요청자(\`sd.RequestedBy\`) 본인 또는 관리자(\`mb_level >= 10\`)만 상세 정보
- ✅ **비본인 응답**: \`{success: true, scheduled: true}\` (boolean만, PII 차단)
- ✅ **캐시 제거**: \`middleware.CacheWithTTL\` 미들웨어 제거 (사용자별 응답이라 공유 캐시 부적합)
- ✅ **DEPRECATED 마크**: ~2026-10 제거 예정

## 영향

| 사용자 | 이전 응답 | 신규 응답 |
|---|---|---|
| 익명/비본인 | 모든 PII 노출 | \`{scheduled: bool}\` |
| 예약 요청자 본인 | 전체 정보 | 전체 정보 (변경 없음) |
| 관리자 | 전체 정보 | 전체 정보 (변경 없음) |

## 성능 영향: 0

- SSR (PR #1243)이 더 이상 호출하지 않음 (OTel 검증: 17:50 ~400/5min → 18:45 88/5min)
- 직접 API 호출만 영향, 권한 체크 추가로 약간 느려져도 거의 호출 없음

## Test plan

- [x] \`make build-api\` 통과
- [ ] CI 통과
- [ ] 새벽 4시 prod 배포 (사용자 명시 승인)
- [ ] 검증: 비로그인 \`curl ... /delete-status\` → \`{scheduled: bool}\`만 반환 확인
- [ ] 검증: 본인/admin 응답에 \`scheduled_at, requested_by\` 등 포함 확인

## 후속 (별도 sprint)

- 6개월 후 endpoint 완전 제거 (deprecation grace period)
- otelgorm 도입 (W4-D)