### PR TITLE
feat(posts): 응답에 author_image + author_image_updated_at 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -539,6 +539,84 @@ func safeIntToUint64(v int) uint64 {
 	return uint64(v) // #nosec G115 -- IDs are always non-negative
 }
 
+// enrichWithAuthorImage augments items with each author's mb_image_url + mb_image_updated_at
+// as `author_image` + `author_image_updated_at` fields. Matches the shape consumed by
+// frontend `classic.svelte` layout (post.author_image / post.author_image_updated_at).
+//
+// Mirrors enrichWithAuthorMemo pattern:
+//   - Items whose author has no image (or no record) are returned unchanged.
+//   - Cache safety: items may be shared across requests (in-memory or Redis cache hit),
+//     so any item receiving image fields is shallow-copied before mutation.
+//
+// Anonymous users 도 author_image 가 필요하므로 currentUserID 입력 X.
+func enrichWithAuthorImage(db *gorm.DB, items []map[string]any) []map[string]any {
+	if len(items) == 0 {
+		return items
+	}
+	seen := make(map[string]struct{}, len(items))
+	targetIDs := make([]string, 0, len(items))
+	for _, item := range items {
+		id, ok := item["author_id"].(string)
+		if !ok || id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		targetIDs = append(targetIDs, id)
+	}
+	if len(targetIDs) == 0 {
+		return items
+	}
+	type imageRow struct {
+		MbID             string     `gorm:"column:mb_id"`
+		MbImageURL       string     `gorm:"column:mb_image_url"`
+		MbImageUpdatedAt *time.Time `gorm:"column:mb_image_updated_at"`
+	}
+	var rows []imageRow
+	if err := db.Table("g5_member").
+		Select("mb_id, mb_image_url, mb_image_updated_at").
+		Where("mb_id IN ? AND mb_image_url != ''", targetIDs).
+		Find(&rows).Error; err != nil {
+		return items
+	}
+	if len(rows) == 0 {
+		return items
+	}
+	type imgEntry struct {
+		URL       string
+		UpdatedAt *time.Time
+	}
+	imgMap := make(map[string]imgEntry, len(rows))
+	for _, r := range rows {
+		imgMap[r.MbID] = imgEntry{URL: r.MbImageURL, UpdatedAt: r.MbImageUpdatedAt}
+	}
+	result := make([]map[string]any, len(items))
+	for i, item := range items {
+		id, _ := item["author_id"].(string)
+		if id == "" {
+			result[i] = item
+			continue
+		}
+		entry, ok := imgMap[id]
+		if !ok {
+			result[i] = item
+			continue
+		}
+		copied := make(map[string]any, len(item)+2)
+		for k, v := range item {
+			copied[k] = v
+		}
+		copied["author_image"] = entry.URL
+		if entry.UpdatedAt != nil {
+			copied["author_image_updated_at"] = entry.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+		result[i] = copied
+	}
+	return result
+}
+
 // extractDisciplinelogID extracts the numeric ID from link1 values like "disciplinelog/1234" or "disciplinelog:1234"
 func extractDisciplinelogID(link1 string) string {
 	for _, prefix := range []string{"disciplinelog/", "disciplinelog:"} {
@@ -2035,6 +2113,10 @@ func main() {
 					}
 				}
 			}
+
+			// author_image enrich (모든 사용자 대상, cache 저장 전 적용 → cache hit 도 자동 포함).
+			// classic.svelte layout 의 author_image / author_image_updated_at 필드 채움.
+			items = enrichWithAuthorImage(db, items)
 
 			meta := gin.H{"board_id": slug, "page": page, "limit": limit}
 			if useHasNextPagination {


### PR DESCRIPTION
## Context

글 상세 페이지 하단의 RecentPosts 가 회원 프로필 이미지(프사) 미표시.

- frontend `classic.svelte:269-270` 는 이미 `post.author_image` / `post.author_image_updated_at` 사용 — layout 코드 변경 0
- board list page 는 SSR `fetchMemberImagesWithTimestamp` 보강으로 표시 OK
- RecentPosts 는 클라 `apiClient.getBoardPosts` → backend 응답 직접 사용 → author_image 누락

## 변경

### `enrichWithAuthorImage` 신규 함수 (`enrichWithAuthorMemo` 패턴 재사용)

```go
// author_id set 추출 → batch SELECT g5_member → map 후 each item shallow-copy + mutate
func enrichWithAuthorImage(db *gorm.DB, items []map[string]any) []map[string]any
```

### `/api/v1/boards/:slug/posts` endpoint 에서 호출

DB query path 끝 (cache store 직전) → enriched items 가 mem cache + Redis cache 저장 → **모든 후속 cache hit (anonymous fast path 포함) 도 자동 author_image 포함**.

## 영향

| 항목 | 영향 |
|---|---|
| DB query 추가 | batch IN 1회 per request (likers endpoint 와 동일 부담) |
| JSON 응답 | +~2KB / 20 posts (gzip 후 작음) |
| frontend 갱신 | 0 |
| cache schema | 변경 0 (transform 후 enrich) |
| cache TTL 30s | 배포 후 30s 내 옛 응답 가능, 자동 새 응답 |

## Test plan

- [ ] `curl 'https://canary.damoang.net/api/v1/boards/free/posts?page=1&limit=10' | jq '.data[0] | {author_id, author_image, author_image_updated_at}'` → 필드 있음
- [ ] 글 상세 (/free/...) 진입 → RecentPosts 하단 미니 목록에 프사 표시
- [ ] 페이지네이션 (page=2, 3) 이동 시도 프사 표시
- [ ] 시스템 row (mb_id 없는 광고/공지) graceful 처리 (필드 누락)
- [ ] otel `/api/v1/boards/:slug/posts` latency 회귀 측정 (+5-15ms 예상)

## 후속 (별도 PR)

- `/posts/:id` (단일 글) + `/posts/:id/comments` 도 동일 enrich
- board list SSR 보강 (fetchMemberImagesWithTimestamp) 제거 가능 검토