### PR TITLE
feat(posts/comments): is_discipline_related 필드 (이용제한 처분 글/댓글)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -617,6 +617,89 @@ func enrichWithAuthorImage(db *gorm.DB, items []map[string]any) []map[string]any
 	return result
 }
 
+// enrichWithDisciplineRelated augments items with `is_discipline_related: true` for posts/comments
+// referenced in completed disciplinary actions (이용제한 처분 완료).
+//
+// Data source: `g5_na_singo.discipline_log_id IS NOT NULL` + sg_table + sg_id matches.
+// 운영자가 사용자 이용제한 처분 시 근거로 삼은 글/댓글이며, 신고잠김(wr_7='lock') 과는 별개 개념.
+//
+// INDEX 활용: `idx_table_id_time` 또는 `idx_singo_table_id` (sg_table, sg_id) 복합 INDEX hit.
+// `discipline_log_id IS NOT NULL` 은 IN clause 결과의 작은 row set 안에서만 filter 됨 → slow query 0.
+//
+// Mirrors enrichWithAuthorImage pattern (cache safety: shallow-copy on mutation).
+func enrichWithDisciplineRelated(db *gorm.DB, slug string, items []map[string]any) []map[string]any {
+	if len(items) == 0 || slug == "" {
+		return items
+	}
+	seen := make(map[int]struct{}, len(items))
+	targetIDs := make([]int, 0, len(items))
+	for _, item := range items {
+		// item["id"] 가 int 인 경우와 float64 (JSON unmarshal) 둘 다 지원
+		var id int
+		switch v := item["id"].(type) {
+		case int:
+			id = v
+		case int64:
+			id = int(v)
+		case float64:
+			id = int(v)
+		default:
+			continue
+		}
+		if id <= 0 {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		targetIDs = append(targetIDs, id)
+	}
+	if len(targetIDs) == 0 {
+		return items
+	}
+	type singoRow struct {
+		SgID int `gorm:"column:sg_id"`
+	}
+	var rows []singoRow
+	if err := db.Table("g5_na_singo").
+		Select("DISTINCT sg_id").
+		Where("sg_table = ? AND sg_id IN ? AND discipline_log_id IS NOT NULL", slug, targetIDs).
+		Find(&rows).Error; err != nil {
+		return items
+	}
+	if len(rows) == 0 {
+		return items
+	}
+	disciplinedSet := make(map[int]struct{}, len(rows))
+	for _, r := range rows {
+		disciplinedSet[r.SgID] = struct{}{}
+	}
+	result := make([]map[string]any, len(items))
+	for i, item := range items {
+		var id int
+		switch v := item["id"].(type) {
+		case int:
+			id = v
+		case int64:
+			id = int(v)
+		case float64:
+			id = int(v)
+		}
+		if _, ok := disciplinedSet[id]; !ok {
+			result[i] = item
+			continue
+		}
+		copied := make(map[string]any, len(item)+1)
+		for k, val := range item {
+			copied[k] = val
+		}
+		copied["is_discipline_related"] = true
+		result[i] = copied
+	}
+	return result
+}
+
 // extractDisciplinelogID extracts the numeric ID from link1 values like "disciplinelog/1234" or "disciplinelog:1234"
 func extractDisciplinelogID(link1 string) string {
 	for _, prefix := range []string{"disciplinelog/", "disciplinelog:"} {
@@ -2118,6 +2201,10 @@ func main() {
 			// classic.svelte layout 의 author_image / author_image_updated_at 필드 채움.
 			items = enrichWithAuthorImage(db, items)
 
+			// is_discipline_related enrich (이용제한 처분 근거 글 표시용).
+			// g5_na_singo.discipline_log_id IS NOT NULL 매칭. cache 저장 전 적용 → cache 자동 포함.
+			items = enrichWithDisciplineRelated(db, slug, items)
+
 			meta := gin.H{"board_id": slug, "page": page, "limit": limit}
 			if useHasNextPagination {
 				meta["has_next"] = hasNext
@@ -2423,6 +2510,10 @@ func main() {
 					}
 				}
 			}
+
+			// is_discipline_related enrich (이용제한 처분 근거 댓글 표시).
+			// g5_na_singo.discipline_log_id IS NOT NULL + sg_table+sg_id 매칭. batch 1 query.
+			transformed = enrichWithDisciplineRelated(db, slug, transformed)
 
 			// 댓글 수정 정책 메타 — 프론트엔드 confirm 다이얼로그에서 사용 (단일 진실 근원: 백엔드 env)
 			editCost, editGraceSeconds := getCommentEditPolicy()


### PR DESCRIPTION
## Context

운영자가 사용자 이용제한 처분 시 근거로 삼은 글/댓글 식별. damoang-ops singo UI 의 신고 승인 흐름이 `g5_na_singo.discipline_log_id` 채움 (Explore 분석 완료).

**신고잠김** (`wr_7='lock'`, PR #482) ≠ **이용제한 처분** (이번 PR) — 별개 개념.

## 데이터 source (실측)

```sql
SELECT DISTINCT sg_id FROM g5_na_singo
WHERE sg_table = ? AND sg_id IN (?,...,?)
  AND discipline_log_id IS NOT NULL
```

INDEX:
- `idx_table_id_time` (sg_table, sg_id, sg_time) ✓
- `idx_singo_table_id` (sg_table, sg_id) ✓
- batch IN clause INDEX hit → slow query 0 (memory `feedback_no_slow_queries.md` 준수)

## 변경

### `enrichWithDisciplineRelated` 신규 함수

`enrichWithAuthorImage` 패턴 그대로:
- items 의 id set 추출 (int/int64/float64 호환)
- batch query 1회
- 매칭 item 에 `is_discipline_related: true` 추가 (shallow-copy)

### 호출 위치 (2 endpoint)

- `/api/v1/boards/:slug/posts` (cache 저장 전 → cache hit 도 자동 포함)
- `/api/v1/boards/:slug/posts/:id/comments`

post detail 은 후속 PR (단일 row).

## Test plan

- [ ] canary 배포 후 이용제한 처분 근거 글 조회
- [ ] `curl '.../api/v1/boards/free/posts?...' | jq '.data[] | select(.is_discipline_related)'` 매칭
- [ ] 댓글 endpoint 도 동일
- [ ] 일반 글/댓글 영향 0
- [ ] otel latency 회귀 (+1-2ms 예상)

## 후속

- frontend DisciplinedBadge + DisciplinedContent (blur + 토글) 별도 PR
- post detail 도 동일 enrich 호출 (단일 row)