### PR TITLE
fix(cron): autoLockPost 댓글 신고 합산 버그 — 원글 오잠금 수정

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -794,10 +794,16 @@ func autoLockPost(tx *gorm.DB, boTable string, postID, threshold int) {
 	}
 
 	// 승인된 고유 신고자 수 카운트 (해당 게시글 대상)
+	// 글 자체 신고만 카운트 (#truthroom-lock 버그 수정).
+	// 신고 INSERT 패턴: 글 신고는 sg_id=sg_parent=postID, 댓글 신고는 sg_id=commentID, sg_parent=postID.
+	// 기존 (sg_id=? OR sg_parent=?) 는 그 글의 모든 "댓글 신고"까지 부모 글로 합산하여
+	// 본문 신고 0건인 글이 댓글 신고만으로 오잠금되는 문제가 있었음.
+	// autoLockComment 와 대칭으로 sg_id AND sg_parent (글 자체 신고) 만 집계한다.
+	// 댓글 신고는 autoLockComment 가 댓글 단위로 개별 처리.
 	var approvedReporterCount int64
 	tx.Raw(`
 		SELECT COUNT(DISTINCT mb_id) FROM g5_na_singo
-		WHERE sg_table = ? AND (sg_id = ? OR sg_parent = ?) AND admin_approved = 1
+		WHERE sg_table = ? AND sg_id = ? AND sg_parent = ? AND admin_approved = 1
 	`, boTable, postID, postID).Scan(&approvedReporterCount)
 
 	if common.SafeInt64ToInt(approvedReporterCount) < threshold {


### PR DESCRIPTION
## 요약
신고 누적 자동잠금(`autoLockPost`)이 **댓글 신고를 부모 글 신고로 합산**하여, 본문 신고 0건인 원글이 댓글 신고만으로 잠기던 버그 수정.

## 증상 (사용자 보고: truthroom/33905)
- `free/6321680` ("박제: 시주티에") 본문 신고 **0건**인데 `wr_7='lock'`
- 실제 신고 대상은 그 글의 **댓글** (6321687, 6321697) — 21명 신고
- 원글이 오잠금되며 cron 이 `truthroom/33905` 박제 자동 생성

## Root cause
신고 INSERT 패턴 (`cmd/api/main.go:4583, 4675`):
| 신고 | sg_id | sg_parent |
|---|---|---|
| 원글 | postID | postID |
| 댓글 | commentID | postID |

기존 `autoLockPost` 카운트 (`internal/cron/report_process.go:800`):
```sql
WHERE sg_table=? AND (sg_id=? OR sg_parent=?) AND admin_approved=1
```
`sg_parent=postID` 가 그 글의 **모든 댓글 신고**를 부모 글로 합산. 본문 신고 0이어도 댓글 신고 누적(임계치 20)으로 원글 오잠금.

## Fix
`autoLockComment` (line 912) 와 대칭으로 글 자체 신고만 집계:
```sql
WHERE sg_table=? AND sg_id=? AND sg_parent=? AND admin_approved=1
```
`OR` → `AND` 변경:
- **원글 신고** (sg_id=sg_parent=postID) → 매칭 → 원글 lock
- **댓글 신고** (sg_id=commentID ≠ postID) → 제외 → `autoLockComment` 가 댓글 개별 lock

원글이면 원글만, 댓글이면 댓글만 잠깁니다.

## 변경 파일 (1)
- `internal/cron/report_process.go` (+7 -1)

## 검증
- `go build ./cmd/api` 통과
- `go vet ./internal/cron/` 통과

## 후속 (별도)
이미 오잠금된 기존 글 (free 12건 의심, 그중 6321680 은 현재 임계치 기준 확정) 의 `wr_7` 해제 + truthroom 박제 정리는 운영 DB 정정으로 별도 진행 (건별 확인).

## canary 검증 (머지 후)
- [ ] 본문 신고 0 + 댓글 다수 신고 → 원글 lock 안 됨, 댓글만 lock
- [ ] 원글 직접 신고 20명+ → 원글 정상 lock (회귀 없음)