### PR TITLE
fix(search): max_query_time 을 SphinxQL OPTION 절로 이동 (incident 회복)

### DIFF
--- a/pkg/sphinx/sphinx.go
+++ b/pkg/sphinx/sphinx.go
@@ -113,7 +113,7 @@ func (c *Client) Search(boardID, searchField, searchQuery string, page, limit in
 	offset := (page - 1) * limit
 
 	orderClause := "ORDER BY wr_id DESC"
-	optionClause := "OPTION max_matches=10000, ranker=proximity_bm25, field_weights=(wr_subject=10, wr_content=1)"
+	optionClause := "OPTION max_matches=10000, ranker=proximity_bm25, field_weights=(wr_subject=10, wr_content=1), max_query_time=5000"
 	if len(sortBy) > 0 && sortBy[0] == "relevance" {
 		orderClause = "ORDER BY WEIGHT() DESC, wr_id DESC"
 	}


### PR DESCRIPTION
## Summary
- 5/01 KST 08:51 sphinx.conf searchd 섹션에 `max_query_time = 5000` 추가가 **Sphinx 2.2.11 indexer parse 에서 unknown key 로 FATAL** → delta indexing 5회 retry 모두 fail (~10분 신규 글 검색 미반영)
- 즉시 sphinx.conf rollback (Phase A1 baseline 복원), Telegram alert 가 정상 도착해 OnFailure hook production 검증됨
- 본 PR 은 같은 의도 (5초 query timeout) 를 **per-query SphinxQL OPTION 절** 로 처리 — indexer 영향 0, searchd 만 인식

## Root cause 분석
- Sphinx 2.2.11 (2016 release) 의 `searchd { }` 섹션이 `max_query_time` directive 를 지원하지 않음
- searchd 는 unknown key 무시하고 동작했지만 indexer 는 strict 파싱 → FATAL
- 옳은 위치: SphinxQL `OPTION max_query_time = N` (ms) — 응용 query 시점에 적용

## 변경
- `pkg/sphinx/sphinx.go` Search() 의 OPTION 절에 `max_query_time=5000` 추가 (1 line, 기존 ranker/field_weights 옆)

## Test plan
- [x] make build / go test ./pkg/sphinx/... ./internal/repository/gnuboard/... 통과
- [x] 라이브 SphinxQL query (`MATCH('차') LIMIT 3 OPTION max_query_time=5000, ranker=proximity_bm25, field_weights=(...)`) 정상 결과
- [ ] 머지 + 운영 배포 후 한국어 검색 회귀 (차/검색/다모앙) 결과 ≥ 4/29 baseline
- [ ] 의도적 무거운 query 가 5초 timeout 으로 잘리는지 확인 (선택)

## 5/01 incident 참조
- progress.md: `/home/damoang/docs/optimization/2026-04-29-sphinx-korean-fix/progress.md`
- 운영 영향: 5/01 08:51 ~ 09:01 (~10분) 신규/수정 글 search 미반영. searchd 자체 정상이라 기존 검색 동작.
- A2-2 (query.log 권한), A2-3 (ClickHouse cron), A2-4 (Telegram OnFailure) 는 영향 없음