### PR TITLE
feat(comments): 응답에 is_restricted 필드 (이용제한 댓글)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2393,6 +2393,37 @@ func main() {
 				transformed = enrichWithAuthorMemo(db, currentUserID, transformed)
 			}
 
+			// is_restricted enrich — 댓글의 wr_7='lock' 검사 (damoang-backend UnlockPostContent
+			// 가 잠금 시 wr_7='lock' 설정). batch 1 query. board 마다 wr_7 컬럼 유무 다름 →
+			// 에러 무시 (defensive, COALESCE).
+			if len(comments) > 0 {
+				commentIDs := make([]int, 0, len(comments))
+				for _, cm := range comments {
+					commentIDs = append(commentIDs, cm.WrID)
+				}
+				type lockRow struct {
+					WrID  int    `gorm:"column:wr_id"`
+					Wr7Val string `gorm:"column:wr_7_value"`
+				}
+				var locks []lockRow
+				tbl := fmt.Sprintf("g5_write_%s", slug)
+				_ = db.Table(tbl).
+					Select("wr_id, COALESCE(wr_7, '') AS wr_7_value").
+					Where("wr_id IN ?", commentIDs).
+					Find(&locks).Error
+				lockSet := make(map[int]struct{}, len(locks))
+				for _, l := range locks {
+					if l.Wr7Val == "lock" {
+						lockSet[l.WrID] = struct{}{}
+					}
+				}
+				for i, cm := range comments {
+					if _, ok := lockSet[cm.WrID]; ok {
+						transformed[i]["is_restricted"] = true
+					}
+				}
+			}
+
 			// 댓글 수정 정책 메타 — 프론트엔드 confirm 다이얼로그에서 사용 (단일 진실 근원: 백엔드 env)
 			editCost, editGraceSeconds := getCommentEditPolicy()
 			c.JSON(http.StatusOK, gin.H{

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2402,7 +2402,7 @@ func main() {
 					commentIDs = append(commentIDs, cm.WrID)
 				}
 				type lockRow struct {
-					WrID  int    `gorm:"column:wr_id"`
+					WrID   int    `gorm:"column:wr_id"`
 					Wr7Val string `gorm:"column:wr_7_value"`
 				}
 				var locks []lockRow


### PR DESCRIPTION
## Context

이용제한 처분 시 damoang-backend (`UnlockPostContent`) 가 글/댓글에 `wr_7='lock'` 설정. 글은 `wr_subject` `[신고잠김]` prefix 도 적용되어 frontend 가 자체 prefix 검사 가능 (PR angple#1529). 그러나 **댓글은 wr_subject 가 빈 string 인 row 가 다수** → `wr_7='lock'` 만 신뢰할 수 있는 신호.

## 변경

`/api/v1/boards/:slug/posts/:id/comments` 응답의 댓글별 `is_restricted` 필드 추가:

```go
// transform 후 댓글 wr_id 리스트로 wr_7 batch query 1회
SELECT wr_id, COALESCE(wr_7, '') AS wr_7_value
FROM g5_write_{slug}
WHERE wr_id IN (cm1, cm2, ..., cm50)
```

`wr_7='lock'` 인 댓글 → `is_restricted: true` 응답에 포함.

## 비용 (memory feedback_no_slow_queries.md 준수)

- 추가 DB query: **batch IN 1회** / response (N+1 ❌)
- response 1 = 50 comments → 1 query (~5ms, wr_id PK hit)
- JSON 응답: `is_restricted: true` 만 추가 (false 시 필드 누락 → 작음)
- defensive: board schema 변종 안전 (`COALESCE` + 에러 무시)
- N+1 / slow query 위험: **0**

## Test plan

- [ ] canary `curl 'https://canary.damoang.net/api/v1/boards/free/posts/{ID}/comments' | jq '.data[] | select(.is_restricted) | .id'` 결과 확인
- [ ] wr_7='lock' 댓글 응답에 `is_restricted: true` 포함
- [ ] 일반 댓글은 필드 누락 (false 절약)
- [ ] otel latency 회귀 측정 (+1-2ms 예상)

## 후속

- frontend `comment-list.svelte` 에 `is_restricted` flag 검사 + Badge 추가 (별도 PR angple)