### PR TITLE
feat: AutoMigrate guard for angple_site_content (zero-impact, multi-host)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5460,6 +5460,17 @@ func main() {
 		// Angple Sites builder content (M1 A1 PoC, issue #1288)
 		// Public route exists for SSR consumption; admin routes are RequireAdmin-gated.
 		// site_id FK omitted at PoC; Phase 2 will wire it once `sites` is in prod.
+		//
+		// Zero-impact migration (multi-host friendly):
+		//   - First boot: HasTable=false → AutoMigrate runs CREATE TABLE on a NEW table (no lock contention).
+		//   - Subsequent boots: HasTable=true (~1ms SELECT to information_schema) → AutoMigrate skipped.
+		//   - Each angple-backend deployment (damoang / ChurchRe / self-hosted) applies idempotently.
+		if !db.Migrator().HasTable(&domain.AngpleSiteContent{}) {
+			if err := db.AutoMigrate(&domain.AngpleSiteContent{}); err != nil {
+				log.Printf("warning: angple_site_content AutoMigrate failed: %v", err)
+			}
+		}
+
 		siteContentRepo := repository.NewSiteContentRepository(db)
 		siteContentSvc := service.NewSiteContentService(siteContentRepo)
 		siteContentHandler := handler.NewSiteContentHandler(siteContentSvc)


### PR DESCRIPTION
## Summary
issue #1288 follow-up — angple_site_content 테이블을 각 hosting (damoang / ChurchRe / self-hosted / SaaS angle.com) 에서 자동 마이그.

## Why

직전 PR #442 머지 후 깨달은 architectural 갭:
- 본 PoC 코드는 main 진입 + 배포됐지만 **DDL 미적용**
- 수동 SQL 실행은 multi-host 비전 (WordPress 한국판 SaaS) 과 안 맞음
- 각 deployment 마다 운영자가 SQL 실행을 기억해야 하는 구조 불안정

## Approach: HasTable guard + AutoMigrate (zero impact)

\`\`\`go
if !db.Migrator().HasTable(&domain.AngpleSiteContent{}) {
    if err := db.AutoMigrate(&domain.AngpleSiteContent{}); err != nil {
        log.Printf("warning: ...")
    }
}
\`\`\`

| 시나리오 | 비용 |
|---|---|
| 첫 부팅 (table 없음) | HasTable SELECT 1ms + CREATE TABLE 10ms (no lock — 새 테이블) |
| 이후 부팅 | HasTable SELECT 1ms + AutoMigrate 호출 안 함 |
| 운영 트래픽 | 0 (boot 단계, 사용자 요청 처리 전) |
| Failure | log.Printf warning, app continue (crash X) |

## 영향

| 환경 | 결과 |
|---|---|
| damoang prod | 다음 deploy 부팅 시 자동 CREATE TABLE → 빌더 PoC 동작 |
| ChurchRe OCI | (angple core 사용 시) 자동 CREATE TABLE |
| 자체 호스팅 | 누구든 angple core 받으면 자동 적용 |
| 미래 SaaS angple.com | 테넌트별 DB 부팅 시 자동 |

## 검증

- ✅ \`go build ./cmd/api/\` exit 0
- ✅ \`go vet ./internal/domain/ ./cmd/api/\` clean
- 같은 패턴 기존 사용처: main.go L824 \`wikiBacklinkRepo.AutoMigrate()\`, L4026 \`V2BoardDisplaySettings\`, L4041 \`V2BoardExtendedSettings\`, L5064 \`subRepo.AutoMigrate()\`

## Out of Scope (Phase 2)

- 정식 migration runner (\`golang-migrate/migrate\` + \`schema_migrations\` 테이블 + 버전 관리)
- 컬럼 rename/drop 지원 (현재는 CREATE TABLE only)
- DDL 통보 채널 (#1224 E15) — 본 PR 은 자동화 추가, 통보는 별도 사항

## 운영 무손상

- 기존 endpoint/테이블 변경 0
- feature flag 불필요 (HasTable check 로 idempotent)
- crash 없음 (AutoMigrate 실패해도 log warning + continue)