### PR TITLE
fix(memo): always include author_memo field (null when no memo)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -471,7 +471,7 @@ func enrichWithAuthorMemo(db *gorm.DB, currentUserID string, items []map[string]
 	if err := db.Table("g5_member_memo").
 		Select("target_member_id, memo, memo_detail, color").
 		Where("member_id = ? AND target_member_id IN ?", currentUserID, targetIDs).
-		Find(&memos).Error; err != nil || len(memos) == 0 {
+		Find(&memos).Error; err != nil {
 		return items
 	}
 	memoMap := make(map[string]gin.H, len(memos))
@@ -485,23 +485,22 @@ func enrichWithAuthorMemo(db *gorm.DB, currentUserID string, items []map[string]
 			"color":       m.Color,
 		}
 	}
-	if len(memoMap) == 0 {
-		return items
-	}
+	// 메모 없는 author도 author_memo: nil 명시 — frontend preloadMemos가 cache 채우도록.
+	// 필드 누락 시 frontend가 fallback batch API 호출 (4/22 진단: prod batch memo 1180 req/min 주범).
 	result := make([]map[string]any, len(items))
 	for i, item := range items {
 		id, _ := item["author_id"].(string)
-		memo, hasMemo := memoMap[id]
-		if !hasMemo {
+		if id == "" {
 			result[i] = item
 			continue
 		}
-		// Shallow copy + add author_memo (avoid mutating cached item)
+		// Shallow copy + add author_memo (avoid mutating cached item).
+		// memoMap[id]는 없으면 nil → frontend는 "메모 없음" 으로 cache 채움.
 		newItem := make(map[string]any, len(item)+1)
 		for k, v := range item {
 			newItem[k] = v
 		}
-		newItem["author_memo"] = memo
+		newItem["author_memo"] = memoMap[id]
 		result[i] = newItem
 	}
 	return result


### PR DESCRIPTION
## 배경

4/22 prod 트래픽 진단:
- `/api/v1/members/batch/memo` 가 전체 API 호출의 **16.5% (1위, 1,180 req/min)** 차지
- web pod CPU 98% 주범 가능성 ↑
- `/free` 게시판 목록 referer 5,278건 (51%) — preloadMemos가 효과 못 봄

## 근본 원인

`enrichWithAuthorMemo` 가 메모 없는 author는 \`author_memo\` 필드 자체를 추가 안 함.
frontend preloadMemos는 \`'author_memo' in item\` 체크로 cache 채울지 판단:
- 필드 있음 + null/객체 → cache 채움 (batch API 호출 회피)
- 필드 없음 → fallback → batch API 호출

→ 메모 없는 author 다수 → 매번 batch API 호출.

## 수정

\`enrichWithAuthorMemo\`:
- DB 메모 결과 0이어도 short-circuit 제거
- 모든 (author_id 있는) item에 \`author_memo\` 항상 포함
  - 메모 있음 → \`gin.H{content, memo_detail, color}\`
  - 메모 없음 → \`nil\` (JSON null)
- author_id 없거나 익명 사용자 → 기존대로 필드 제외 (frontend가 호출 안 함)

## 예상 효과

- batch memo API 호출 1,180/min → ~200/min (5x 감소)
- web pod CPU 일부 회복 (HPA 21 pod → 더 적은 수로 안정)
- 응답 크기 소폭 증가 (각 item당 +20 bytes 정도, gzip 후 무시 가능)

## Test plan

- [ ] dev 환경에서 \`/api/v1/boards/free/posts\` 응답에 모든 item이 \`author_memo\` 키 포함 확인 (null이라도)
- [ ] frontend devtools Network: 게시판 목록 진입 후 \`/api/v1/members/batch/memo\` 호출 0 확인
- [ ] 메모 있는 author는 배지 정상 표시 확인
- [ ] 응답 size 변화 측정

## Deploy

새벽 4시 배포 규칙. canary 검증 후 prod 승격.