### PR TITLE
feat(disciplinelog): reported_items 에 개별 신고 사유 (sg_types) 추가

### DIFF
--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -39,9 +39,10 @@ type DisciplineLogContent struct {
 
 // ReportedItem represents a reported post or comment
 type ReportedItem struct {
-	Table  string `json:"table"`
-	ID     int    `json:"id"`
-	Parent int    `json:"parent,omitempty"`
+	Table   string `json:"table"`
+	ID      int    `json:"id"`
+	Parent  int    `json:"parent,omitempty"`
+	SgTypes []int  `json:"sg_types,omitempty"` // 개별 신고 사유 코드 목록 (g5_na_singo.sg_type)
 }
 
 // ViolationType represents a type of rule violation
@@ -325,14 +326,25 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		penaltyDateTo = &dateTo
 	}
 
-	// Convert reported items format (table -> board_id)
+	// Convert reported items format (table -> board_id) + enrich with per-item sg_types from g5_na_singo
 	reportedItems := make([]ReportedItem, 0, len(data.ReportedItems))
 	for _, item := range data.ReportedItems {
-		reportedItems = append(reportedItems, ReportedItem{
+		ri := ReportedItem{
 			Table:  item.Table,
 			ID:     item.ID,
 			Parent: item.Parent,
-		})
+		}
+		// 개별 신고 사유 코드 (sg_type 21~40) 조회 — discipline_log_id 로 처분 연결
+		var sgTypes []int
+		if err := h.db.Raw(`
+			SELECT DISTINCT sg_type
+			FROM g5_na_singo
+			WHERE discipline_log_id = ? AND sg_table = ? AND sg_id = ? AND admin_approved = 1
+			ORDER BY sg_type
+		`, post.WrID, item.Table, item.ID).Scan(&sgTypes).Error; err == nil && len(sgTypes) > 0 {
+			ri.SgTypes = sgTypes
+		}
+		reportedItems = append(reportedItems, ri)
 	}
 
 	detail := DisciplineLogDetail{


### PR DESCRIPTION
## 변경
\`GetDetail\` 응답의 \`reported_items\` 각 row 에 \`sg_types[]\` 추가. g5_na_singo 의 \`sg_type\` 코드 (21~40) 를 \`discipline_log_id + sg_table + sg_id\` 로 join 해서 채움.

**Before**:
\`\`\`json
{ "table": "free", "id": 6375836, "parent": 6375836 }
\`\`\`

**After**:
\`\`\`json
{ "table": "free", "id": 6375836, "parent": 6375836, "sg_types": [21, 22, 23, 25, 26] }
\`\`\`

## 효과
- bug #12588 잔여 부분 해결: disciplinelog 상세 페이지에서 글/댓글 row 별 신고 사유 표시 가능
- 처분 시점 store 없이 read-time join — **기존 처분 데이터도 자동 적용**
- DB schema 변경 없음

## 파일
- \`internal/handler/v2/discipline_log_handler.go:40-46\` — ReportedItem struct 에 SgTypes 추가
- \`internal/handler/v2/discipline_log_handler.go:329-348\` — GetDetail loop 에 g5_na_singo SELECT 추가

## Frontend 별도 PR
- \`apps/web/src/lib/api/discipline-log.ts\` — ReportedItem type 확장
- \`apps/web/src/routes/disciplinelog/[id]/+page.svelte\` — 사유 배지 UI

## Test plan
- [ ] 임의 처분 #N 호출 → sg_types[] 채워져 옴
- [ ] 옛 처분 (sg_types 없는 경우) → omitempty 로 응답에서 누락