### PR TITLE
fix: 직접홍보 게시판 서버 측 Redis 캐시 무효화

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2850,6 +2850,11 @@ func main() {
 				}
 			}
 
+			// 직접홍보 게시판: Redis 캐시 무효화 (서버 측 — 클라이언트 의존 제거)
+			if slug == "promotion" && redisClient != nil {
+				redisClient.Del(c.Request.Context(), "promotion:board_posts", "promotion:posts")
+			}
+
 			payload := gin.H{
 				"success": true,
 				"data":    v1handler.TransformToV1PostDetail(&post, false, slug),
@@ -3386,6 +3391,11 @@ func main() {
 				}
 			}
 
+			// 직접홍보 게시판: Redis 캐시 무효화
+			if slug == "promotion" && redisClient != nil {
+				redisClient.Del(c.Request.Context(), "promotion:board_posts", "promotion:posts")
+			}
+
 			payload := gin.H{"success": true, "message": "수정 완료"}
 			storeIdempotentWriteResponse(c.Request.Context(), redisClient, idempotencyBaseKey, http.StatusOK, payload)
 			c.JSON(http.StatusOK, payload)
@@ -3686,6 +3696,10 @@ func main() {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
 					return
 				}
+				// 직접홍보 게시판: Redis 캐시 무효화
+				if slug == "promotion" && redisClient != nil {
+					redisClient.Del(c.Request.Context(), "promotion:board_posts", "promotion:posts")
+				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return
 			}
@@ -3724,6 +3738,10 @@ func main() {
 				if txErr != nil {
 					c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "게시글 삭제 실패"})
 					return
+				}
+				// 직접홍보 게시판: Redis 캐시 무효화
+				if slug == "promotion" && redisClient != nil {
+					redisClient.Del(c.Request.Context(), "promotion:board_posts", "promotion:posts")
 				}
 				c.JSON(http.StatusOK, gin.H{"success": true, "message": "삭제 완료"})
 				return


### PR DESCRIPTION
## 문제

직접홍보 게시판 글 작성/수정/삭제 시 SvelteKit 클라이언트의 fire-and-forget 
캐시 무효화(`fetch('/api/boards/promotion/invalidate-cache')`)에 의존하고 있어,
네트워크 실패 등으로 무효화가 누락되면 24시간 TTL 만료까지 stale 데이터가 노출됨.

## 수정

Go backend의 4개 핸들러에서 성공 응답 직전에 Redis DEL 실행:

- `POST /api/v1/boards/:slug/posts` (글 작성)
- `PUT /api/v1/boards/:slug/posts/:id` (글 수정)  
- `PATCH /api/v1/boards/:slug/posts/:id/soft-delete` (관리자 즉시 삭제)
- `PATCH /api/v1/boards/:slug/posts/:id/soft-delete` (5분 grace period 삭제)

삭제 키: `promotion:board_posts`, `promotion:posts`

## 테스트

- [x] `go build ./...` 성공
- slug == "promotion" 조건이므로 다른 게시판에 영향 없음
- redisClient nil 체크로 Redis 미연결 시에도 안전