### PR TITLE
fix(api): 신고잠금 글/댓글 수정·신고 차단 (#12420)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3178,6 +3178,21 @@ func main() {
 				return
 			}
 
+			// #12420: 신고 누적으로 자동 잠긴 글 수정 차단. admin (level>=10) 만 예외.
+			// G5Write struct 가 wr_7 컬럼을 직접 매핑하지 않으므로 raw select.
+			// wr_7 컬럼 없는 게시판에서는 Scan 실패하나 wrLock 이 "" 유지 → lock 체크 통과 (defensive).
+			if userLevel < 10 {
+				var wrLock string
+				_ = db.Table(fmt.Sprintf("g5_write_%s", slug)).
+					Select("COALESCE(wr_7, '')").
+					Where("wr_id = ?", postID).
+					Scan(&wrLock).Error
+				if wrLock == "lock" {
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "신고 누적으로 잠긴 게시물은 수정할 수 없습니다"})
+					return
+				}
+			}
+
 			// 요청 바디 파싱
 			var req struct {
 				Title              *string  `json:"title"`
@@ -3423,6 +3438,19 @@ func main() {
 			if comment.MbID != userID && userLevel < 10 {
 				c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "수정 권한이 없습니다"})
 				return
+			}
+
+			// #12420: 신고 누적으로 자동 잠긴 댓글 수정 차단. admin (level>=10) 만 예외.
+			if userLevel < 10 {
+				var wrLock string
+				_ = db.Table(fmt.Sprintf("g5_write_%s", slug)).
+					Select("COALESCE(wr_7, '')").
+					Where("wr_id = ?", commentID).
+					Scan(&wrLock).Error
+				if wrLock == "lock" {
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "신고 누적으로 잠긴 댓글은 수정할 수 없습니다"})
+					return
+				}
 			}
 
 			// 자식 댓글(대댓글) 존재 시 작성자 수정 차단 — 관리자는 우회
@@ -4525,6 +4553,19 @@ func main() {
 				return
 			}
 
+			// #12420: 이미 신고 누적으로 자동 잠긴 글은 추가 신고 차단 (idempotent — 처리 완료 신호)
+			{
+				var wrLock string
+				_ = db.Table(fmt.Sprintf("g5_write_%s", slug)).
+					Select("COALESCE(wr_7, '')").
+					Where("wr_id = ?", postID).
+					Scan(&wrLock).Error
+				if wrLock == "lock" {
+					c.JSON(http.StatusConflict, gin.H{"success": false, "error": "이미 신고 처리가 완료된 게시물입니다"})
+					return
+				}
+			}
+
 			// 중복 신고 확인 (g5_na_singo 테이블)
 			var count int64
 			db.Table("g5_na_singo").Where("sg_table = ? AND sg_id = ? AND mb_id = ?", slug, postID, userID).Count(&count)
@@ -4602,6 +4643,19 @@ func main() {
 			if comment.MbID == userID {
 				c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "자신의 댓글은 신고할 수 없습니다"})
 				return
+			}
+
+			// #12420: 이미 신고 누적으로 자동 잠긴 댓글은 추가 신고 차단 (idempotent)
+			{
+				var wrLock string
+				_ = db.Table(fmt.Sprintf("g5_write_%s", slug)).
+					Select("COALESCE(wr_7, '')").
+					Where("wr_id = ?", commentID).
+					Scan(&wrLock).Error
+				if wrLock == "lock" {
+					c.JSON(http.StatusConflict, gin.H{"success": false, "error": "이미 신고 처리가 완료된 댓글입니다"})
+					return
+				}
 			}
 
 			// 중복 신고 확인 (g5_na_singo 테이블)


### PR DESCRIPTION
## 요약
다모앙 버그 게시판 #12420 — 신고 누적으로 자동 lock 된 글/댓글에 대해 수정·신고 기능을 백엔드 수준에서 차단합니다. admin 예외.

원본 보고: https://damoang.net/bug/12420

## 변경 (1 파일, +54)
- `cmd/api/main.go` 4 라우트에 lock 가드 추가

| 라우트 | 동작 |
|---|---|
| `PUT /api/v1/boards/:slug/posts/:id` | lock 시 403 |
| `PUT /api/v1/boards/:slug/posts/:id/comments/:comment_id` | lock 시 403 |
| `POST /api/v1/boards/:slug/posts/:id/report` | lock 시 409 (idempotent — 이미 처리 완료 신호) |
| `POST /api/v1/boards/:slug/posts/:id/comments/:comment_id/report` | lock 시 409 |

## 구현 메모

`G5Write` struct (`internal/domain/gnuboard/write.go`) 는 `wr_7` 컬럼을 직접 매핑하지 않음 — 모든 게시판에 해당 컬럼이 존재하지 않을 수 있어 의도적 제외 (write.go:10 주석).

따라서 inline raw select 로 lock 상태 확인:
```go
var wrLock string
_ = db.Table(fmt.Sprintf("g5_write_%s", slug)).
    Select("COALESCE(wr_7, '')").
    Where("wr_id = ?", postID).
    Scan(&wrLock).Error
if wrLock == "lock" { ... }
```

`wr_7` 컬럼 없는 게시판에서는 Scan 실패하나 `wrLock=""` 유지 → lock 체크 통과 (defensive, 회귀 없음).

## admin 예외

`userLevel < 10` 가드:
- 운영자 (mb_level≥10) 는 lock 글/댓글 수정 가능 (운영 도구 보존)
- 일반 사용자는 작성자라도 차단

## 관련 PR
프론트엔드 측 가드 + 블라인드 UI 는 damoang/angple repo 의 별도 PR (후속) 로 진행. **이 백엔드 PR 이 진실의 원천** — API 직접 호출 우회 차단.

## 검증
- `go build ./cmd/api` — 통과
- `go vet ./cmd/api` — 통과

## canary 검증 (머지 후)
- [ ] lock 글 작성자 → PUT → 403 ("신고 누적으로 잠긴 게시물은 수정할 수 없습니다")
- [ ] lock 댓글 작성자 → PUT → 403
- [ ] lock 글 추가 신고 시도 → POST report → 409 ("이미 신고 처리가 완료된 게시물입니다")
- [ ] admin (mb_level=10) → lock 글/댓글 수정 가능 (운영 도구)
- [ ] 일반 (lock 아닌) 글/댓글 수정·신고 정상 (회귀 없음)