### PR TITLE
feat(posts): 단건 post detail 응답에 is_discipline_related 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -2376,6 +2376,13 @@ func main() {
 				}
 			}
 
+			// is_discipline_related enrich (이용제한 처분 근거 글 표시).
+			// g5_na_singo.discipline_log_id IS NOT NULL + sg_table+sg_id 매칭. batch 1 query.
+			// list/comments endpoint 와 일관성 유지 (PR #484 후속).
+			if enriched := enrichWithDisciplineRelated(db, slug, []map[string]any{postDetail}); len(enriched) > 0 {
+				postDetail = enriched[0]
+			}
+
 			c.JSON(http.StatusOK, gin.H{
 				"success": true,
 				"data":    postDetail,


### PR DESCRIPTION
## 배경

PR #484 가 list (`/api/v1/boards/:slug/posts`) + comments 응답에만 `enrichWithDisciplineRelated` 적용. 단건 endpoint `/api/v1/boards/:slug/posts/:id` 는 미적용 → SSR (`bFetch`) 응답에 `is_discipline_related` 누락 → frontend 본문 표시 분기 진입 불가.

## 변경

`enrichWithAuthorMemo` 패턴으로 `[]map[string]any{postDetail}` array wrap → enrich → 첫 element 다시 받기.

## 안전

- 1 batch query (item 1개), INDEX `(sg_table, sg_id)` hit
- raw post 캐시 (G5Write 구조체) 와 무관 — enrich 는 transform 후 매 요청 적용
- 일반 글 영향 0 (false 면 필드 미설정)

## 검증

- list 응답과 필드 일관성 확인
- otel latency 회귀 0 (+ <1ms 예상)