### PR TITLE
Exclude reaction notifications from all notification queries

### DIFF
--- a/internal/repository/gnuboard/noti_repo.go
+++ b/internal/repository/gnuboard/noti_repo.go
@@ -137,8 +137,10 @@ func (r *notiRepository) Exists(mbID, boTable string, wrID int, fromCase, relMbI
 // GetGroupedNotifications returns notifications grouped by (bo_table, wr_id, ph_from_case)
 // Optimized: 2-pass approach — first identify top N groups (lightweight), then enrich only those groups
 func (r *notiRepository) GetGroupedNotifications(mbID string, page, limit int, filterType string) ([]GroupedNotification, int64, int64, error) {
-	// Build filter condition
-	fromCaseFilter := ""
+	// Build filter condition.
+	// 'reaction' 타입은 항상 제외 — 이모지 리액션 알림은 운영 정책상 비활성.
+	// ph_from_case='reaction' 행이 DB에 존재하지만 사용자에게 노출하지 않는다.
+	fromCaseFilter := "AND ph_from_case != 'reaction'"
 	switch filterType {
 	case "comment":
 		fromCaseFilter = "AND ph_from_case IN ('board', 'comment', 'reply')"


### PR DESCRIPTION
## 배경

이모지 리액션(ph_from_case='reaction') 이 g5_na_noti 에 INSERT 되고 있고, mapFromCase 에 reaction 매핑이 없어 **"새 알림이 있습니다"** 로 표시되던 문제.

운영 정책: 이모지 리액션은 알림을 발송하지 않음.

## 변경

`internal/repository/gnuboard/noti_repo.go` — GetGroupedNotifications 의 기본 필터를 `ph_from_case != 'reaction'` 으로 변경.

- filterType 파라미터와 무관하게 reaction 타입은 항상 제외
- good(추천), comment, mention, memo, system 등 모든 기존 타입 영향 없음

## 검증

- go build 통과
- 기존 알림 타입 필터 (like/comment/mention 등) 로직 변경 없음