### PR TITLE
feat: support past celebration message period

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1821,7 +1821,7 @@ func main() {
 			if slug != "message" {
 				celebrationPeriod = ""
 			}
-			if celebrationPeriod != "" && celebrationPeriod != "today" && celebrationPeriod != "month" && celebrationPeriod != "upcoming" {
+			if celebrationPeriod != "" && celebrationPeriod != "today" && celebrationPeriod != "month" && celebrationPeriod != "upcoming" && celebrationPeriod != "past" {
 				celebrationPeriod = "today"
 			}
 

--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -458,6 +458,10 @@ func (r *writeRepository) FindMessagePostsByPeriod(period string, today time.Tim
 		baseWhere += " AND " + dateExpr + " >= ?"
 		args = append(args, tomorrow.Format("2006-01-02"))
 		orderClause = dateExpr + " ASC, wr_id DESC"
+	case "past":
+		baseWhere += " AND " + dateExpr + " < ?"
+		args = append(args, today.Format("2006-01-02"))
+		orderClause = dateExpr + " DESC, wr_id DESC"
 	default:
 		baseWhere += " AND " + dateExpr + " = ?"
 		args = append(args, today.Format("2006-01-02"))


### PR DESCRIPTION
## Summary\n- Add support for the  celebration period in the board API.\n- Return rows older than today for the message board period filter.\n\n## Notes\n- Today/month/upcoming behavior is unchanged.\n- Only the message board uses the celebration period filter.