### PR TITLE
feat: filter message celebrations by period

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1807,6 +1807,13 @@ func main() {
 			category := c.Query("category") // category filter (ca_name)
 			isSearching := sfl != "" && stx != ""
 			summaryMode := c.Query("summary") == "1" && !isSearching
+			celebrationPeriod := c.Query("celebration_period")
+			if slug != "message" {
+				celebrationPeriod = ""
+			}
+			if celebrationPeriod != "" && celebrationPeriod != "today" && celebrationPeriod != "month" && celebrationPeriod != "upcoming" {
+				celebrationPeriod = "today"
+			}
 
 			// Get blocked user IDs (skip for admins)
 			var blockedIDs []string
@@ -1824,7 +1831,7 @@ func main() {
 			}
 
 			currentUserIDForMemo := middleware.GetUserID(c)
-			if !summaryMode && !isSearching && !useCursor && category == "" {
+			if !summaryMode && !isSearching && !useCursor && category == "" && celebrationPeriod == "" {
 				// Layer 1: In-memory cache (30s TTL)
 				if cached, ok := postMemCache.Load(memKey); ok {
 					mc := cached.(*memCachedPosts)
@@ -1901,6 +1908,11 @@ func main() {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit, "relevance")
 			} else if isSearching {
 				posts, total, err = gnuWriteRepo.SearchPosts(slug, sfl, stx, page, limit)
+			} else if celebrationPeriod != "" && !isSearching {
+				kst := time.FixedZone("KST", 9*60*60)
+				now := time.Now().In(kst)
+				today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, kst)
+				posts, total, err = gnuWriteRepo.FindMessagePostsByPeriod(celebrationPeriod, today, page, limit)
 			} else if summaryMode && useCursor {
 				posts, total, err = gnuWriteRepo.FindPostsAfterSummary(slug, limit, cursorWrNum, cursorWrReply)
 			} else if summaryMode && useHasNextPagination && category != "" && len(blockedIDs) > 0 {
@@ -2004,7 +2016,7 @@ func main() {
 			}
 
 			// Store in both caches (only for non-search, non-category requests, unfiltered data)
-			if !summaryMode && !isSearching && !useCursor && category == "" {
+			if !summaryMode && !isSearching && !useCursor && category == "" && celebrationPeriod == "" {
 				if cacheService != nil {
 					_ = cacheService.SetPosts(ctx, slug, page, limit, response)
 				}

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -76,6 +76,7 @@ type WriteRepository interface {
 	FindPostsFilteredHasNextSummary(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error)
 	FindPostsByCategoryFilteredHasNext(boardID string, category string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error)
 	FindPostsByCategoryFilteredHasNextSummary(boardID string, category string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, bool, error)
+	FindMessagePostsByPeriod(period string, today time.Time, page, limit int) ([]*gnuboard.G5Write, int64, error)
 	FindPostsAfter(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsAfterSummary(boardID string, limit int, cursorWrNum int, cursorWrReply string) ([]*gnuboard.G5Write, int64, error)
 	FindPostsFiltered(boardID string, page, limit int, excludeMbIDs []string) ([]*gnuboard.G5Write, int64, error)
@@ -427,6 +428,54 @@ func (r *writeRepository) findPostsByCategoryHasNext(boardID string, category st
 
 	trimmed, hasNext := trimHasNextPosts(posts, limit)
 	return trimmed, hasNext, err
+}
+
+func (r *writeRepository) FindMessagePostsByPeriod(period string, today time.Time, page, limit int) ([]*gnuboard.G5Write, int64, error) {
+	var posts []*gnuboard.G5Write
+	var total int64
+
+	offset := (page - 1) * limit
+	if offset > maxPostOffset {
+		offset = maxPostOffset
+	}
+
+	table := tableName("message")
+	selectCols := postSelectColumnsForList("message", "", true)
+	dateExpr := "COALESCE(STR_TO_DATE(wr_subject, '%Y.%m.%d'), STR_TO_DATE(wr_subject, '%Y-%m-%d'))"
+	baseWhere := "wr_is_comment = 0 AND " + dateExpr + " IS NOT NULL"
+	args := make([]any, 0, 2)
+	orderClause := "wr_id DESC"
+
+	switch period {
+	case "month":
+		monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
+		nextMonth := monthStart.AddDate(0, 1, 0)
+		baseWhere += " AND " + dateExpr + " >= ? AND " + dateExpr + " < ?"
+		args = append(args, monthStart.Format("2006-01-02"), nextMonth.Format("2006-01-02"))
+		orderClause = dateExpr + " ASC, wr_id DESC"
+	case "upcoming":
+		tomorrow := today.AddDate(0, 0, 1)
+		baseWhere += " AND " + dateExpr + " >= ?"
+		args = append(args, tomorrow.Format("2006-01-02"))
+		orderClause = dateExpr + " ASC, wr_id DESC"
+	default:
+		baseWhere += " AND " + dateExpr + " = ?"
+		args = append(args, today.Format("2006-01-02"))
+	}
+
+	if err := r.db.Table(table).Where(baseWhere, args...).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	err := r.db.Table(table).
+		Select(selectCols).
+		Where(baseWhere, args...).
+		Order(orderClause).
+		Offset(offset).
+		Limit(limit).
+		Find(&posts).Error
+
+	return posts, total, err
 }
 
 // FindPostsAfter retrieves posts using cursor pagination for the default gnuboard sort.


### PR DESCRIPTION
## Summary
- add message-board-only celebration_period filtering to the posts API
- support today, month, and upcoming periods based on KST
- bypass generic posts cache for period-filtered message results

## Verification
- go test ./internal/repository/gnuboard ./cmd/api