### PR TITLE
feat: Angple Sites builder backend (M1 A1 PoC)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5453,6 +5453,23 @@ func main() {
 			adminPlugins.GET("/:name/detail", storeHandler.PluginDetail)
 		}
 
+		// Angple Sites builder content (M1 A1 PoC, issue #1288)
+		// Public route exists for SSR consumption; admin routes are RequireAdmin-gated.
+		// site_id FK omitted at PoC; Phase 2 will wire it once `sites` is in prod.
+		siteContentRepo := repository.NewSiteContentRepository(db)
+		siteContentSvc := service.NewSiteContentService(siteContentRepo)
+		siteContentHandler := handler.NewSiteContentHandler(siteContentSvc)
+
+		router.GET("/api/v1/sites/:id/content/:key", siteContentHandler.GetPublic)
+
+		adminSiteContent := router.Group("/api/v1/admin/sites/:id/content")
+		adminSiteContent.Use(middleware.JWTAuth(jwtManager), middleware.RequireAdmin())
+		{
+			adminSiteContent.GET("/:key", siteContentHandler.GetAdmin)
+			adminSiteContent.PUT("/:key", siteContentHandler.Upsert)
+			adminSiteContent.DELETE("/:key", siteContentHandler.Delete)
+		}
+
 		// Marketplace
 		marketplaceRepo := pluginstoreRepo.NewMarketplaceRepository(db)
 		if err := marketplaceRepo.AutoMigrate(); err != nil {

--- a/internal/domain/site_content.go
+++ b/internal/domain/site_content.go
@@ -1,0 +1,58 @@
+package domain
+
+import (
+	"time"
+)
+
+// AngpleSiteContent stores block-based page content for the Angple Sites builder (M1 A1).
+// PoC scope (issue #1288): site_id FK omitted; will be added in Phase 2 once `sites` table is in prod.
+//
+// schema_version=1: blocks JSON shape is `{schema_version, blocks: [{id, type, data, meta}, ...]}`.
+type AngpleSiteContent struct {
+	CreatedAt     time.Time `gorm:"column:created_at;autoCreateTime"          json:"created_at"`
+	UpdatedAt     time.Time `gorm:"column:updated_at;autoUpdateTime"          json:"updated_at"`
+	Meta          *string   `gorm:"column:meta;type:json"                     json:"meta,omitempty"`
+	Blocks        string    `gorm:"column:blocks;type:json;not null"          json:"blocks"`
+	ContentKey    string    `gorm:"column:content_key;not null"               json:"content_key"`
+	ID            int64     `gorm:"column:id;primaryKey;autoIncrement"        json:"id"`
+	SiteID        int64     `gorm:"column:site_id;not null"                   json:"site_id"`
+	SchemaVersion uint16    `gorm:"column:schema_version;not null;default:1"  json:"schema_version"`
+}
+
+// TableName returns the GORM table name. `angple_*` prefix per issue #1224 agreement.
+func (AngpleSiteContent) TableName() string {
+	return "angple_site_content"
+}
+
+// AngpleSiteContentUpsertRequest is the payload for PUT /content/:key.
+type AngpleSiteContentUpsertRequest struct {
+	Meta          *string `json:"meta,omitempty"`
+	Blocks        string  `json:"blocks"         binding:"required"`
+	SchemaVersion uint16  `json:"schema_version" binding:"required,oneof=1"`
+}
+
+// AngpleSiteContentResponse is the response shape returned to clients.
+type AngpleSiteContentResponse struct {
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	Meta          *string   `json:"meta,omitempty"`
+	ContentKey    string    `json:"content_key"`
+	Blocks        string    `json:"blocks"`
+	ID            int64     `json:"id"`
+	SiteID        int64     `json:"site_id"`
+	SchemaVersion uint16    `json:"schema_version"`
+}
+
+// ToResponse converts an AngpleSiteContent to its response DTO.
+func (c *AngpleSiteContent) ToResponse() *AngpleSiteContentResponse {
+	return &AngpleSiteContentResponse{
+		ID:            c.ID,
+		SiteID:        c.SiteID,
+		ContentKey:    c.ContentKey,
+		SchemaVersion: c.SchemaVersion,
+		Blocks:        c.Blocks,
+		Meta:          c.Meta,
+		CreatedAt:     c.CreatedAt,
+		UpdatedAt:     c.UpdatedAt,
+	}
+}

--- a/internal/handler/site_content_handler.go
+++ b/internal/handler/site_content_handler.go
@@ -1,0 +1,124 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// SiteContentHandler exposes the Angple Sites builder content endpoints
+// (issue #1288 PoC).
+type SiteContentHandler struct {
+	service *service.SiteContentService
+}
+
+// NewSiteContentHandler constructs a SiteContentHandler.
+func NewSiteContentHandler(svc *service.SiteContentService) *SiteContentHandler {
+	return &SiteContentHandler{service: svc}
+}
+
+// parseSiteID extracts and validates the :id path parameter.
+func (h *SiteContentHandler) parseSiteID(c *gin.Context) (int64, bool) {
+	raw := c.Param("id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid site_id", err)
+		return 0, false
+	}
+	return id, true
+}
+
+// GetPublic returns published content for SSR.
+//
+// GET /api/v1/sites/:id/content/:key
+func (h *SiteContentHandler) GetPublic(c *gin.Context) {
+	siteID, ok := h.parseSiteID(c)
+	if !ok {
+		return
+	}
+	key := c.Param("key")
+	if key == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "content_key is required", nil)
+		return
+	}
+	row, err := h.service.Get(c.Request.Context(), siteID, key)
+	if err != nil {
+		if errors.Is(err, common.ErrNotFound) {
+			common.ErrorResponse(c, http.StatusNotFound, "Content not found", err)
+			return
+		}
+		if errors.Is(err, common.ErrBadRequest) {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+			return
+		}
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to get content", err)
+		return
+	}
+	common.SuccessResponse(c, gin.H{"content": row.ToResponse()}, nil)
+}
+
+// GetAdmin returns content for admin authoring. Requires admin middleware upstream.
+//
+// GET /api/v1/admin/sites/:id/content/:key
+func (h *SiteContentHandler) GetAdmin(c *gin.Context) {
+	h.GetPublic(c) // Same logic; auth is enforced by middleware on the route group.
+}
+
+// Upsert creates or updates content. Requires admin middleware upstream.
+//
+// PUT /api/v1/admin/sites/:id/content/:key
+func (h *SiteContentHandler) Upsert(c *gin.Context) {
+	siteID, ok := h.parseSiteID(c)
+	if !ok {
+		return
+	}
+	key := c.Param("key")
+	if key == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "content_key is required", nil)
+		return
+	}
+	var req domain.AngpleSiteContentUpsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+	row, err := h.service.Upsert(c.Request.Context(), siteID, key, &req)
+	if err != nil {
+		if errors.Is(err, common.ErrBadRequest) {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+			return
+		}
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to save content", err)
+		return
+	}
+	common.SuccessResponse(c, gin.H{"content": row.ToResponse()}, nil)
+}
+
+// Delete removes content. Requires admin middleware upstream.
+//
+// DELETE /api/v1/admin/sites/:id/content/:key
+func (h *SiteContentHandler) Delete(c *gin.Context) {
+	siteID, ok := h.parseSiteID(c)
+	if !ok {
+		return
+	}
+	key := c.Param("key")
+	if key == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "content_key is required", nil)
+		return
+	}
+	if err := h.service.Delete(c.Request.Context(), siteID, key); err != nil {
+		if errors.Is(err, common.ErrBadRequest) {
+			common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+			return
+		}
+		common.ErrorResponse(c, http.StatusInternalServerError, "Failed to delete content", err)
+		return
+	}
+	common.SuccessResponse(c, gin.H{"message": "deleted"}, nil)
+}

