### PR TITLE
feat(redis): JSON-typed cache helpers (GetOrSet, Invalidate)

### DIFF
--- a/pkg/redis/cache.go
+++ b/pkg/redis/cache.go
@@ -1,0 +1,126 @@
+// Package redis — JSON-typed cache helpers built on top of go-redis client.
+//
+// 2026-04-25: backend Redis cache middleware (Phase 2, N+1 해소) 도입을 위한 헬퍼.
+// 비인증 사용자 GET 응답 캐시용. 무효화는 write 핸들러에서 수동 호출.
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// Cache wraps a redis.Client with JSON-typed GetOrSet + invalidation helpers.
+// Nil-safe: methods on a nil Cache are no-ops (loader fallthrough).
+type Cache struct {
+	client *goredis.Client
+}
+
+// NewCache creates a Cache wrapper. Pass the *redis.Client returned from NewClient.
+func NewCache(c *goredis.Client) *Cache {
+	return &Cache{client: c}
+}
+
+// ErrCacheMiss is returned by Get when the key does not exist.
+var ErrCacheMiss = errors.New("redis: cache miss")
+
+// Get returns the JSON-decoded value or ErrCacheMiss.
+func Get[T any](ctx context.Context, c *Cache, key string) (T, error) {
+	var zero T
+	if c == nil || c.client == nil {
+		return zero, ErrCacheMiss
+	}
+	raw, err := c.client.Get(ctx, key).Bytes()
+	if err == goredis.Nil {
+		return zero, ErrCacheMiss
+	}
+	if err != nil {
+		return zero, fmt.Errorf("redis get %q: %w", key, err)
+	}
+	var val T
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return zero, fmt.Errorf("redis json decode %q: %w", key, err)
+	}
+	return val, nil
+}
+
+// Set stores v as JSON with the given TTL. Best-effort (errors logged by caller if needed).
+func Set[T any](ctx context.Context, c *Cache, key string, v T, ttl time.Duration) error {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	blob, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("redis json encode %q: %w", key, err)
+	}
+	return c.client.Set(ctx, key, blob, ttl).Err()
+}
+
+// GetOrSet returns the cached value if present, else invokes loader, stores the
+// result with TTL, and returns it. Cache write failures are silently ignored
+// (we always return the loader's result on miss).
+//
+// Use only for idempotent, anonymous-safe data. Do NOT cache user-scoped data
+// without including a user identifier in the key.
+func GetOrSet[T any](
+	ctx context.Context,
+	c *Cache,
+	key string,
+	ttl time.Duration,
+	loader func() (T, error),
+) (T, error) {
+	if c != nil && c.client != nil {
+		if v, err := Get[T](ctx, c, key); err == nil {
+			return v, nil
+		}
+	}
+	v, err := loader()
+	if err != nil {
+		return v, err
+	}
+	if c != nil && c.client != nil {
+		_ = Set(ctx, c, key, v, ttl)
+	}
+	return v, nil
+}
+
+// Invalidate best-effort deletes the given keys. Nil-safe.
+func (c *Cache) Invalidate(ctx context.Context, keys ...string) error {
+	if c == nil || c.client == nil || len(keys) == 0 {
+		return nil
+	}
+	return c.client.Del(ctx, keys...).Err()
+}
+
+// InvalidatePrefix SCANs and deletes all keys matching prefix*. Sparingly use —
+// SCAN is O(N) over the keyspace and may be slow on large databases. For
+// frequent invalidation, prefer explicit per-key Invalidate.
+func (c *Cache) InvalidatePrefix(ctx context.Context, prefix string) error {
+	if c == nil || c.client == nil || prefix == "" {
+		return nil
+	}
+	iter := c.client.Scan(ctx, 0, prefix+"*", 100).Iterator()
+	var keys []string
+	for iter.Next(ctx) {
+		keys = append(keys, iter.Val())
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("redis scan %q: %w", prefix, err)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	return c.client.Del(ctx, keys...).Err()
+}
+
+// Client returns the underlying go-redis client (escape hatch for advanced ops).
+func (c *Cache) Client() *goredis.Client {
+	if c == nil {
+		return nil
+	}
+	return c.client
+}

--- a/pkg/redis/cache.go
+++ b/pkg/redis/cache.go
@@ -35,7 +35,7 @@ func Get[T any](ctx context.Context, c *Cache, key string) (T, error) {
 		return zero, ErrCacheMiss
 	}
 	raw, err := c.client.Get(ctx, key).Bytes()
-	if err == goredis.Nil {
+	if errors.Is(err, goredis.Nil) {
 		return zero, ErrCacheMiss
 	}
 	if err != nil {
@@ -83,7 +83,9 @@ func GetOrSet[T any](
 		return v, err
 	}
 	if c != nil && c.client != nil {
-		_ = Set(ctx, c, key, v, ttl)
+		// 캐시 쓰기 실패는 path-blocking 이 아님 — best-effort.
+		//nolint:errcheck // intentionally ignored: cache miss case still returns loader value
+		Set(ctx, c, key, v, ttl)
 	}
 	return v, nil
 }

--- a/pkg/redis/cache_test.go
+++ b/pkg/redis/cache_test.go
@@ -1,0 +1,57 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// nil-Cache 동작 검증 — 모든 함수가 안전하게 fallthrough 해야 함.
+func TestNilCacheNoOps(t *testing.T) {
+	ctx := context.Background()
+	var c *Cache // nil
+
+	// Get → ErrCacheMiss
+	if _, err := Get[string](ctx, c, "k"); !errors.Is(err, ErrCacheMiss) {
+		t.Errorf("Get nil: want ErrCacheMiss, got %v", err)
+	}
+
+	// Set → no-op, no error
+	if err := Set(ctx, c, "k", "v", time.Minute); err != nil {
+		t.Errorf("Set nil: want nil, got %v", err)
+	}
+
+	// GetOrSet → loader called, returns its value
+	called := false
+	v, err := GetOrSet(ctx, c, "k", time.Minute, func() (string, error) {
+		called = true
+		return "loaded", nil
+	})
+	if err != nil || v != "loaded" || !called {
+		t.Errorf("GetOrSet nil: want loader called and value=loaded, got v=%q err=%v called=%v", v, err, called)
+	}
+
+	// Invalidate → no-op
+	if err := c.Invalidate(ctx, "k1", "k2"); err != nil {
+		t.Errorf("Invalidate nil: want nil, got %v", err)
+	}
+
+	// InvalidatePrefix → no-op
+	if err := c.InvalidatePrefix(ctx, "prefix:"); err != nil {
+		t.Errorf("InvalidatePrefix nil: want nil, got %v", err)
+	}
+}
+
+// GetOrSet loader error propagation — 캐시 miss 시 loader err 그대로 반환.
+func TestGetOrSetLoaderError(t *testing.T) {
+	ctx := context.Background()
+	var c *Cache
+	expected := errors.New("loader failed")
+	_, err := GetOrSet(ctx, c, "k", time.Minute, func() (string, error) {
+		return "", expected
+	})
+	if !errors.Is(err, expected) {
+		t.Errorf("want %v, got %v", expected, err)
+	}
+}


### PR DESCRIPTION
## Summary
Phase 2 (N+1 해소 / `pod CPU -30~40%` 목표) 인프라 — `pkg/redis/cache.go` 신규.

후속 PR 에서 4개 공개 GET 핸들러(ListBoards/ListPosts/ListComments/MembersLevels) 통합 예정.

## 추가 (pkg/redis/cache.go, 100줄)
- `Cache` wrapper (nil-safe — nil receiver 시 fallthrough)
- `Get[T any]()` / `Set[T any]()` — JSON encode/decode
- `GetOrSet[T any]()` — cache-aside 패턴 (loader fallthrough on miss)
- `Invalidate(keys...)` / `InvalidatePrefix(prefix)` — write 핸들러용

## Test (pkg/redis/cache_test.go, 50줄)
- Nil-Cache 안전성: Get→ErrCacheMiss, Set/Invalidate→no-op, GetOrSet→loader 호출
- Loader error 전파 검증
- `go test ./pkg/redis/` PASS

## Sprint Contract
- 상위 doc: `/home/damoang/docs/work-tracker/backend-redis-cache-2026-04-25/task_plan.md`
- findings: `findings.md` (4 핸들러 + 무효화 후크 + auth 패턴 조사)

## 안전성
- 비인증 사용자만 캐시 (후속 PR 에서 적용)
- Feature flag `BACKEND_CACHE_ENABLED` 추가 예정
- 04:00 KST 배포 윈도우 진행 (운영 가드레일 준수)

## Rollback
이 PR 은 Helper 만 추가 — 미사용 상태이므로 회귀 위험 0. 후속 핸들러 PR 에서 feature flag로 회귀 가능.