### PR TITLE
fix(api): block comment edit/delete when child replies exist (#12401)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3387,6 +3387,24 @@ func main() {
 				return
 			}
 
+			// 자식 댓글(대댓글) 존재 시 작성자 수정 차단 — 관리자는 우회
+			// 그누보드 답글 트리 규칙: 같은 wr_parent 안에서 wr_comment_reply 가
+			// 본 댓글의 prefix 로 시작하고 길이가 더 긴 row 가 자식.
+			if userLevel < 10 {
+				var childCount int64
+				parentReply := comment.WrCommentReply
+				tbl := fmt.Sprintf("g5_write_%s", slug)
+				if err := db.Table(tbl).
+					Where("wr_parent = ?", comment.WrParent).
+					Where("wr_is_comment = 1").
+					Where("wr_comment_reply LIKE ?", parentReply+"%").
+					Where("LENGTH(wr_comment_reply) > ?", len(parentReply)).
+					Count(&childCount).Error; err == nil && childCount > 0 {
+					c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "대댓글이 있는 댓글은 수정할 수 없습니다"})
+					return
+				}
+			}
+
 			// 요청 바디 파싱
 			var req struct {
 				Content string `json:"content" binding:"required"`
@@ -3814,6 +3832,22 @@ func main() {
 			if comment.MbID != userID && userLevel < 10 {
 				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "삭제 권한이 없습니다"})
 				return
+			}
+
+			// 자식 댓글(대댓글) 존재 시 작성자 삭제 차단 — 관리자는 우회
+			if userLevel < 10 {
+				var childCount int64
+				parentReply := comment.WrCommentReply
+				tbl := fmt.Sprintf("g5_write_%s", slug)
+				if err := db.Table(tbl).
+					Where("wr_parent = ?", comment.WrParent).
+					Where("wr_is_comment = 1").
+					Where("wr_comment_reply LIKE ?", parentReply+"%").
+					Where("LENGTH(wr_comment_reply) > ?", len(parentReply)).
+					Count(&childCount).Error; err == nil && childCount > 0 {
+					c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "대댓글이 있는 댓글은 삭제할 수 없습니다"})
+					return
+				}
 			}
 
 			// 관리자(level >= 10)는 즉시 삭제


### PR DESCRIPTION
## Summary
- Bug #12401 (긴급): 대댓글이 달린 댓글이 작성자에 의해 수정/삭제 가능했던 회귀를 차단합니다.
- 프론트엔드 `comment-list.svelte:407 canEditComment()` 는 이미 `hasReplies()` 로 수정/삭제 버튼을 숨기고 있었지만, **백엔드 핸들러에 동일 가드가 없어** DevTools/curl 로 우회 가능했습니다.
- 그누보드 답글 트리 표준 룰 (`wr_parent` + `wr_is_comment=1` + `wr_comment_reply` prefix + 길이 비교) 로 자식 댓글 존재 판정.
- 관리자(`mb_level >= 10`)는 우회 허용 — 프론트엔드의 `isAdmin()` short-circuit 과 동일.
- 수정 히스토리는 기존 `g5_write_revisions` / `v2_content_revisions` / `g5_da_content_history` 트리플 저장이 이미 정상 동작 중이라 별도 변경 없음.

## Affected endpoints
- `PUT /api/v1/boards/:slug/posts/:id/comments/:comment_id` (main.go:3367)
- `DELETE /api/v1/boards/:slug/posts/:id/comments/:comment_id` (main.go:3795)

## Test plan
- [ ] 자식 댓글 없는 본인 댓글: 수정/삭제 정상
- [ ] 자식 댓글 있는 본인 댓글 (UI 우회, curl): **HTTP 400 + "대댓글이 있는 댓글은 수정/삭제할 수 없습니다"**
- [ ] 자식 댓글 있는 댓글, 관리자 계정 (level>=10): 수정/삭제 가능 (우회 동작 확인)
- [ ] 다른 사용자 댓글에 대한 수정/삭제 시도: 403 그대로
- [ ] 수정 후 `g5_write_revisions` / `v2_content_revisions` / `g5_da_content_history` 3 곳 모두 신규 row 적재 확인
- [ ] CI: build / vet / lint 통과

Refs #12401