### PR TITLE
Record leave reason when admin processes member withdrawal

### DIFF
--- a/internal/domain/gnuboard/member.go
+++ b/internal/domain/gnuboard/member.go
@@ -34,6 +34,7 @@ type G5Member struct {
 	MbDatetime       time.Time  `gorm:"column:mb_datetime" json:"mb_datetime"`
 	MbIP             string     `gorm:"column:mb_ip" json:"-"`
 	MbLeaveDate      string     `gorm:"column:mb_leave_date" json:"mb_leave_date"`
+	MbLeaveReason    string     `gorm:"column:mb_leave_reason" json:"mb_leave_reason"`
 	MbInterceptDate  string     `gorm:"column:mb_intercept_date" json:"mb_intercept_date"`
 	MbEmailCertify   string     `gorm:"column:mb_email_certify" json:"mb_email_certify"`
 	MbMemo           string     `gorm:"column:mb_memo" json:"-"`

--- a/internal/handler/admin_member_handler.go
+++ b/internal/handler/admin_member_handler.go
@@ -215,15 +215,15 @@ func (h *AdminMemberHandler) GetMember(c *gin.Context) {
 func (h *AdminMemberHandler) UpdateMember(c *gin.Context) {
 	mbID := c.Param("mbId")
 	var req struct {
-		MbLevel     *int    `json:"mb_level"`
-		MbPoint     *int    `json:"mb_point"`
-		MbName      *string `json:"mb_name"`
-		MbRealName  *string `json:"mb_real_name"`
-		MbEmail     *string `json:"mb_email"`
-		MbSignature *string `json:"mb_signature"`
-		MbMemo      *string `json:"mb_memo"`
-		MbLeave        *bool   `json:"mb_leave"`
-		MbLeaveReason  *string `json:"mb_leave_reason"`
+		MbLevel       *int    `json:"mb_level"`
+		MbPoint       *int    `json:"mb_point"`
+		MbName        *string `json:"mb_name"`
+		MbRealName    *string `json:"mb_real_name"`
+		MbEmail       *string `json:"mb_email"`
+		MbSignature   *string `json:"mb_signature"`
+		MbMemo        *string `json:"mb_memo"`
+		MbLeave       *bool   `json:"mb_leave"`
+		MbLeaveReason *string `json:"mb_leave_reason"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)

--- a/internal/handler/admin_member_handler.go
+++ b/internal/handler/admin_member_handler.go
@@ -37,6 +37,7 @@ type adminMemberResponse struct {
 	MbTodayLogin    *string `json:"mb_today_login"`
 	MbImage         *string `json:"mb_image,omitempty"`
 	MbLeaveDate     *string `json:"mb_leave_date,omitempty"`
+	MbLeaveReason   *string `json:"mb_leave_reason,omitempty"`
 	MbInterceptDate *string `json:"mb_intercept_date,omitempty"`
 }
 
@@ -57,6 +58,9 @@ func toAdminMemberResponse(m *gnuboard.G5Member) adminMemberResponse {
 	}
 	if m.MbLeaveDate != "" {
 		resp.MbLeaveDate = &m.MbLeaveDate
+		if m.MbLeaveReason != "" {
+			resp.MbLeaveReason = &m.MbLeaveReason
+		}
 	}
 	if m.MbInterceptDate != "" {
 		resp.MbInterceptDate = &m.MbInterceptDate
@@ -218,7 +222,8 @@ func (h *AdminMemberHandler) UpdateMember(c *gin.Context) {
 		MbEmail     *string `json:"mb_email"`
 		MbSignature *string `json:"mb_signature"`
 		MbMemo      *string `json:"mb_memo"`
-		MbLeave     *bool   `json:"mb_leave"`
+		MbLeave        *bool   `json:"mb_leave"`
+		MbLeaveReason  *string `json:"mb_leave_reason"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
@@ -263,9 +268,15 @@ func (h *AdminMemberHandler) UpdateMember(c *gin.Context) {
 	}
 	if req.MbLeave != nil {
 		if *req.MbLeave {
-			updates["mb_leave_date"] = time.Now().Format("2006-01-02")
+			updates["mb_leave_date"] = time.Now().Format("20060102")
+			reason := "self"
+			if req.MbLeaveReason != nil && *req.MbLeaveReason != "" {
+				reason = *req.MbLeaveReason
+			}
+			updates["mb_leave_reason"] = reason
 		} else {
 			updates["mb_leave_date"] = ""
+			updates["mb_leave_reason"] = ""
 		}
 	}
 	if len(updates) == 0 {

--- a/migration/008_add_mb_leave_reason.up.sql
+++ b/migration/008_add_mb_leave_reason.up.sql
@@ -1,0 +1,12 @@
+-- 회원 탈퇴 사유 컬럼 추가 (#feat/leave-reason-recording)
+-- 값 목록: self(본인탈퇴), admin(관리자처리), terms_violation(약관위반),
+--          contract_withdrawal(계약철회/개인정보보호법), account_abuse(계정도용/악용), other(기타)
+ALTER TABLE g5_member
+  ADD COLUMN mb_leave_reason VARCHAR(50) NOT NULL DEFAULT '' AFTER mb_leave_date;
+
+-- diynbetterlife(naver_9c950964) 탈퇴 날짜 오기록 보정 (05.01 → 20260511)
+UPDATE g5_member
+SET mb_leave_date   = '20260511',
+    mb_leave_reason = 'admin'
+WHERE mb_id = 'naver_9c950964'
+  AND mb_leave_date != '';


### PR DESCRIPTION
## 요약

회원 탈퇴 처리 시 탈퇴 사유를 기록하는 기능 추가.

## 변경

- `migration/008_add_mb_leave_reason.up.sql` — g5_member 에 mb_leave_reason VARCHAR(50) 컬럼 추가 + diynbetterlife 날짜 오기록 보정 (20260501 → 20260511)
- `internal/domain/gnuboard/member.go` — MbLeaveReason 필드 추가
- `internal/handler/admin_member_handler.go` — 탈퇴 처리 시 reason 저장, 응답에 mb_leave_reason 포함

## 탈퇴 사유 목록

| value | 표시 |
|-------|------|
| self | 본인 탈퇴 (기본값) |
| admin | 관리자 처리 |
| terms_violation | 약관 위반 |
| contract_withdrawal | 계약 철회 (개인정보보호법) |
| account_abuse | 계정 도용/악용 |
| other | 기타 |

## Migration 실행 필요

PR 머지 후 운영 DB 에 직접 실행:
```
mysql damoang < migration/008_add_mb_leave_reason.up.sql
```

## 연관 PR

- angple frontend PR (탈퇴 UI 사유 선택 dialog)