### PR TITLE
feat: add social invite reconnect API

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -816,6 +816,12 @@ func main() {
 		gnuTagRepo := gnurepo.NewTagRepository(db)
 		gnuMemberRepo := gnurepo.NewMemberRepository(db)
 		scheduledDeleteRepo := gnurepo.NewScheduledDeleteRepository(db)
+		if err := db.AutoMigrate(&domain.SocialInvite{}); err != nil {
+			pkglogger.Error("SocialInvite AutoMigrate failed: %v", err)
+		}
+		socialInviteRepo := repository.NewSocialInviteRepository(db)
+		socialInviteService := service.NewSocialInviteService(socialInviteRepo)
+		socialInviteHandler := handler.NewSocialInviteHandler(socialInviteService)
 
 		// v2 Core API
 		v2PostRepo := v2repo.NewPostRepository(db)
@@ -915,6 +921,10 @@ func main() {
 		v1Auth.POST("/logout", v2AuthHandler.Logout)
 		v1Auth.GET("/me", middleware.JWTAuth(jwtManager), v2AuthHandler.GetMe)
 		v1Auth.GET("/profile", middleware.JWTAuth(jwtManager), v2AuthHandler.GetMe)
+		router.POST("/api/v1/member-recovery/social-invite", middleware.JWTAuth(jwtManager), middleware.RequireAdmin(), socialInviteHandler.CreateInvite)
+		socialInviteGroup := router.Group("/api/v1/social-invite")
+		socialInviteGroup.GET("/:token", middleware.OptionalJWTAuth(jwtManager), socialInviteHandler.GetInviteInfo)
+		socialInviteGroup.POST("/:token/confirm", middleware.JWTAuth(jwtManager), socialInviteHandler.ConfirmInvite)
 		router.GET("/api/v1/menus/sidebar", func(c *gin.Context) {
 			var menus []domain.Menu
 			if err := db.Where("is_active = ? AND (show_in_sidebar = ? OR show_in_header = ?)", true, true, true).

--- a/internal/domain/social_invite.go
+++ b/internal/domain/social_invite.go
@@ -1,0 +1,67 @@
+package domain
+
+import "time"
+
+// SocialInvite is a one-time token for moving social profiles to a restored member.
+type SocialInvite struct {
+	ID           int        `gorm:"primaryKey" json:"id"`
+	Token        string     `gorm:"column:token;type:varchar(32);uniqueIndex" json:"token"`
+	TargetMbID   string     `gorm:"column:target_mb_id;type:varchar(20)" json:"target_mb_id"`
+	TargetMbNick string     `gorm:"column:target_mb_nick;type:varchar(50)" json:"target_mb_nick"`
+	CreatedBy    string     `gorm:"column:created_by;type:varchar(20)" json:"created_by"`
+	ExpiresAt    time.Time  `gorm:"column:expires_at" json:"expires_at"`
+	UsedAt       *time.Time `gorm:"column:used_at" json:"used_at"`
+	UsedBy       *string    `gorm:"column:used_by;type:varchar(20)" json:"used_by"`
+	CreatedAt    time.Time  `gorm:"column:created_at" json:"created_at"`
+}
+
+func (SocialInvite) TableName() string { return "social_invites" }
+
+type CreateSocialInviteRequest struct {
+	TargetMbID string `json:"target_mb_id" binding:"required"`
+}
+
+type SocialInviteInfoResponse struct {
+	TargetMbID        string            `json:"target_mb_id"`
+	TargetMbNick      string            `json:"target_mb_nick"`
+	ExpiresAt         string            `json:"expires_at"`
+	CurrentUserMbID   string            `json:"current_user_mb_id,omitempty"`
+	CurrentUserMbNick string            `json:"current_user_mb_nick,omitempty"`
+	CurrentSocials    []SocialInviteRef `json:"current_socials,omitempty"`
+}
+
+type SocialInviteRef struct {
+	Provider   string `json:"provider"`
+	SocialName string `json:"social_name"`
+}
+
+type SocialInviteCreateResponse struct {
+	Token               string `json:"token"`
+	URL                 string `json:"url"`
+	ExpiresAt           string `json:"expires_at"`
+	EmailTemplate       string `json:"email_template"`
+	EmailTemplateNoCert string `json:"email_template_no_cert"`
+}
+
+type SocialProfile struct {
+	MpNo        int    `gorm:"column:mp_no;primaryKey" json:"mp_no"`
+	MbID        string `gorm:"column:mb_id" json:"mb_id"`
+	Provider    string `gorm:"column:provider" json:"provider"`
+	Identifier  string `gorm:"column:identifier" json:"identifier"`
+	DisplayName string `gorm:"column:displayname" json:"displayname"`
+	RegisterDay string `gorm:"column:mp_register_day" json:"register_day"`
+	LatestDay   string `gorm:"column:mp_latest_day" json:"latest_day"`
+}
+
+func (SocialProfile) TableName() string { return "g5_member_social_profiles" }
+
+type RecoveryLog struct {
+	ID        int64     `gorm:"primaryKey" json:"id"`
+	MbID      string    `gorm:"column:mb_id" json:"mb_id"`
+	AdminID   string    `gorm:"column:admin_id" json:"admin_id"`
+	Action    string    `gorm:"column:action" json:"action"`
+	Details   string    `gorm:"column:details" json:"details"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"created_at"`
+}
+
+func (RecoveryLog) TableName() string { return "recovery_logs" }

--- a/internal/handler/social_invite_handler.go
+++ b/internal/handler/social_invite_handler.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/damoang/angple-backend/internal/common"
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/middleware"
+	"github.com/damoang/angple-backend/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type SocialInviteHandler struct {
+	service *service.SocialInviteService
+}
+
+func NewSocialInviteHandler(service *service.SocialInviteService) *SocialInviteHandler {
+	return &SocialInviteHandler{service: service}
+}
+
+func (h *SocialInviteHandler) CreateInvite(c *gin.Context) {
+	var req domain.CreateSocialInviteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, "요청 데이터가 올바르지 않습니다", err)
+		return
+	}
+
+	result, err := h.service.CreateInvite(req.TargetMbID, middleware.GetUserID(c))
+	if err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, common.APIResponse{Data: result})
+}
+
+func (h *SocialInviteHandler) GetInviteInfo(c *gin.Context) {
+	token := strings.TrimSpace(c.Param("token"))
+	if token == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "토큰이 필요합니다", nil)
+		return
+	}
+
+	info, err := h.service.GetInviteInfo(token, middleware.GetUserID(c))
+	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "찾을 수 없") || strings.Contains(errMsg, "만료") || strings.Contains(errMsg, "사용된") {
+			common.ErrorResponse(c, http.StatusBadRequest, errMsg, nil)
+			return
+		}
+		common.ErrorResponse(c, http.StatusInternalServerError, "초대 정보를 가져올 수 없습니다", err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: info})
+}
+
+func (h *SocialInviteHandler) ConfirmInvite(c *gin.Context) {
+	token := strings.TrimSpace(c.Param("token"))
+	if token == "" {
+		common.ErrorResponse(c, http.StatusBadRequest, "토큰이 필요합니다", nil)
+		return
+	}
+
+	currentUserMbID := middleware.GetUserID(c)
+	if currentUserMbID == "" {
+		common.ErrorResponse(c, http.StatusUnauthorized, "로그인이 필요합니다", nil)
+		return
+	}
+
+	if err := h.service.ConfirmInvite(token, currentUserMbID); err != nil {
+		common.ErrorResponse(c, http.StatusBadRequest, err.Error(), err)
+		return
+	}
+
+	c.JSON(http.StatusOK, common.APIResponse{Data: gin.H{"message": "소셜 연동이 완료되었습니다"}})
+}

