### PR TITLE
fix(ci): load-test workflow가 Makefile target 사용 (network 자동 생성)

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -50,7 +50,7 @@ jobs:
       run: pip install -r tests/load/requirements.txt
 
     - name: Start all services
-      run: docker compose -f docker-compose.dev.yml up -d --build
+      run: make dev-docker-rebuild
 
     - name: Wait for API to be healthy
       run: |

--- a/Makefile
+++ b/Makefile
@@ -54,15 +54,15 @@ setup:
 	fi
 	@echo "Next: edit .env (set DB_PASSWORD, JWT_SECRET) → make dev"
 
-# 로컬 개발 환경 (Docker All-in-One)
-dev-docker:
-	@echo "Ensuring Docker network exists: angple-dev-network"
+# Docker network 존재 보장 (compose 의 external network 참조 전 필수)
+dev-docker-network:
 	@if ! docker network inspect angple-dev-network >/dev/null 2>&1; then \
 		echo "Creating network: angple-dev-network"; \
 		docker network create angple-dev-network >/dev/null; \
-	else \
-		echo "Network already exists: angple-dev-network"; \
 	fi
+
+# 로컬 개발 환경 (Docker All-in-One)
+dev-docker: dev-docker-network
 	@echo "Starting development environment with Docker (MySQL + Redis + API)..."
 	@echo "Containers: angple-dev-mysql, angple-dev-redis, angple-dev-api"
 	docker compose -f docker-compose.dev.yml up
@@ -83,7 +83,7 @@ dev-docker-logs:
 	@echo "Showing logs (Ctrl+C to exit)..."
 	docker compose -f docker-compose.dev.yml logs -f
 
-dev-docker-rebuild:
+dev-docker-rebuild: dev-docker-network
 	@echo "Rebuilding development environment..."
 	docker compose -f docker-compose.dev.yml up -d --build
 


### PR DESCRIPTION
## Summary
- CI `load-test.yml` 이 `docker compose -f docker-compose.dev.yml up` 을 직접 호출 → `angple-dev-network` external 참조 실패로 빌드 깨짐
- Makefile 에 `dev-docker-network` prerequisite 분리 후 `dev-docker` / `dev-docker-rebuild` 모두 의존 → 두 path 모두 네트워크 자동 생성
- CI workflow 는 `make dev-docker-rebuild` 호출로 통일

## Why this approach (Option C)
A. CI 에 `docker network create` 직접 추가 — 로직 산재
B. compose 의 `external: true` 제거 — backend / web 간 네트워크 공유 깨짐
C. **Makefile target 호출 (이 PR)** — single source of truth, 로컬과 CI 동일 경로

## Test plan
- [ ] Load Test workflow 수동 트리거 → angple-dev-network 자동 생성 확인
- [ ] `make dev-docker` 로컬 실행 (network 이미 존재 시 skip 확인)
- [ ] `make dev-docker-rebuild` 로컬 실행 (network 신규 생성 확인)