### PR TITLE
feat(search): SPHINX_PORT env override (Manticore cutover 지원)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -780,17 +780,24 @@ func main() {
 		v2UserRepo := v2repo.NewUserRepository(db)
 		siteRepo := repository.NewSiteRepository(db)
 
-		// Sphinx full-text search (SphinxQL on port 9306)
+		// Sphinx/Manticore full-text search via SphinxQL (default port 9306).
+		// SPHINX_PORT override allows cutover to Manticore container (port 9307).
 		sphinxHost := os.Getenv("SPHINX_HOST")
 		if sphinxHost == "" {
 			sphinxHost = "127.0.0.1"
 		}
+		sphinxPort := 9306
+		if v := os.Getenv("SPHINX_PORT"); v != "" {
+			if p, err := strconv.Atoi(v); err == nil && p > 0 {
+				sphinxPort = p
+			}
+		}
 		var sphinxClient *pkgsphinx.Client
-		if sc, err := pkgsphinx.New(sphinxHost, 9306); err != nil {
+		if sc, err := pkgsphinx.New(sphinxHost, sphinxPort); err != nil {
 			pkglogger.Info("Sphinx unavailable, falling back to MySQL LIKE: %v", err)
 		} else {
 			sphinxClient = sc
-			pkglogger.Info("Sphinx connected (%s:9306)", sphinxHost)
+			pkglogger.Info("Sphinx connected (%s:%d)", sphinxHost, sphinxPort)
 		}
 
 		// Gnuboard repositories for v1 API (g5_* tables)


### PR DESCRIPTION
## Summary
- `cmd/api/main.go` 에 `SPHINX_PORT` 환경변수 추가. 기본 9306 (Sphinx 호환), `SPHINX_PORT=9307` 지정 시 Manticore container (도커 내부 9306, 호스트 9307 bind) 호출
- SphinxQL 프로토콜 호환이라 `pkg/sphinx` 클라이언트 무수정 → drop-in cutover

## Phase C1 Manticore 마이그레이션 컨텍스트
- Sphinx 2.2.11 (2016, EOL) → Manticore 25.0.0 (현재 안정)
- RFC: `/home/damoang/docs/optimization/2026-05-01-search-engine-rfc.md`
- 사용자 요청: Sphinx 삭제 X (disable 만), Docker container 격리 운영
- 호환성 노트 (RFC §8): conf 6 항목 변경 (path / wrapper / chown / charset 한글 / indexer user / restart 흐름)

## 호환성 검증 결과 (free 보드)
| 검색어 | Manticore (9307) | Sphinx (9306) | 차이 |
|---|---|---|---|
| 차 | 341,944 | 341,855 | +0.026% |
| 검색 | 27,571 | 27,559 | +0.044% |
| 다모앙 | 86,784 | 86,759 | +0.029% |
| 전기차 | 81,495 | 81,473 | +0.027% |

Manticore 가 약간 많은 건 방금 indexer 시점 차이 (Sphinx 04:15 daily 대비). 정합성 확인.

## 운영 cutover 절차 (별도 deploy 단계)
1. K8s deployment manifest 의 backend pod env 에 `SPHINX_PORT=9307` 추가
2. canary 1 pod 부터 검증
3. 점진 rollout
4. 안정화 1-2일 → Sphinx (9306) `systemctl disable --now searchd && systemctl mask searchd` (삭제 X)

## Test plan
- [x] `go build ./cmd/api/...` 통과
- [x] `go test ./pkg/sphinx/... ./internal/repository/gnuboard/...` 통과
- [x] Manticore vs Sphinx 한국어 query 결과 정합성 (오차 < 0.05%)
- [ ] 배포 후 SPHINX_PORT 미지정 시 기본 9306 호출 확인 (regression)
- [ ] SPHINX_PORT=9307 지정 시 Manticore 호출 확인 (canary)