### PR TITLE
feat(comments): configurable edit policy — 50k P + 5min grace (#12401 follow-up)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -127,6 +127,26 @@ var writeDuplicateDetectedTotal = promauto.NewCounterVec(
 	[]string{"operation", "reason"},
 )
 
+// getCommentEditPolicy returns the comment-edit cost (in points) and grace period (in seconds)
+// from environment variables, falling back to safe defaults. Defaults match the operator
+// decision of 2026-05-15: 50,000 P per edit with a 5-minute grace window after creation.
+// Setting COMMENT_EDIT_COST=0 disables charging entirely (revision-only mode).
+func getCommentEditPolicy() (cost, graceSeconds int) {
+	cost = 50000
+	if v := os.Getenv("COMMENT_EDIT_COST"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 0 {
+			cost = parsed
+		}
+	}
+	graceSeconds = 300
+	if v := os.Getenv("COMMENT_EDIT_GRACE_SECONDS"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 0 {
+			graceSeconds = parsed
+		}
+	}
+	return cost, graceSeconds
+}
+
 func makePostDedupKey(boardID, memberID, title string) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(strings.ToLower(title))))
 	return fmt.Sprintf("write:dedupe:%s:%s:%s", boardID, memberID, hex.EncodeToString(sum[:]))
@@ -2286,9 +2306,17 @@ func main() {
 				transformed = enrichWithAuthorMemo(db, currentUserID, transformed)
 			}
 
+			// 댓글 수정 정책 메타 — 프론트엔드 confirm 다이얼로그에서 사용 (단일 진실 근원: 백엔드 env)
+			editCost, editGraceSeconds := getCommentEditPolicy()
 			c.JSON(http.StatusOK, gin.H{
 				"success": true,
 				"data":    transformed,
+				"meta": gin.H{
+					"comment_edit_policy": gin.H{
+						"cost":          editCost,
+						"grace_seconds": editGraceSeconds,
+					},
+				},
 			})
 		})
 
@@ -3426,11 +3454,13 @@ func main() {
 				return
 			}
 
-			// 댓글 수정 포인트 차감 — 작성자 부담, 관리자 면제
-			// 수정 행위 자체에 비용을 부과하여 "신중한 작성" 을 유도. UI 와 API 우회 호출 양쪽 동일 적용.
-			const commentEditCost = 10000
+			// 댓글 수정 포인트 차감 정책 — env 기반, 하드코딩 금지 (getCommentEditPolicy 참고).
+			// 관리자(mb_level >= 10) 는 항상 면제. UI / API 우회 호출 동일 적용.
+			commentEditCost, graceSeconds := getCommentEditPolicy()
+			inGracePeriod := time.Since(comment.WrDatetime) <= time.Duration(graceSeconds)*time.Second
+
 			pointDeducted := false
-			if userLevel < 10 {
+			if userLevel < 10 && !inGracePeriod && commentEditCost > 0 {
 				canAfford, err := gnuPointWriteRepo.CanAfford(userID, -commentEditCost)
 				if err != nil {
 					releaseIdempotentWrite(c.Request.Context(), redisClient, idempotencyBaseKey)


### PR DESCRIPTION
## Summary
PR #467 의 하드코딩된 10,000P 차감을 env 기반 정책으로 전환 + 5분 grace 추가.

운영진 결정 (2026-05-15):
- **기본 차감**: 50,000P (PR #467 의 10,000 → 상향)
- **Grace period**: 작성 후 5분 이내 수정은 면제 (오타 즉시 수정 보호)
- **하드코딩 금지**: 정책 변경 시 코드 변경 없이 env 만 갱신 후 pod rollout

## Changes
- `getCommentEditPolicy()` 헬퍼 신설 — `COMMENT_EDIT_COST` / `COMMENT_EDIT_GRACE_SECONDS` env 읽기, default 50000/300, 0 으로 두면 정책 비활성화 (kill switch)
- UpdateComment 핸들러: grace 내 수정 또는 cost=0 일 때 차감 스킵, 환불 경로도 동적 cost 사용
- 댓글 list GET 응답에 `meta.comment_edit_policy: {cost, grace_seconds}` 추가 — 프론트엔드 confirm 다이얼로그가 SSOT (백엔드 env) 의 값을 직접 사용 가능 → 프론트엔드 하드코딩 불가

## Behavior matrix (mb_level < 10)
| 케이스 | 결과 |
|---|---|
| Grace 윈도우 (≤300s) 안 수정 | 차감 없음, 수정 진행 |
| Grace 윈도우 밖 + 잔액 충분 | -50,000P, 수정 진행 |
| Grace 윈도우 밖 + 잔액 부족 | 403, 차감/수정 모두 없음 |
| `COMMENT_EDIT_COST=0` | 차감 없음, 수정 진행 (kill switch) |
| 관리자 (mb_level ≥ 10) | 항상 면제 (변경 없음) |

## Operator notes
- 운영 적용 = K8s configmap 에 `COMMENT_EDIT_COST=50000` / `COMMENT_EDIT_GRACE_SECONDS=300` 추가 + rollout (또는 env 미설정 시 default 적용)
- Kill switch 가 필요한 경우 `COMMENT_EDIT_COST=0` 으로 변경 후 rollout

## Test plan
- [ ] env 미설정: default 50000 / 300 적용
- [ ] env 설정: 값 그대로 반영
- [ ] Grace 윈도우 (<5분) 수정: 차감 없음
- [ ] Grace 윈도우 (>5분) 수정 + 잔액 충분: -50,000P
- [ ] Grace 윈도우 밖 + 잔액 부족: 403
- [ ] `COMMENT_EDIT_COST=0` 설정: 차감 비활성, 수정 정상
- [ ] 댓글 list GET 응답에 `meta.comment_edit_policy` 포함
- [ ] CI: build / vet / lint 통과

Refs #12401, depends on / supersedes parts of #467