--- a/internal/repository/site_content_repo.go
+++ b/internal/repository/site_content_repo.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// SiteContentRepository persists Angple Sites builder content (issue #1288 PoC).
+type SiteContentRepository struct {
+	db *gorm.DB
+}
+
+// NewSiteContentRepository constructs a SiteContentRepository.
+func NewSiteContentRepository(db *gorm.DB) *SiteContentRepository {
+	return &SiteContentRepository{db: db}
+}
+
+// FindBySiteAndKey returns the content row for (site_id, content_key) or nil if not found.
+func (r *SiteContentRepository) FindBySiteAndKey(
+	ctx context.Context, siteID int64, contentKey string,
+) (*domain.AngpleSiteContent, error) {
+	var c domain.AngpleSiteContent
+	err := r.db.WithContext(ctx).
+		Where("site_id = ? AND content_key = ?", siteID, contentKey).
+		First(&c).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &c, nil
+}
+
+// Upsert creates or updates the content row for (site_id, content_key).
+func (r *SiteContentRepository) Upsert(ctx context.Context, c *domain.AngpleSiteContent) error {
+	existing, err := r.FindBySiteAndKey(ctx, c.SiteID, c.ContentKey)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return r.db.WithContext(ctx).Create(c).Error
+	}
+	c.ID = existing.ID
+	c.CreatedAt = existing.CreatedAt
+	return r.db.WithContext(ctx).Save(c).Error
+}
+
+// Delete removes the content row for (site_id, content_key).
+func (r *SiteContentRepository) Delete(
+	ctx context.Context, siteID int64, contentKey string,
+) error {
+	return r.db.WithContext(ctx).
+		Where("site_id = ? AND content_key = ?", siteID, contentKey).
+		Delete(&domain.AngpleSiteContent{}).Error
+}
+
+// ListBySite returns all content rows for a site, optionally limited.
+func (r *SiteContentRepository) ListBySite(
+	ctx context.Context, siteID int64, limit, offset int,
+) ([]domain.AngpleSiteContent, error) {
+	var rows []domain.AngpleSiteContent
+	q := r.db.WithContext(ctx).Where("site_id = ?", siteID).Order("content_key ASC")
+	if limit > 0 {
+		q = q.Limit(limit).Offset(offset)
+	}
+	err := q.Find(&rows).Error
+	return rows, err
+}

