### PR TITLE
Persist is_comments_disabled to wr_option in v1 board create/update

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2512,17 +2512,18 @@ func main() {
 
 			// 요청 바디 파싱
 			var req struct {
-				Title    string   `json:"title" binding:"required"`
-				Content  string   `json:"content" binding:"required"`
-				Category *string  `json:"category"`
-				IsSecret *bool    `json:"is_secret"`
-				Link1    *string  `json:"link1"`
-				Link2    *string  `json:"link2"`
-				Extra1   *string  `json:"extra_1"`
-				Extra2   *string  `json:"extra_2"`
-				Extra3   *string  `json:"extra_3"`
-				Tags     []string `json:"tags"`
-				Files    []struct {
+				Title              string   `json:"title" binding:"required"`
+				Content            string   `json:"content" binding:"required"`
+				Category           *string  `json:"category"`
+				IsSecret           *bool    `json:"is_secret"`
+				IsCommentsDisabled *bool    `json:"is_comments_disabled"`
+				Link1              *string  `json:"link1"`
+				Link2              *string  `json:"link2"`
+				Extra1             *string  `json:"extra_1"`
+				Extra2             *string  `json:"extra_2"`
+				Extra3             *string  `json:"extra_3"`
+				Tags               []string `json:"tags"`
+				Files              []struct {
 					Key      string `json:"key"`
 					URL      string `json:"url"`
 					Filename string `json:"filename"`
@@ -2598,10 +2599,16 @@ func main() {
 			now := time.Now()
 			nowStr := now.Format("2006-01-02 15:04:05")
 
-			wrOption := ""
+			// wr_option: 콤마 구분 토큰 — 검증 측은 strings.Contains 로 체크하므로 형식 일치
+			var wrOptionTokens []string
 			if req.IsSecret != nil && *req.IsSecret {
-				wrOption = "secret"
+				wrOptionTokens = append(wrOptionTokens, "secret")
 			}
+			// 댓글 비활성화는 admin (mb_level >= 10) 만 설정 가능 (frontend 게이트와 동일)
+			if req.IsCommentsDisabled != nil && *req.IsCommentsDisabled && userLevel >= 10 {
+				wrOptionTokens = append(wrOptionTokens, "comments_disabled")
+			}
+			wrOption := strings.Join(wrOptionTokens, ",")
 
 			post := gnuboard.G5Write{
 				WrNum:       0,
@@ -3137,16 +3144,17 @@ func main() {
 
 			// 요청 바디 파싱
 			var req struct {
-				Title    *string  `json:"title"`
-				Content  *string  `json:"content"`
-				Category *string  `json:"category"`
-				Link1    *string  `json:"link1"`
-				Link2    *string  `json:"link2"`
-				Extra1   *string  `json:"extra_1"`
-				Extra2   *string  `json:"extra_2"`
-				Extra3   *string  `json:"extra_3"`
-				Tags     []string `json:"tags"`
-				Files    *[]struct {
+				Title              *string  `json:"title"`
+				Content            *string  `json:"content"`
+				Category           *string  `json:"category"`
+				IsCommentsDisabled *bool    `json:"is_comments_disabled"`
+				Link1              *string  `json:"link1"`
+				Link2              *string  `json:"link2"`
+				Extra1             *string  `json:"extra_1"`
+				Extra2             *string  `json:"extra_2"`
+				Extra3             *string  `json:"extra_3"`
+				Tags               []string `json:"tags"`
+				Files              *[]struct {
 					Key      string `json:"key"`
 					URL      string `json:"url"`
 					Filename string `json:"filename"`
@@ -3221,6 +3229,23 @@ func main() {
 			}
 			if req.Extra3 != nil {
 				updates["wr_3"] = *req.Extra3
+			}
+
+			// 댓글 비활성화 토글 (admin only) — 기존 wr_option 의 다른 토큰 (secret 등) 은 보존
+			if req.IsCommentsDisabled != nil && userLevel >= 10 {
+				existing := strings.Split(post.WrOption, ",")
+				kept := existing[:0]
+				for _, tok := range existing {
+					tok = strings.TrimSpace(tok)
+					if tok == "" || tok == "comments_disabled" {
+						continue
+					}
+					kept = append(kept, tok)
+				}
+				if *req.IsCommentsDisabled {
+					kept = append(kept, "comments_disabled")
+				}
+				updates["wr_option"] = strings.Join(kept, ",")
 			}
 
 			if len(updates) == 0 {


### PR DESCRIPTION
## 배경

프론트엔드 글 작성 폼에는 admin (mb_level >= 10) 에게 "댓글 비활성화 (읽기 전용)" 체크박스가 노출되며, 활성화 시 `is_comments_disabled: true` 가 POST/PUT body 에 실립니다.

그러나 v1 board API 가 이 필드를 받지 않아 wr_option 에 저장되지 않았고, 결과적으로 옵션이 무시되었습니다 (#21).

## 진단

- `POST /api/v1/boards/:slug/posts` (cmd/api/main.go:2497~) 의 req struct 가 `IsSecret` 만 bind. `is_comments_disabled` 는 ShouldBindJSON 단계에서 무시됨.
- `PUT /api/v1/boards/:slug/posts/:id` 의 updates map 에 `wr_option` 처리 자체가 없음. admin 이 글 수정으로 옵션을 켜거나 끌 수 없음.
- 댓글 작성 측 (handler v2 L864~872) 은 이미 `strings.Contains(wr_option, "comments_disabled")` 로 차단. 즉 wr_option 에 토큰만 들어가면 차단 동작은 정상.

## 변경

- `cmd/api/main.go` POST /api/v1/boards/:slug/posts
  - req struct 에 `IsCommentsDisabled *bool` 추가
  - wrOption 구성 로직을 콤마 join 으로 변경 → secret + comments_disabled 동시 적용 가능
  - admin only (`userLevel >= 10`) 게이트 (frontend visibility 와 일치)
- `cmd/api/main.go` PUT /api/v1/boards/:slug/posts/:id
  - req struct 에 `IsCommentsDisabled *bool` 추가
  - admin 이 toggle 시 기존 wr_option 의 다른 토큰 (secret 등) 보존 + comments_disabled 만 add/remove
  - 비-admin 의 변경 시도는 무시

## 검증

- `go build ./cmd/api/...` 통과

## Test Plan

- [ ] admin 계정으로 새 글 작성 시 댓글 비활성화 체크 → 글 상세에서 댓글 입력폼 차단 + "공감/이모지로 응원" 안내 노출
- [ ] admin 이 기존 글 수정해서 옵션 켜기/끄기 → DB `wr_option` 토큰 add/remove 확인
- [ ] secret + comments_disabled 동시 활성 → wr_option="secret,comments_disabled"
- [ ] 일반 사용자가 `is_comments_disabled` 을 직접 POST 해도 admin 게이트로 무시됨