--- a/internal/repository/social_invite_repo.go
+++ b/internal/repository/social_invite_repo.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	gnuboard "github.com/damoang/angple-backend/internal/domain/gnuboard"
+	"gorm.io/gorm"
+)
+
+type SocialInviteRepository struct {
+	db *gorm.DB
+}
+
+func NewSocialInviteRepository(db *gorm.DB) *SocialInviteRepository {
+	return &SocialInviteRepository{db: db}
+}
+
+func (r *SocialInviteRepository) Create(invite *domain.SocialInvite) error {
+	return r.db.Create(invite).Error
+}
+
+func (r *SocialInviteRepository) FindByToken(token string) (*domain.SocialInvite, error) {
+	var invite domain.SocialInvite
+	if err := r.db.Where("token = ?", token).First(&invite).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("초대 토큰 조회 실패: %w", err)
+	}
+	return &invite, nil
+}
+
+func (r *SocialInviteRepository) MarkUsed(token string, usedBy string) error {
+	now := time.Now()
+	result := r.db.Model(&domain.SocialInvite{}).
+		Where("token = ? AND used_at IS NULL", token).
+		Updates(map[string]interface{}{
+			"used_at": now,
+			"used_by": usedBy,
+		})
+	if result.Error != nil {
+		return fmt.Errorf("초대 사용 처리 실패: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("초대를 찾을 수 없거나 이미 사용되었습니다")
+	}
+	return nil
+}
+
+func (r *SocialInviteRepository) FindMemberByID(mbID string) (*gnuboard.G5Member, error) {
+	var member gnuboard.G5Member
+	if err := r.db.Where("mb_id = ?", mbID).First(&member).Error; err != nil {
+		return nil, fmt.Errorf("회원을 찾을 수 없습니다: %w", err)
+	}
+	return &member, nil
+}
+
+func (r *SocialInviteRepository) FindSocialProfiles(mbID string) ([]domain.SocialProfile, error) {
+	var profiles []domain.SocialProfile
+	if err := r.db.Where("mb_id = ?", mbID).Find(&profiles).Error; err != nil {
+		return nil, err
+	}
+	return profiles, nil
+}
+
+func (r *SocialInviteRepository) UpdateSocialProfileOwner(mpNo int, newMbID string) error {
+	result := r.db.Model(&domain.SocialProfile{}).Where("mp_no = ?", mpNo).Update("mb_id", newMbID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("소셜 프로필을 찾을 수 없습니다: mp_no=%d", mpNo)
+	}
+	return nil
+}
+
+func (r *SocialInviteRepository) AppendMemo(mbID string, text string) error {
+	return r.db.Exec(
+		"UPDATE g5_member SET mb_memo = CONCAT(?, '\n', mb_memo) WHERE mb_id = ?",
+		text,
+		mbID,
+	).Error
+}
+
+func (r *SocialInviteRepository) WriteRecoveryLog(mbID, adminID, action, details string) error {
+	return r.db.Create(&domain.RecoveryLog{
+		MbID:    mbID,
+		AdminID: adminID,
+		Action:  action,
+		Details: details,
+	}).Error
+}

--- a/internal/repository/social_invite_repo.go
+++ b/internal/repository/social_invite_repo.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -24,7 +25,7 @@ func (r *SocialInviteRepository) Create(invite *domain.SocialInvite) error {
 func (r *SocialInviteRepository) FindByToken(token string) (*domain.SocialInvite, error) {
 	var invite domain.SocialInvite
 	if err := r.db.Where("token = ?", token).First(&invite).Error; err != nil {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("초대 토큰 조회 실패: %w", err)

--- a/internal/service/social_invite_service.go
+++ b/internal/service/social_invite_service.go
@@ -39,7 +39,7 @@ func (s *SocialInviteService) CreateInvite(targetMbID string, adminID string) (*
 		return nil, fmt.Errorf("회원 '%s'을(를) 찾을 수 없습니다", targetMbID)
 	}
 	if member.MbLeaveDate != "" {
-		return nil, fmt.Errorf("대상 계정이 탈퇴 상태입니다. 먼저 탈퇴 해제 후 초대 링크를 생성해주세요.")
+		return nil, fmt.Errorf("대상 계정이 탈퇴 상태입니다. 먼저 탈퇴 해제 후 초대 링크를 생성해주세요")
 	}
 
 	token, err := generateSocialInviteToken()

--- a/internal/service/social_invite_service.go
+++ b/internal/service/social_invite_service.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/damoang/angple-backend/internal/domain"
+	"github.com/damoang/angple-backend/internal/repository"
+	pkglogger "github.com/damoang/angple-backend/pkg/logger"
+)
+
+type SocialInviteService struct {
+	repo *repository.SocialInviteRepository
+}
+
+func NewSocialInviteService(repo *repository.SocialInviteRepository) *SocialInviteService {
+	return &SocialInviteService{repo: repo}
+}
+
+func generateSocialInviteToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("토큰 생성 실패: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func (s *SocialInviteService) CreateInvite(targetMbID string, adminID string) (*domain.SocialInviteCreateResponse, error) {
+	targetMbID = strings.TrimSpace(targetMbID)
+	if targetMbID == "" {
+		return nil, fmt.Errorf("대상 회원 ID가 필요합니다")
+	}
+
+	member, err := s.repo.FindMemberByID(targetMbID)
+	if err != nil {
+		return nil, fmt.Errorf("회원 '%s'을(를) 찾을 수 없습니다", targetMbID)
+	}
+	if member.MbLeaveDate != "" {
+		return nil, fmt.Errorf("대상 계정이 탈퇴 상태입니다. 먼저 탈퇴 해제 후 초대 링크를 생성해주세요.")
+	}
+
+	token, err := generateSocialInviteToken()
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().Add(12 * time.Hour)
+	invite := &domain.SocialInvite{
+		Token:        token,
+		TargetMbID:   targetMbID,
+		TargetMbNick: member.MbNick,
+		CreatedBy:    adminID,
+		ExpiresAt:    expiresAt,
+	}
+	if err := s.repo.Create(invite); err != nil {
+		return nil, fmt.Errorf("초대 생성 실패: %w", err)
+	}
+
+	s.writeLog(targetMbID, adminID, "social_invite_create", fmt.Sprintf("토큰: %s...", token[:8]))
+
+	url := fmt.Sprintf("https://damoang.net/invite/%s", token)
+	emailCert := fmt.Sprintf("안녕하세요, 다모앙 개인정보책임자입니다.\n\n회원님의 아이디가 실명 인증 처리 및 복원이 완료되었습니다.\n아래 링크에서 소셜 로그인을 연결해주시기 바랍니다.\n\n아이디 : %s\n\n소셜 로그인 연결 : %s\n\n감사합니다.", targetMbID, url)
+	emailNoCert := fmt.Sprintf("안녕하세요, 다모앙 개인정보책임자입니다.\n\n회원님의 아이디가 복원이 완료되었습니다.\n아래 링크에서 소셜 로그인을 연결해주시기 바랍니다.\n\n아이디 : %s\n\n소셜 로그인 연결 : %s\n\n해당 아이디는 실명인증 하지 않는 것으로 나오는데, 실명인증 후에 사용부탁드립니다.\n\n감사합니다.", targetMbID, url)
+
+	pkglogger.Info("[SocialInvite] invite created: target=%s, admin=%s, token=%s...", targetMbID, adminID, token[:8])
+
+	return &domain.SocialInviteCreateResponse{
+		Token:               token,
+		URL:                 url,
+		ExpiresAt:           expiresAt.Format(time.RFC3339),
+		EmailTemplate:       emailCert,
+		EmailTemplateNoCert: emailNoCert,
+	}, nil
+}
+
+func (s *SocialInviteService) GetInviteInfo(token string, currentUserMbID string) (*domain.SocialInviteInfoResponse, error) {
+	invite, err := s.repo.FindByToken(token)
+	if err != nil {
+		return nil, err
+	}
+	if invite == nil {
+		return nil, fmt.Errorf("초대를 찾을 수 없습니다")
+	}
+	if invite.UsedAt != nil {
+		return nil, fmt.Errorf("이미 사용된 초대입니다")
+	}
+	if time.Now().After(invite.ExpiresAt) {
+		return nil, fmt.Errorf("만료된 초대입니다")
+	}
+
+	resp := &domain.SocialInviteInfoResponse{
+		TargetMbID:   invite.TargetMbID,
+		TargetMbNick: invite.TargetMbNick,
+		ExpiresAt:    invite.ExpiresAt.Format(time.RFC3339),
+	}
+
+	if currentUserMbID != "" {
+		resp.CurrentUserMbID = currentUserMbID
+		if member, err := s.repo.FindMemberByID(currentUserMbID); err == nil {
+			resp.CurrentUserMbNick = member.MbNick
+		}
+		if profiles, err := s.repo.FindSocialProfiles(currentUserMbID); err == nil {
+			for _, p := range profiles {
+				resp.CurrentSocials = append(resp.CurrentSocials, domain.SocialInviteRef{
+					Provider:   p.Provider,
+					SocialName: p.DisplayName,
+				})
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+func (s *SocialInviteService) ConfirmInvite(token string, currentUserMbID string) error {
+	if currentUserMbID == "" {
+		return fmt.Errorf("로그인이 필요합니다")
+	}
+
+	invite, err := s.repo.FindByToken(token)
+	if err != nil {
+		return err
+	}
+	if invite == nil {
+		return fmt.Errorf("초대를 찾을 수 없습니다")
+	}
+	if invite.UsedAt != nil {
+		return fmt.Errorf("이미 사용된 초대입니다")
+	}
+	if time.Now().After(invite.ExpiresAt) {
+		return fmt.Errorf("만료된 초대입니다")
+	}
+
+	profiles, err := s.repo.FindSocialProfiles(currentUserMbID)
+	if err != nil {
+		return fmt.Errorf("소셜 프로필 조회 실패: %w", err)
+	}
+	if len(profiles) == 0 {
+		return fmt.Errorf("이전할 소셜 프로필이 없습니다")
+	}
+
+	if err := s.repo.MarkUsed(token, currentUserMbID); err != nil {
+		return fmt.Errorf("이미 사용된 초대입니다")
+	}
+
+	count := 0
+	var transferErrors []string
+	for _, p := range profiles {
+		if err := s.repo.UpdateSocialProfileOwner(p.MpNo, invite.TargetMbID); err != nil {
+			transferErrors = append(transferErrors, fmt.Sprintf("mp_no=%d: %v", p.MpNo, err))
+			pkglogger.Error("[SocialInvite] failed to transfer profile mp_no=%d: %v", p.MpNo, err)
+			continue
+		}
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("소셜 프로필 이전에 실패했습니다 (초대 토큰은 사용 처리됨, 관리자에게 문의하세요)")
+	}
+	if len(transferErrors) > 0 {
+		pkglogger.Error("[SocialInvite] partial transfer: %d/%d succeeded, errors: %v", count, len(profiles), transferErrors)
+	}
+
+	now := time.Now().Format("2006-01-02 15:04:05")
+	_ = s.repo.AppendMemo(currentUserMbID, fmt.Sprintf("[%s] 소셜 프로필 %d개가 %s 계정으로 이전됨 (초대 링크)", now, count, invite.TargetMbID))
+	_ = s.repo.AppendMemo(invite.TargetMbID, fmt.Sprintf("[%s] %s 계정에서 소셜 프로필 %d개 이전받음 (초대 링크)", now, currentUserMbID, count))
+
+	details := fmt.Sprintf("%s → %s: 소셜 프로필 %d개 이전", currentUserMbID, invite.TargetMbID, count)
+	s.writeLog(invite.TargetMbID, invite.CreatedBy, "social_invite_confirm", details)
+
+	pkglogger.Info("[SocialInvite] confirmed: from=%s, to=%s, profiles=%d/%d", currentUserMbID, invite.TargetMbID, count, len(profiles))
+	return nil
+}
+
+func (s *SocialInviteService) writeLog(mbID, adminID, action, details string) {
+	_ = s.repo.WriteRecoveryLog(mbID, adminID, action, details)
+}

--- a/migration/007_social_invites.down.sql
+++ b/migration/007_social_invites.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS social_invites;

--- a/migration/007_social_invites.up.sql
+++ b/migration/007_social_invites.up.sql
@@ -1,0 +1,16 @@
+-- One-time social login reconnect invites for restored accounts.
+CREATE TABLE IF NOT EXISTS social_invites (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    token VARCHAR(32) NOT NULL,
+    target_mb_id VARCHAR(20) NOT NULL,
+    target_mb_nick VARCHAR(50) NOT NULL,
+    created_by VARCHAR(20) NOT NULL,
+    expires_at DATETIME NOT NULL,
+    used_at DATETIME NULL,
+    used_by VARCHAR(20) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uniq_social_invites_token (token),
+    KEY idx_social_invites_target_mb_id (target_mb_id),
+    KEY idx_social_invites_expires_at (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- add backend-owned social invite create/info/confirm API
- add social invite repository/service/handler and routes
- add explicit migration for social_invites table

## Verification
- go test ./...
- go build ./...

## Follow-up
After this backend PR is deployed and verified, the web legacy-backend proxy exception for social-invite can be removed.