--- a/internal/service/site_content_service.go
+++ b/internal/service/site_content_service.go
@@ -61,7 +61,7 @@ func validateBlocks(blocksJSON string) error {
 	}
 	var envelope blockListEnvelope
 	if err := json.Unmarshal([]byte(blocksJSON), &envelope); err != nil {
-		return fmt.Errorf("%w: invalid blocks JSON: %v", common.ErrBadRequest, err)
+		return fmt.Errorf("%w: invalid blocks JSON: %w", common.ErrBadRequest, err)
 	}
 	if envelope.SchemaVersion != 1 {
 		return fmt.Errorf("%w: schema_version must be 1", common.ErrBadRequest)

--- a/internal/service/site_content_service.go
+++ b/internal/service/site_content_service.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+)
+
+// SiteContentService implements the business logic for the Angple Sites builder
+// (issue #1288 PoC). All methods are safe to call concurrently.
+type SiteContentService struct {
+	repo *repository.SiteContentRepository
+}
+
+// NewSiteContentService constructs a SiteContentService.
+func NewSiteContentService(repo *repository.SiteContentRepository) *SiteContentService {
+	return &SiteContentService{repo: repo}
+}
+
+// MaxBlocksJSONBytes caps the size of the blocks JSON document to keep DB rows small.
+// 100 KB matches the §6 R2 risk mitigation in the PoC Sprint Contract.
+const MaxBlocksJSONBytes = 100 * 1024
+
+// blockListEnvelope mirrors the schema documented in the A1 RFC §3-2.
+type blockListEnvelope struct {
+	Blocks        []blockEntry `json:"blocks"`
+	SchemaVersion uint16       `json:"schema_version"`
+}
+
+type blockEntry struct {
+	Data map[string]any `json:"data"`
+	Meta map[string]any `json:"meta,omitempty"`
+	ID   string         `json:"id"`
+	Type string         `json:"type"`
+}
+
+// allowedBlockTypes matches the MVP set agreed in RFC §10 (Phase 1).
+var allowedBlockTypes = map[string]struct{}{
+	"header":    {},
+	"paragraph": {},
+	"image":     {},
+	"button":    {},
+	"list":      {},
+	"embed":     {},
+	"divider":   {},
+}
+
+// validateBlocks runs the content-side schema check before persistence.
+// Returns common.ErrBadRequest (wrapped) if the payload is malformed.
+func validateBlocks(blocksJSON string) error {
+	if blocksJSON == "" {
+		return fmt.Errorf("%w: blocks cannot be empty", common.ErrBadRequest)
+	}
+	if len(blocksJSON) > MaxBlocksJSONBytes {
+		return fmt.Errorf("%w: blocks exceed %d bytes", common.ErrBadRequest, MaxBlocksJSONBytes)
+	}
+	var envelope blockListEnvelope
+	if err := json.Unmarshal([]byte(blocksJSON), &envelope); err != nil {
+		return fmt.Errorf("%w: invalid blocks JSON: %v", common.ErrBadRequest, err)
+	}
+	if envelope.SchemaVersion != 1 {
+		return fmt.Errorf("%w: schema_version must be 1", common.ErrBadRequest)
+	}
+	if len(envelope.Blocks) == 0 {
+		return fmt.Errorf("%w: blocks array cannot be empty", common.ErrBadRequest)
+	}
+	for i, b := range envelope.Blocks {
+		if b.ID == "" {
+			return fmt.Errorf("%w: block[%d].id is required", common.ErrBadRequest, i)
+		}
+		if _, ok := allowedBlockTypes[b.Type]; !ok {
+			return fmt.Errorf("%w: block[%d].type %q not in MVP set", common.ErrBadRequest, i, b.Type)
+		}
+	}
+	return nil
+}
+
+// Get returns the content row for (site_id, content_key).
+// Returns common.ErrNotFound if the row does not exist.
+func (s *SiteContentService) Get(
+	ctx context.Context, siteID int64, contentKey string,
+) (*domain.AngpleSiteContent, error) {
+	if siteID <= 0 {
+		return nil, fmt.Errorf("%w: site_id must be positive", common.ErrBadRequest)
+	}
+	if contentKey == "" {
+		return nil, fmt.Errorf("%w: content_key is required", common.ErrBadRequest)
+	}
+	row, err := s.repo.FindBySiteAndKey(ctx, siteID, contentKey)
+	if err != nil {
+		return nil, err
+	}
+	if row == nil {
+		return nil, common.ErrNotFound
+	}
+	return row, nil
+}
+
+// Upsert validates and persists the content for (site_id, content_key).
+func (s *SiteContentService) Upsert(
+	ctx context.Context, siteID int64, contentKey string, req *domain.AngpleSiteContentUpsertRequest,
+) (*domain.AngpleSiteContent, error) {
+	if siteID <= 0 {
+		return nil, fmt.Errorf("%w: site_id must be positive", common.ErrBadRequest)
+	}
+	if contentKey == "" {
+		return nil, fmt.Errorf("%w: content_key is required", common.ErrBadRequest)
+	}
+	if req == nil {
+		return nil, fmt.Errorf("%w: request body required", common.ErrBadRequest)
+	}
+	if err := validateBlocks(req.Blocks); err != nil {
+		return nil, err
+	}
+	row := &domain.AngpleSiteContent{
+		SiteID:        siteID,
+		ContentKey:    contentKey,
+		SchemaVersion: req.SchemaVersion,
+		Blocks:        req.Blocks,
+		Meta:          req.Meta,
+	}
+	if err := s.repo.Upsert(ctx, row); err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
+// Delete removes the content row for (site_id, content_key).
+func (s *SiteContentService) Delete(
+	ctx context.Context, siteID int64, contentKey string,
+) error {
+	if siteID <= 0 {
+		return fmt.Errorf("%w: site_id must be positive", common.ErrBadRequest)
+	}
+	if contentKey == "" {
+		return fmt.Errorf("%w: content_key is required", common.ErrBadRequest)
+	}
+	return s.repo.Delete(ctx, siteID, contentKey)
+}
+
+// IsNotFound is a convenience helper for handler error mapping.
+func IsNotFound(err error) bool {
+	return errors.Is(err, common.ErrNotFound)
+}

--- a/internal/service/site_content_service_test.go
+++ b/internal/service/site_content_service_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/damoang/angple-backend/internal/common"
+)
+
+// TestValidateBlocks covers the schema-validation path used by Upsert.
+// Repository is not exercised here; integration is covered separately.
+func TestValidateBlocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "empty payload rejected",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON rejected",
+			input:   "{not json",
+			wantErr: true,
+		},
+		{
+			name:    "wrong schema_version rejected",
+			input:   `{"schema_version": 2, "blocks": [{"id":"a","type":"header","data":{}}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty blocks array rejected",
+			input:   `{"schema_version": 1, "blocks": []}`,
+			wantErr: true,
+		},
+		{
+			name:    "missing block id rejected",
+			input:   `{"schema_version": 1, "blocks": [{"type":"header","data":{}}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "unknown block type rejected",
+			input:   `{"schema_version": 1, "blocks": [{"id":"a","type":"alien","data":{}}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "valid header block accepted",
+			input:   `{"schema_version": 1, "blocks": [{"id":"01H8XY","type":"header","data":{"text":"hi","level":1}}]}`,
+			wantErr: false,
+		},
+		{
+			name:    "valid mixed blocks accepted",
+			input:   `{"schema_version": 1, "blocks": [{"id":"a","type":"header","data":{}},{"id":"b","type":"paragraph","data":{}},{"id":"c","type":"image","data":{}},{"id":"d","type":"button","data":{}},{"id":"e","type":"list","data":{}},{"id":"f","type":"embed","data":{}},{"id":"g","type":"divider","data":{}}]}`,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBlocks(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateBlocks(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, common.ErrBadRequest) {
+				t.Fatalf("expected error to wrap common.ErrBadRequest; got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateBlocksTooLarge ensures the size guard at MaxBlocksJSONBytes triggers.
+func TestValidateBlocksTooLarge(t *testing.T) {
+	prefix := `{"schema_version": 1, "blocks": [{"id":"x","type":"paragraph","data":{"text":"`
+	suffix := `"}}]}`
+	filler := strings.Repeat("a", MaxBlocksJSONBytes+1)
+	payload := prefix + filler + suffix
+
+	err := validateBlocks(payload)
+	if err == nil {
+		t.Fatalf("expected size guard to reject %d-byte payload", len(payload))
+	}
+	if !errors.Is(err, common.ErrBadRequest) {
+		t.Fatalf("expected ErrBadRequest, got %v", err)
+	}
+}

--- a/migrations/003_angple_site_content.sql
+++ b/migrations/003_angple_site_content.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- Angple Sites builder content (M1 A1 PoC, issue #1288)
+-- ============================================================
+-- 작성: 2026-04-25
+-- 적용: 새벽 4시 + canary 절차 준수 (메모리 production-guardrails)
+-- DDL 통보 채널: damoang/angple#1224 댓글 (E15 합의)
+-- prefix 합의: angple_*  (#1224 4316951688)
+--
+-- PoC 시점 결정 (Sprint Contract §6 R4):
+--   - site_id FK 미설정 — angple `sites` 테이블이 prod 미존재
+--   - Phase 2 에서 `sites` 마이그 후 FK 추가
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS angple_site_content (
+    id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    site_id         BIGINT UNSIGNED NOT NULL                   COMMENT 'angple sites.id (FK 미설정 — Phase 2)',
+    content_key     VARCHAR(64)     NOT NULL                   COMMENT 'home, about, _header, _footer 등',
+    schema_version  SMALLINT UNSIGNED NOT NULL DEFAULT 1       COMMENT 'blocks JSON schema 버전 (현재 1)',
+    blocks          JSON            NOT NULL                   COMMENT '{schema_version, blocks: [{id, type, data, meta}]}',
+    meta            JSON            NULL                       COMMENT 'updated_by, lang, tags 등 부가 메타',
+    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_site_key (site_id, content_key),
+    INDEX idx_site (site_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Angple Sites builder block-based content (RFC: 2026-04-25-builder-rfc.md §3-1)';
+
+-- 검증 쿼리 (수동 확인용)
+-- SHOW CREATE TABLE angple_site_content\G
+-- SELECT COUNT(*) FROM angple_site_content;  -- 신규 테이블, 0 row 예상


### PR DESCRIPTION
## Summary
issue #1288 (M1 A1 — Gutenberg-style 빌더) Sprint Contract **Day 1-2** — backend 구현.

## Scope (PoC)
- 신규 테이블: \`angple_site_content\` (\`angple_*\` prefix, #1224 합의 준수)
- REST endpoint:
  - \`GET /api/v1/sites/:id/content/:key\` (public, SSR)
  - \`GET|PUT|DELETE /api/v1/admin/sites/:id/content/:key\` (RequireAdmin)
- 검증: schema_version=1, 7개 MVP block types (header/paragraph/image/button/list/embed/divider), 100KB blocks cap

## 신규 파일 (6) + main.go
- domain/site_content.go (58 lines)
- repository/site_content_repo.go (72 lines)
- service/site_content_service.go (149 lines)
- service/site_content_service_test.go (88 lines, 8 케이스 + size guard)
- handler/site_content_handler.go (124 lines)
- migrations/003_angple_site_content.sql (31 lines)
- cmd/api/main.go (+17 lines, DI wiring + routes)

## 운영 무손상

| 항목 | 상태 |
|---|---|
| 기존 테이블 ALTER | 0 |
| 기존 endpoint 변경 | 0 |
| feature flag | 불필요 (admin only + 미래 frontend 가 enable 결정) |
| go build | ✅ OK |
| go test | ✅ ok 0.009s (8 cases + size guard) |
| go vet | ✅ clean |
| breaking change | 0 |

## 일정상 위치 (Sprint Contract §8)
- ✅ Day 1: backend domain/repo/service/handler + migration SQL
- ✅ Day 2: backend wiring + tests
- 🔲 Day 3-4: frontend (TipTap + 5 blocks + admin route) — 별 PR
- 🔲 Day 5: E2E + Evaluator — 별 PR

## 의존성

| 항목 | 상태 |
|---|---|
| sites 테이블 prod 존재 | ❌ 없음 (PoC 시점 site_id FK skip, Phase 2 추가) |
| Phase 1 multisite resolver 머지 | ✅ sha-616ebad 운영 배포 완료 (2026-04-25 02:30 UTC) |
| #1224 prefix 합의 | ✅ angple_* 준수 |

## DDL Apply 절차 (별 PR 권장)

본 PR 머지 ≠ DDL apply. Migration 003 적용은 다음 절차:

1. 본 PR 머지 → 코드만 main 진입
2. 별 PR 또는 deploy script 로 \`mysql ... < migrations/003_angple_site_content.sql\` 실행
3. **새벽 4시 + canary 절차** + #1224 댓글 사전 통보 (E15 합의)
4. 검증: \`SHOW CREATE TABLE angple_site_content\\G\`

## Out of Scope (별 Sprint)
- 실제 marketplace 머지 (도메인 검증, plan tier 등) — Phase 2
- 메뉴/헤더/푸터/디자인/회원 빌더 — Phase 2-5
- ChurchRe 13화면 마이그 — Phase 2 (별 SQL)
- 추가 블록 (gallery, accordion 등) — Phase 2

## Test plan
- [ ] \`go test ./internal/service/...\` → ok (already passing)
- [ ] migration SQL syntax 검증 (\`mysql --syntax-check\` 또는 dry-run)
- [ ] dev 환경에 migration apply → SHOW CREATE TABLE 확인
- [ ] curl POST/GET 으로 endpoint 동작 확인 (admin 토큰 필요)
- [ ] svelte-check 0 errors (frontend PR 에서)

## 연관

- 부모: damoang/angple#1287, damoang/angple#1288
- Sprint Contract: \`/home/damoang/docs/harness-task/task_plan.md\`
- RFC: \`/home/damoang/docs/2026-04-25-builder-rfc.md\`
- DB 가드: \`/home/damoang/docs/2026-04-25-angple-db-table-name-guards.md\`