### PR TITLE
Broaden wr_subject date parsing for past celebration archive

### DIFF
--- a/internal/repository/gnuboard/write_repo.go
+++ b/internal/repository/gnuboard/write_repo.go
@@ -183,6 +183,14 @@ func postSelectColumns(boardID, alias string) string {
 	return postSelectColumnsForList(boardID, alias, true)
 }
 
+func messageSubjectDateExpr(column string) string {
+	trimmed := fmt.Sprintf("TRIM(%s)", column)
+	return fmt.Sprintf(
+		"COALESCE(STR_TO_DATE(%s, '%%Y.%%m.%%d'), STR_TO_DATE(%s, '%%Y.%%c.%%e'), STR_TO_DATE(%s, '%%Y-%%m-%%d'), STR_TO_DATE(%s, '%%Y-%%c-%%e'))",
+		trimmed, trimmed, trimmed, trimmed,
+	)
+}
+
 // allowedSortColumns is the whitelist for bo_sort_field values
 var allowedSortColumns = map[string]bool{
 	"wr_num, wr_reply":            true,
@@ -441,8 +449,9 @@ func (r *writeRepository) FindMessagePostsByPeriod(period string, today time.Tim
 
 	table := tableName("message")
 	selectCols := postSelectColumnsForList("message", "", true)
-	dateExpr := "COALESCE(STR_TO_DATE(wr_subject, '%Y.%m.%d'), STR_TO_DATE(wr_subject, '%Y-%m-%d'))"
-	baseWhere := "wr_is_comment = 0 AND " + dateExpr + " IS NOT NULL"
+	dateExpr := messageSubjectDateExpr("wr_subject")
+	messageDayExpr := "DATE(wr_datetime)"
+	baseWhere := "wr_is_comment = 0"
 	args := make([]any, 0, 2)
 	orderClause := "wr_id DESC"
 
@@ -450,20 +459,20 @@ func (r *writeRepository) FindMessagePostsByPeriod(period string, today time.Tim
 	case "month":
 		monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
 		nextMonth := monthStart.AddDate(0, 1, 0)
-		baseWhere += " AND " + dateExpr + " >= ? AND " + dateExpr + " < ?"
+		baseWhere += " AND " + dateExpr + " IS NOT NULL AND " + dateExpr + " >= ? AND " + dateExpr + " < ?"
 		args = append(args, monthStart.Format("2006-01-02"), nextMonth.Format("2006-01-02"))
 		orderClause = dateExpr + " ASC, wr_id DESC"
 	case "upcoming":
 		tomorrow := today.AddDate(0, 0, 1)
-		baseWhere += " AND " + dateExpr + " >= ?"
+		baseWhere += " AND " + dateExpr + " IS NOT NULL AND " + dateExpr + " >= ?"
 		args = append(args, tomorrow.Format("2006-01-02"))
 		orderClause = dateExpr + " ASC, wr_id DESC"
 	case "past":
-		baseWhere += " AND " + dateExpr + " < ?"
-		args = append(args, today.Format("2006-01-02"))
-		orderClause = dateExpr + " DESC, wr_id DESC"
+		baseWhere += " AND ((" + dateExpr + " IS NOT NULL AND " + dateExpr + " < ?) OR (" + dateExpr + " IS NULL AND " + messageDayExpr + " < ?))"
+		args = append(args, today.Format("2006-01-02"), today.Format("2006-01-02"))
+		orderClause = "COALESCE(" + dateExpr + ", " + messageDayExpr + ") DESC, wr_id DESC"
 	default:
-		baseWhere += " AND " + dateExpr + " = ?"
+		baseWhere += " AND " + dateExpr + " IS NOT NULL AND " + dateExpr + " = ?"
 		args = append(args, today.Format("2006-01-02"))
 	}
 

--- a/internal/repository/gnuboard/write_repo_test.go
+++ b/internal/repository/gnuboard/write_repo_test.go
@@ -1,6 +1,7 @@
 package gnuboard
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -77,6 +78,22 @@ func TestTableName(t *testing.T) {
 		result := tableName(tt.boardID)
 		if result != tt.expected {
 			t.Errorf("tableName(%q) = %q, want %q", tt.boardID, result, tt.expected)
+		}
+	}
+}
+
+func TestMessageSubjectDateExpr(t *testing.T) {
+	expr := messageSubjectDateExpr("wr_subject")
+	checks := []string{
+		"STR_TO_DATE(TRIM(wr_subject), '%Y.%m.%d')",
+		"STR_TO_DATE(TRIM(wr_subject), '%Y.%c.%e')",
+		"STR_TO_DATE(TRIM(wr_subject), '%Y-%m-%d')",
+		"STR_TO_DATE(TRIM(wr_subject), '%Y-%c-%e')",
+	}
+
+	for _, check := range checks {
+		if !strings.Contains(expr, check) {
+			t.Fatalf("messageSubjectDateExpr() missing %q in %q", check, expr)
 		}
 	}
 }


### PR DESCRIPTION
## 요약

- 추억의 축하메시지를 `wr_subject` 의 더 넓은 날짜 형식으로 해석합니다 — 2026.05.06 / 2026-5-6 / 2026-05-06 / 2026.5.6 등.
- 제목 날짜가 비어있는 오래된 글도 `wr_datetime` 기준으로 잡아 past 아카이브에서 누락되지 않도록 합니다.
- past 결과는 가장 최근 과거 메시지가 먼저 보이도록 날짜 내림차순 정렬을 유지합니다.

## 변경

- `internal/repository/gnuboard/write_repo.go:120`
- `internal/repository/gnuboard/write_repo_test.go` — subject 형식 변형 + wr_datetime fallback 케이스

## 검증

- `go test ./internal/repository/gnuboard ./cmd/api` — 통과

## Test Plan

- [ ] today / month / upcoming / past 각각 결과 확인
- [ ] past 에 오늘 날짜 미포함 + 그 이전은 모두 포함
- [ ] `wr_subject` 가 2026.05.06 / 2026-05-06 둘 다 잡히는지 확인
- [ ] `/message?period=past&page=1` 페이지네이션 정상 동작

## 가정

- 축하메시지 날짜 기준은 게시글 본문이 아닌 `wr_subject` 입니다.
- 오늘 이전은 KST 기준입니다.
- 본 변경은 message 게시판 축하메시지 필터에만 적용됩니다.