### PR TITLE
feat(saas): sites 통합 테이블 + cookieDomain dual-read (Phase 8 Day 1+2)

### DIFF
--- a/internal/handler/v2/auth_handler.go
+++ b/internal/handler/v2/auth_handler.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,7 +50,7 @@ func isSecureCookie() bool {
 	return gin.Mode() == gin.ReleaseMode
 }
 
-// authDomainGroup — auth_domain_groups 테이블 1 row (cookie domain 멀티 테넌트 매핑)
+// authDomainGroup — auth_domain_groups 테이블 1 row (legacy, Phase 8 Day 6 에서 deprecated 예정)
 type authDomainGroup struct {
 	Suffix       string `gorm:"primaryKey"`
 	CookieDomain string
@@ -57,10 +58,21 @@ type authDomainGroup struct {
 
 func (authDomainGroup) TableName() string { return "auth_domain_groups" }
 
+// site — sites 테이블 1 row (Phase 8 Day 1, multi-tenant SaaS 통합 식별)
+type site struct {
+	Slug         string `gorm:"column:slug"`
+	PrimaryHost  string `gorm:"column:primary_host"`
+	Aliases      string `gorm:"column:aliases;type:json"` // JSON 문자열 (gorm 이 raw 로 가져옴)
+	CookieDomain string `gorm:"column:cookie_domain"`
+	Status       string `gorm:"column:status"`
+}
+
+func (site) TableName() string { return "sites" }
+
 // cookieDomainCache — DB-backed lookup 의 in-memory cache (5분 TTL)
 type cookieDomainCache struct {
 	mu       sync.RWMutex
-	rules    map[string]string // suffix → cookie_domain
+	rules    map[string]string // host/suffix → cookie_domain
 	loadedAt time.Time
 }
 
@@ -70,16 +82,48 @@ const cdCacheTTL = 5 * time.Minute
 
 // StartCookieDomainCacheRefresher — 앱 부팅 시 1회 호출하여 즉시 cache 로드 + 5분마다 background refresh.
 // 새 사이트 admin UI 추가 시 5분 안에 자동 적용.
+//
+// Phase 8 Day 2 — dual-read: sites 테이블 우선, auth_domain_groups fallback.
+//   - sites.primary_host + sites.aliases → cookie_domain (활성 상태만)
+//   - auth_domain_groups.suffix (sites 미커버 suffix backfill)
+//
+// Phase 8 Day 6 에서 auth_domain_groups 제거 예정 (sites 단일 source).
 func StartCookieDomainCacheRefresher(db *gorm.DB) {
 	refresh := func() {
+		m := make(map[string]string)
+
+		// 1) sites 테이블 — primary_host + aliases 등록 (활성만)
+		var sites []site
+		if err := db.Where("status = ?", "active").Find(&sites).Error; err == nil {
+			for _, s := range sites {
+				m[s.PrimaryHost] = s.CookieDomain
+				if s.Aliases != "" && s.Aliases != "null" {
+					var aliases []string
+					if err := json.Unmarshal([]byte(s.Aliases), &aliases); err == nil {
+						for _, a := range aliases {
+							m[a] = s.CookieDomain
+						}
+					}
+				}
+			}
+		}
+		// sites 쿼리 실패 시: m 비어있어도 다음 단계 진행 (auth_domain_groups fallback)
+
+		// 2) auth_domain_groups — sites 미커버 suffix 만 backfill (legacy 호환)
 		var rules []authDomainGroup
-		if err := db.Find(&rules).Error; err != nil {
-			return // DB 에러 시 기존 cache 유지 (fail-safe)
+		if err := db.Find(&rules).Error; err == nil {
+			for _, r := range rules {
+				if _, exists := m[r.Suffix]; !exists {
+					m[r.Suffix] = r.CookieDomain
+				}
+			}
 		}
-		m := make(map[string]string, len(rules))
-		for _, r := range rules {
-			m[r.Suffix] = r.CookieDomain
+
+		// 둘 다 실패 + 기존 cache 있으면 유지 (fail-safe)
+		if len(m) == 0 {
+			return
 		}
+
 		globalCDCache.mu.Lock()
 		globalCDCache.rules = m
 		globalCDCache.loadedAt = time.Now()

--- a/migrations/004_sites_table.sql
+++ b/migrations/004_sites_table.sql
@@ -1,0 +1,60 @@
+-- sites: 통합 multi-tenant SaaS 식별 테이블 (WordPress wp_blogs / Discourse Multisite / Ghost sites 패턴)
+-- Phase 8 Day 1: church_sites + auth_domain_groups + hostname 하드코딩 을 단일 source of truth 로 통합
+--
+-- 점진 마이그레이션 전략:
+--   Day 2 — backend cookieDomain(host) 가 sites 우선, auth_domain_groups fallback (dual-read)
+--   Day 3 — super-admin/sites UI 가 sites 사용
+--   Day 4 — frontend getSiteByHost() helper + locals.site 주입
+--   Day 5 — church_sites ↔ sites 매핑
+--   Day 6 — auth_domain_groups deprecated (sites.cookie_domain 단일 source)
+--   Day 7 — regression
+
+CREATE TABLE IF NOT EXISTS sites (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    slug VARCHAR(64) NOT NULL UNIQUE COMMENT 'URL-safe identifier: muzia, damoang, churchre, hdbc',
+    primary_host VARCHAR(255) NOT NULL UNIQUE COMMENT 'Canonical hostname (muzia.net)',
+    aliases JSON DEFAULT NULL COMMENT 'Alternative hostnames: ["muzia.io","www.muzia.net"]',
+    site_type ENUM('saas','tenant') NOT NULL DEFAULT 'saas'
+        COMMENT 'saas=root site, tenant=sub-site (churchre 안 각 교회)',
+    parent_site_id BIGINT DEFAULT NULL
+        COMMENT 'tenant 사이트의 부모 (hopechurch → churchre.id)',
+    cookie_domain VARCHAR(255) NOT NULL DEFAULT ''
+        COMMENT '".damoang.net" 멀티 서브도메인 SSO 또는 빈 문자열 (host-only)',
+    theme_slug VARCHAR(64) NOT NULL DEFAULT 'default'
+        COMMENT '활성 테마: muzia, churchre, damoang, default',
+    plan ENUM('free','pro','enterprise','internal') NOT NULL DEFAULT 'internal'
+        COMMENT '구독 플랜 (Phase 8.4 에서 구독 결제 연동)',
+    status ENUM('active','suspended','archived') NOT NULL DEFAULT 'active',
+    settings JSON DEFAULT NULL
+        COMMENT '사이트별 설정: {logo_url, brand_color, csp_extra, features: {market:true, arrange:false}, ...}',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_primary_host (primary_host),
+    INDEX idx_parent (parent_site_id),
+    INDEX idx_status_type (status, site_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed: 현재 운영 중인 4 root SaaS 사이트
+-- (churchre tenants 는 Day 5 에 church_sites 에서 migrate)
+INSERT INTO sites (slug, primary_host, aliases, site_type, cookie_domain, theme_slug, plan, settings) VALUES
+  ('damoang', 'damoang.net',
+   JSON_ARRAY('www.damoang.net','ww1.damoang.net','m.damoang.net'),
+   'saas', '.damoang.net', 'damoang', 'internal',
+   JSON_OBJECT('description','다모앙 커뮤니티 — 멀티 서브도메인 SSO')),
+
+  ('muzia', 'muzia.net',
+   JSON_ARRAY('www.muzia.net','muzia.io'),
+   'saas', '', 'muzia', 'internal',
+   JSON_OBJECT('description','뮤지아 — 한국 음악 커뮤니티 (2002~), host-only cookie',
+               'features', JSON_OBJECT('market', true, 'arrange', true, 'tools', true))),
+
+  ('churchre', 'church.re.kr',
+   JSON_ARRAY('www.church.re.kr'),
+   'saas', '.church.re.kr', 'churchre', 'internal',
+   JSON_OBJECT('description','처치레 — 교회 SaaS root (각 교회는 *.church.re.kr tenant)')),
+
+  ('hdbc', 'hdbc.kr',
+   JSON_ARRAY('www.hdbc.kr'),
+   'saas', '', 'default', 'internal',
+   JSON_OBJECT('description','hdbc.kr — host-only cookie'))
+ON DUPLICATE KEY UPDATE updated_at = NOW();


### PR DESCRIPTION
## Summary

multi-tenant SaaS 식별을 단일 `sites` 테이블로 통합. WordPress (wp_blogs) / Discourse (Multisite) / Ghost (sites) 패턴 차용.

기존: `church_sites` (churchre 전용) + `auth_domain_groups` (cookie domain only) + hostname 하드코딩 → 3 source of truth 분산.
→ 단일 `sites` 테이블로 통합 (점진 마이그, Day 1~7 plan).

## Changes

### Day 1 — `migrations/004_sites_table.sql` (신규)

```sql
CREATE TABLE sites (
    id BIGINT PK AUTO_INCREMENT,
    slug VARCHAR(64) UNIQUE,                  -- 'muzia','damoang','churchre','hdbc'
    primary_host VARCHAR(255) UNIQUE,         -- canonical hostname
    aliases JSON,                             -- ['muzia.io','www.muzia.net']
    site_type ENUM('saas','tenant'),          -- saas=root, tenant=churchre sub
    parent_site_id BIGINT NULL,               -- hierarchical
    cookie_domain VARCHAR(255) DEFAULT '',
    theme_slug VARCHAR(64) DEFAULT 'default',
    plan ENUM('free','pro','enterprise','internal'),
    status ENUM('active','suspended','archived'),
    settings JSON,
    created_at, updated_at
);
```

seed 4 root SaaS: damoang(.damoang.net SSO) / muzia(host-only) / churchre(.church.re.kr SSO) / hdbc(host-only).

### Day 2 — `internal/handler/v2/auth_handler.go` (dual-read)

`StartCookieDomainCacheRefresher` 가 두 테이블 동시 로드 (5분 cache):
1. `sites` 우선 — primary_host + aliases 등록 (활성만)
2. `auth_domain_groups` fallback — sites 미커버 suffix backfill (legacy)

함수 시그니처 `cookieDomain(host)` 동일 — 호출자 영향 0. 외부 동작도 동일 (기존 매핑 유지).

## Test plan

- [x] DB 마이그 적용 + sites 4 row seed 확인
- [x] Go 빌드 통과 (Docker golang:1.25 검증)
- [x] muzia-api 컨테이너 swap + 부팅 정상 (`:8081 listen` 로그)
- [x] /api/v2/auth/refresh 401 응답 (서비스 살아있음)
- [ ] muzia.net 로그인 → cookie host-only 유지 (Day 1+2 후에도 변화 0)
- [ ] damoang.net 로그인 → cookie `.damoang.net` 유지
- [ ] CI Test + Lint + Security 통과

## Next phases (별도 PR)

- Day 3: super-admin/sites UI 가 sites 테이블 사용 (frontend)
- Day 4: frontend `getSiteByHost()` helper + `locals.site` 주입
- Day 5: church_sites ↔ sites 매핑
- Day 6: auth_domain_groups deprecated (sites 단일 source)
- Day 7: regression