### PR TITLE
chore(lint): cmd/ad-free-setup 의 noctx 제외 (일회성 도구)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -103,6 +103,9 @@ linters:
           - noctx
         path: _test\.go
       - linters:
+          - noctx
+        path: cmd/ad-free-setup/.*\.go
+      - linters:
           - errcheck
           - goconst
           - gocyclo


### PR DESCRIPTION
## 요약
PR #473 머지 후 main push 트리거 golangci-lint 가 `cmd/ad-free-setup/main.go` 의 **noctx 위반** 으로 fail.

원본 run: https://github.com/damoang/angple-backend/actions/runs/26337243698

## Root cause (PR #473 과 무관)
- `cmd/ad-free-setup` 은 PR #469 에서 추가된 **일회성 수동 셋업 도구**
- `db.Query / Exec / Begin / Ping / QueryRow / Tx.Exec` 등을 context 없이 호출 (10개 위반)
- PR CI 에서는 `Lint` workflow 가 다른 trigger 라 노출 안 됐고, **main push 시점에 첫 fail**

PR #473 의 변경 (`cmd/api/main.go`) 은 lint 위반 없음. 단지 우리 머지가 main push 를 트리거.

## Fix
`.golangci.yml` 의 `exclusions.rules` 에 `cmd/ad-free-setup/.*\.go` 에 대한 noctx 제외 추가.
일회성 수동 도구라 context 전파 가치 없음. (이미 `_test.go` 도 동일 패턴으로 noctx 제외 중)

```yaml
- linters:
    - noctx
  path: cmd/ad-free-setup/.*\.go
```

## 변경 파일 (1)
- `.golangci.yml` (+3)

## 검증
- 머지 후 main push 트리거 lint workflow 통과 확인

PR #473 (lock 가드) 의 lock 가드 로직과 무관 — separate concern.