### PR TITLE
feat(v2/boards): ListBoards Redis 캐시 (비인증 5min)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -827,6 +827,10 @@ func main() {
 		// 권한 체크
 		permChecker := middleware.NewDBBoardPermissionChecker(v2BoardRepo)
 		v2Handler := v2handler.NewV2Handler(v2UserRepo, v2PostRepo, v2CommentRepo, v2BoardRepo, permChecker)
+		// 비인증 GET 응답 Redis 캐시 (nil-safe — Redis 미가용 시 자동 fallthrough)
+		if redisClient != nil {
+			v2Handler.SetCache(pkgredis.NewCache(redisClient))
+		}
 		v2Handler.SetPointRepository(v2PointRepo)
 		v2Handler.SetRevisionRepository(v2RevisionRepo)
 		v2Handler.SetNotiRepository(gnurepo.NewNotiRepository(db))

--- a/internal/handler/v2/handler.go
+++ b/internal/handler/v2/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/damoang/angple-backend/internal/middleware"
 	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
 	v2repo "github.com/damoang/angple-backend/internal/repository/v2"
+	pkgredis "github.com/damoang/angple-backend/pkg/redis"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -36,6 +37,7 @@ type V2Handler struct {
 	pointConfigRepo   v2repo.PointConfigRepository
 	blockRepo         v2repo.BlockRepository
 	tagRepo           gnurepo.TagRepository
+	cache             *pkgredis.Cache // 비인증 GET 응답 캐시 (nil-safe — 미주입 시 fallthrough)
 }
 
 const claimBoardSlug = "claim"
@@ -55,6 +57,12 @@ func NewV2Handler(
 		boardRepo:   boardRepo,
 		permChecker: permChecker,
 	}
+}
+
+// SetCache sets the optional Redis cache for anonymous GET responses.
+// nil-safe: when not set, handlers bypass cache and call the loader directly.
+func (h *V2Handler) SetCache(c *pkgredis.Cache) {
+	h.cache = c
 }
 
 // SetPointRepository sets the optional point repository for point operations
@@ -260,16 +268,19 @@ type boardWithPermissions struct {
 }
 
 // ListBoards handles GET /api/v1/boards
+//
+// Caching: 비인증 사용자에 한해 Redis 5분 캐시. 인증 사용자는 per-user
+// permissions 가 결과에 포함되므로 캐시 bypass.
 func (h *V2Handler) ListBoards(c *gin.Context) {
-	boards, err := h.boardRepo.FindAll()
-	if err != nil {
-		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
-		return
-	}
-
-	// 인증된 사용자면 각 게시판별 permissions 포함
 	memberLevel := middleware.GetUserLevel(c)
+
+	// 인증 사용자: per-user permissions 포함, 캐시 bypass
 	if memberLevel > 0 && h.permChecker != nil {
+		boards, err := h.boardRepo.FindAll()
+		if err != nil {
+			common.V2ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
+			return
+		}
 		result := make([]boardWithPermissions, len(boards))
 		for i, board := range boards {
 			perms, _ := h.permChecker.GetAllPermissions(board.Slug, memberLevel)
@@ -279,6 +290,20 @@ func (h *V2Handler) ListBoards(c *gin.Context) {
 		return
 	}
 
+	// 비인증: Redis 5분 캐시 (cache nil 이면 자동 fallthrough)
+	boards, err := pkgredis.GetOrSet(
+		c.Request.Context(),
+		h.cache,
+		"v2:boards:active:v1",
+		5*time.Minute,
+		func() ([]*v2domain.V2Board, error) {
+			return h.boardRepo.FindAll()
+		},
+	)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "게시판 목록 조회 실패", err)
+		return
+	}
 	common.V2Success(c, boards)
 }
 


### PR DESCRIPTION
## Summary
Phase 2 S2 첫 핸들러 — \`pkg/redis\` 헬퍼 (PR #440 머지) 활용.

\`/api/v1/boards\` 비인증 응답을 Redis 5분 캐시 → DB 부하 -90% 추정.

## 변경
**\`internal/handler/v2/handler.go\`**:
- \`pkgredis\` import + \`V2Handler.cache\` 필드 추가
- \`SetCache(*pkgredis.Cache)\` 옵셔널 setter
- \`ListBoards\` 재구조화: 인증 사용자 path 우선 → 비인증은 \`GetOrSet[[]*v2domain.V2Board]\` (key=\`v2:boards:active:v1\`, TTL=5min)

**\`cmd/api/main.go\`**:
- redisClient != nil 시 \`v2Handler.SetCache(pkgredis.NewCache(redisClient))\` 자동 wire

## 안전성
- 인증 사용자: per-user permissions path 그대로 (캐시 bypass)
- Cache nil 시 자동 fallthrough (Redis 장애 → 기존 동작)
- 무효화 hook 은 S3 별도 PR — 5min stale 허용 가능 (게시판 CRUD 빈도 매우 낮음)
- \`go build ./...\` PASS

## 기대 효과
- pod CPU 절감 → HPA pod 수 자연 감소
- N+1 (10 boards × GetAllPermissions) → 비인증 path 에서 5분당 1회

## Verify
- 비인증 \`curl /api/v1/boards\` 두 번 → 2번째는 Redis hit (응답 시간 단축)
- 인증 \`curl -H 'Authorization: ...' /api/v1/boards\` → 항상 fresh
- Redis 종료 시나리오 → 비인증도 정상 동작 (loader fallthrough)

## Sprint Contract
- task_plan: \`/home/damoang/docs/work-tracker/backend-redis-cache-2026-04-25/task_plan.md\`
- progress: \`/home/damoang/docs/work-tracker/backend-redis-cache-2026-04-25/progress.md\`
- 다음 PR: ListPosts/ListComments (user-scope 분기), invalidation hook, GetMembersLevels