### PR TITLE
feat(comments): charge 10,000P per comment edit (#12401 follow-up)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3426,6 +3426,30 @@ func main() {
 				return
 			}
 
+			// 댓글 수정 포인트 차감 — 작성자 부담, 관리자 면제
+			// 수정 행위 자체에 비용을 부과하여 "신중한 작성" 을 유도. UI 와 API 우회 호출 양쪽 동일 적용.
+			const commentEditCost = 10000
+			pointDeducted := false
+			if userLevel < 10 {
+				canAfford, err := gnuPointWriteRepo.CanAfford(userID, -commentEditCost)
+				if err != nil {
+					releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 확인 실패"})
+					return
+				}
+				if !canAfford {
+					releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": fmt.Sprintf("댓글 수정에 %d 포인트가 필요합니다. 보유 포인트가 부족합니다.", commentEditCost)})
+					return
+				}
+				if err := gnuPointWriteRepo.AddPoint(userID, -commentEditCost, "댓글 수정", fmt.Sprintf("g5_write_%s", slug), strconv.Itoa(commentID), "comment_edit", nil); err != nil {
+					releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
+					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "포인트 차감 실패"})
+					return
+				}
+				pointDeducted = true
+			}
+
 			// 수정 전 내용을 리비전에 저장 — 양쪽 테이블 모두 기록
 			var nextVersion int
 			db.Raw("SELECT COALESCE(MAX(version), 0) + 1 FROM g5_write_revisions WHERE board_id = ? AND wr_id = ?",
@@ -3492,6 +3516,12 @@ func main() {
 				)
 			}
 			if txErr != nil {
+				// 본문 update 실패 시 차감 보상 트랜잭션 — 사용자 손해 방지
+				if pointDeducted {
+					if err := gnuPointWriteRepo.AddPoint(userID, commentEditCost, "댓글 수정 실패 환불", fmt.Sprintf("g5_write_%s", slug), strconv.Itoa(commentID), "comment_edit_rollback", nil); err != nil {
+						log.Printf("[CRITICAL] 댓글 수정 차감 롤백 실패 mb_id=%s wr_id=%d: %v", userID, commentID, err)
+					}
+				}
 				releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)
 				c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "댓글 수정 실패"})
 				return


### PR DESCRIPTION
## Summary
운영진 결정 — 댓글 수정 1회당 작성자에게 10,000P 차감 (관리자 면제).

UI 와 API 우회 호출 양쪽이 동일 endpoint 를 쓰기 때문에 백엔드에서 구분 불가 → "수정 행위 자체에 비용을 부과해 신중한 작성 유도" 정책으로 통일 적용.

## Behavior
- `mb_level < 10` (일반 작성자):
  - `gnuPointWriteRepo.CanAfford` 로 잔액 확인 → 부족 시 **403 + "댓글 수정에 10,000 포인트가 필요합니다. 보유 포인트가 부족합니다."** (차감/수정 모두 발생 안 함)
  - 잔액 충분 시 `AddPoint(-10000, "댓글 수정", g5_write_{slug}, wr_id, comment_edit, nil)` 호출 → `g5_point` 음수 row + `g5_member.mb_point` 감소
- `mb_level >= 10` (관리자): 우회 (운영 작업 영향 없도록 PR #466 패턴과 일관)
- 본문 UPDATE 트랜잭션이 차감 이후 실패하면 `AddPoint(+10000, "댓글 수정 실패 환불", ..., comment_edit_rollback, nil)` 보상 트랜잭션으로 환불. 환불 실패는 CRITICAL 로깅 (운영 follow-up).

## Order in handler
1. 권한 체크
2. 자식 댓글 가드 (#466)
3. 요청 바디 파싱
4. Idempotency 시작
5. **포인트 차감 (본 PR)**
6. Revision 저장 (g5_write_revisions / v2_content_revisions / g5_da_content_history) — 변경 없음
7. 본문 UPDATE 트랜잭션
8. 실패 시 차감 롤백 + idempotency release

## Test plan
- [ ] 일반 사용자, 잔액 ≥ 10000: 수정 성공 + `g5_point` 음수 row + `mb_point` -10000
- [ ] 일반 사용자, 잔액 < 10000: 403 응답, 차감/수정 모두 발생 안 함
- [ ] 관리자(mb_level >= 10): 수정 성공, **포인트 변동 없음**
- [ ] 자식 댓글 있는 댓글 (PR #466 가드): 400 응답, **포인트 변동 없음** (가드가 차감 전에 실행됨)
- [ ] DevTools / Postman / curl 로 직접 PUT 호출: 동일 정책 적용 (10,000P 차감)
- [ ] 본문 UPDATE 인위 실패 시뮬레이션: 차감 후 환불 row (`comment_edit_rollback`) 적재 + `mb_point` 원복
- [ ] Idempotency duplicate: 두 번째 호출은 cached 응답, 차감 1회만

## Not in scope
- 게시글(원글) 수정 — 별도 정책 결정 후 후속 PR
- 사용자 안내 UI (예: 수정 버튼 옆 "10,000P 차감" 표기) — 프론트엔드 PR 별도

## Operational notes
- 머지 후 새벽 4시 정기 배포 + 운영 측 명시 승인 후 적용
- 일반 사용자 입장에서는 큰 정책 변화 — 공지 병행 권장

Refs #12401