### PR TITLE
fix(sphinx): CJK 2자+ phrase strict match — "산불" false positive (#12543)

### DIFF
--- a/pkg/sphinx/sphinx.go
+++ b/pkg/sphinx/sphinx.go
@@ -47,14 +47,18 @@ func containsCJK(s string) bool {
 }
 
 // addInfixWildcards wraps each whitespace-separated token with * for partial matching.
-// For CJK tokens (ngram_len=1), uses phrase search ("*token*") to ensure
-// adjacent ngram matching instead of scattered individual character matches.
+// For CJK tokens (ngram_len=1), uses strict phrase search ("token") so that
+// 1-character ngrams must be adjacent — prevents "산불" matching "생산 불가"
+// where "산" and "불" appear in different words (#12543, #11791 재발 패턴).
+// Non-CJK (영문/숫자) 은 기존 infix wildcard 그대로 유지.
 func addInfixWildcards(escaped string) string {
 	tokens := strings.Fields(escaped)
 	for i, t := range tokens {
 		if containsCJK(t) && len([]rune(t)) >= 2 {
-			// CJK phrase: "단파" → "*단파*" (adjacent ngram matching)
-			tokens[i] = `"*` + t + `*"`
+			// CJK 2자+ phrase: strict ordered match ("산불").
+			// 이전엔 `"*산불*"` 였으나 Manticore 가 wildcard expand 시 1글자
+			// ngram ("산", "불") 단독 매칭으로 분해되어 false positive 발생.
+			tokens[i] = `"` + t + `"`
 		} else {
 			tokens[i] = "*" + t + "*"
 		}


### PR DESCRIPTION
## 증상

- **#12543** (5/30): "산불" 검색 → "생산 불가" 매칭됨
- **#11791** (4/10): 같은 패턴 "난가" — 부분 fix 후 재발

## Root cause (실측)

Manticore conf `/etc/manticoresearch/manticore.conf:1050-1063`:
```
ngram_len = 1                  # 한글 1글자 = 1 토큰
min_infix_len = 1              # 1글자 infix index
ngram_chars = U+AC00..U+D7A3 (한글), 자모, CJK
morphology = none
```

`pkg/sphinx/sphinx.go:addInfixWildcards` 가 CJK 2자+ 를 `"*산불*"` 로 wrap → Manticore wildcard expand 시 1글자 ngram ("산", "불") 단독 매칭 가능 → 다른 단어의 "산", "불" 도 hit.

## 변경

`addInfixWildcards` CJK 2자+ 분기:

```diff
- if containsCJK(t) && len([]rune(t)) >= 2 {
-     tokens[i] = `"*` + t + `*"`     // "*산불*"
- }
+ if containsCJK(t) && len([]rune(t)) >= 2 {
+     tokens[i] = `"` + t + `"`       // "산불" strict ordered
+ }
```

Non-CJK 영문/숫자 분기 그대로 — 영문 검색 회귀 0.

## Test plan

canary 검증 (5종 query):
- [ ] "산불" → "생산 불가" 포함 글 미매칭
- [ ] "산불" → "산불 발생", "산불입니다" 정상 hit (recall 유지)
- [ ] "난가" → false positive 없음
- [ ] 영문 "GIF" / "gif" → 회귀 없음
- [ ] 1글자 한글 ("가", "물") → 영향 측정 (의도)

otel `/api/search` latency 회귀 없음.

## 후속

- Manticore conf `min_infix_len=1 → 2` 보강 (별도 PR + 인덱스 재빌드)
- Phase B 토큰화 결정 (memory: project_2026_05_06_sphinx_query_log_followup.md)