### PR TITLE
feat(otel): otelgorm 도입 — DB query span 측정 (W4-D)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -60,6 +60,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
+	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -5491,6 +5492,14 @@ func initDB(cfg *config.Config) (*gorm.DB, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// OTel GORM 계측 — OTEL_ENABLED=true 시에만 활성 (DB query span 추가)
+	// outlier 600ms+ 원인 정밀 분석용 (W4-D)
+	if os.Getenv("OTEL_ENABLED") == "true" {
+		if pluginErr := db.Use(otelgorm.NewPlugin()); pluginErr != nil {
+			log.Printf("[WARN] otelgorm plugin registration failed: %v", pluginErr)
+		}
 	}
 
 	db.Exec("SET SESSION sql_mode = ''")

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
+	github.com/uptrace/opentelemetry-go-extra/otelgorm v0.3.2
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.68.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0
@@ -104,6 +105,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
+	github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,10 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=
 github.com/ugorji/go/codec v1.3.1/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+github.com/uptrace/opentelemetry-go-extra/otelgorm v0.3.2 h1:Jjn3zoRz13f8b1bR6LrXWglx93Sbh4kYfwgmPju3E2k=
+github.com/uptrace/opentelemetry-go-extra/otelgorm v0.3.2/go.mod h1:wocb5pNrj/sjhWB9J5jctnC0K2eisSdz/nJJBNFHo+A=
+github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 h1:ZjUj9BLYf9PEqBn8W/OapxhPjVRdC6CsXTdULHsyk5c=
+github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2/go.mod h1:O8bHQfyinKwTXKkiKNGmLQS7vRsqRxIQTFZpYpHK3IQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=


### PR DESCRIPTION
## Summary

GORM 쿼리에 OTel 계측 추가 — DB query span을 ClickHouse \`otel.traces\`에 수집.

## 목적

OTel HTTP layer만으로는 \`/delete-status\` outlier 600ms+ 원인 불명. DB layer span 추가하여:
- prepared statement 누적 / connection pool exhaustion 영향 식별
- 느린 SQL 쿼리 정확 파악
- N+1 쿼리 자동 감지

## 변경

### \`cmd/api/main.go\`
```go
import "github.com/uptrace/opentelemetry-go-extra/otelgorm"

// gorm.Open 직후
if os.Getenv("OTEL_ENABLED") == "true" {
    if pluginErr := db.Use(otelgorm.NewPlugin()); pluginErr != nil {
        log.Printf("[WARN] otelgorm plugin registration failed: %v", pluginErr)
    }
}
```

### \`go.mod\`
- \`github.com/uptrace/opentelemetry-go-extra/otelgorm v0.3.2\` (추가)
- \`github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2\` (간접 추가)

## 안전성

- ✅ OTEL_ENABLED=true 시에만 활성 (기존 flag 재사용)
- ✅ Plugin overhead 미미 (GORM hook 기반, 수us 추가)
- ✅ 등록 실패 시 WARN 로그만, 서비스는 계속 동작
- ✅ 별도 환경변수 불요

## 효과 (flag ON 후)

ClickHouse 쿼리 예시:
\`\`\`sql
SELECT SpanName, SpanAttributes['db.statement'] sql, count() c, avg(Duration)/1e6 avg_ms
FROM otel.traces
WHERE ServiceName='damoang-api' AND SpanAttributes['db.system'] != ''
  AND Timestamp > now() - INTERVAL 1 HOUR
GROUP BY SpanName, sql
ORDER BY avg_ms DESC LIMIT 20
\`\`\`

→ 가장 느린 SQL 쿼리 식별, outlier 원인 정밀 분석 가능

## Test plan

- [x] \`make build-api\` 통과
- [ ] CI 통과
- [ ] 새벽 4시 prod 배포 (사용자 명시 승인)
- [ ] 검증: ClickHouse otel.traces에 db.system='mysql' span 존재 확인
- [ ] 글 상세 trace에서 HTTP + DB span 모두 표시 확인

## 후속

- DB span 1시간 누적 → 가장 느린 쿼리 식별 → 인덱스/쿼리 최적화 sprint