### PR TITLE
fix(giving): active 탭에 시간 미입력 글(noGiving) 포함

### DIFF
--- a/internal/handler/giving_handler.go
+++ b/internal/handler/giving_handler.go
@@ -82,8 +82,14 @@ func (h *GivingHandler) List(c *gin.Context) {
 			ParticipantCount: r.ParticipantCount,
 		})
 
+		// 시작/종료 시각 미입력 (wr_4='' 또는 wr_5='') 글도 active 탭에 노출.
+		// damoang-backend ListActive 정책 (wr_4='' OR wr_5 > NOW + wr_5='' OR wr_5 > NOW) 과 일치.
+		// /giving/2238 처럼 시간 미정 진행중 글이 noGiving 으로 분류되어 응답 누락되던 #new 버그 fix.
 		if meta.Status == givingdomain.StatusNoGiving {
-			continue
+			if tab == "ended" {
+				continue
+			}
+			// active 탭 에는 noGiving 도 포함 (진행중 으로 간주)
 		}
 		if tab == "active" && meta.Status == givingdomain.StatusEnded {
 			continue


### PR DESCRIPTION
## 증상

`/giving/2238` 같이 wr_4(시작일)/wr_5(종료일) 미입력 진행중 글이 위젯 '진행 중 나눔' 응답에서 누락 (0건 표시). 다른 사용자가 본 신규 버그.

## Root cause

`internal/handler/giving_handler.go:85-87`:
```go
if meta.Status == givingdomain.StatusNoGiving {
    continue  // ← active 탭에서도 무조건 제외
}
```

`Normalize` 가 wr_4 또는 wr_5 빈 string 시 `StatusNoGiving` 반환 → continue → 빈 array.

damoang-backend 의 ListActive 정책 (`(wr_5='' OR wr_5 > NOW) AND (wr_4='' OR wr_4 <= NOW)`) 과 불일치.

## 변경

active 탭 에는 noGiving 도 포함 (시간 미정 진행중 글). ended 탭에선 제외 유지.

## Test plan

- [ ] canary 'https://canary.damoang.net/api/plugins/giving/list?tab=active' 응답에 wr_id=2238 포함 확인
- [ ] /giving 게시판 진입 → 진행중 나눔 위젯 표시
- [ ] tab='ended' 탭은 노출 안 됨 (회귀 없음)