### PR TITLE
fix: 쪽지 unread-count의 datetime '' 비교 MySQL 8 에러 수정

### DIFF
--- a/internal/repository/gnuboard/memo_repo.go
+++ b/internal/repository/gnuboard/memo_repo.go
@@ -125,8 +125,9 @@ func (r *memoRepository) Send(senderID, receiverID, content string) (*gnuboard.G
 }
 
 // CountUnread returns the count of unread memos for the user.
-// me_read_datetime은 NOT NULL datetime 컬럼이라 미열람 = zero date.
-// MySQL 8은 datetime 컬럼과 ''의 비교에서 'Incorrect DATETIME value' 에러를 던지므로 '' 비교 금지.
+// me_read_datetime 은 NOT NULL datetime 컬럼이라 미열람 = zero date(0000-00-00 00:00:00).
+// MySQL 8 은 datetime 컬럼을 빈 문자열과 비교하면 'Incorrect DATETIME value' 에러를 던지므로
+// 빈 문자열 비교를 제거하고 zero date 비교만 사용한다.
 func (r *memoRepository) CountUnread(mbID string) (int64, error) {
 	var count int64
 	err := r.db.Model(&gnuboard.G5Memo{}).

--- a/internal/repository/gnuboard/memo_repo.go
+++ b/internal/repository/gnuboard/memo_repo.go
@@ -124,11 +124,13 @@ func (r *memoRepository) Send(senderID, receiverID, content string) (*gnuboard.G
 	return &recvMemo, nil
 }
 
-// CountUnread returns the count of unread memos for the user
+// CountUnread returns the count of unread memos for the user.
+// me_read_datetime은 NOT NULL datetime 컬럼이라 미열람 = zero date.
+// MySQL 8은 datetime 컬럼과 ''의 비교에서 'Incorrect DATETIME value' 에러를 던지므로 '' 비교 금지.
 func (r *memoRepository) CountUnread(mbID string) (int64, error) {
 	var count int64
 	err := r.db.Model(&gnuboard.G5Memo{}).
-		Where("me_recv_mb_id = ? AND me_type = 'recv' AND (me_read_datetime = '' OR me_read_datetime = '0000-00-00 00:00:00')", mbID).
+		Where("me_recv_mb_id = ? AND me_type = 'recv' AND me_read_datetime = '0000-00-00 00:00:00'", mbID).
 		Count(&count).Error
 	return count, err
 }


### PR DESCRIPTION
## 문제

`GET /api/v1/messages/unread-count` → `CountUnread`의 WHERE 절에 `me_read_datetime = ''` 비교가 포함되어 있는데, `me_read_datetime`은 **NOT NULL datetime** 컬럼이라 MySQL 8에서 이 비교가 `ERROR 1525 Incorrect DATETIME value: ''` 를 발생시킴 (RDS 실측 확인). 즉 이 엔드포인트는 호출되면 항상 실패하는 상태.

미열람 쪽지는 zero date(`0000-00-00 00:00:00`)로 저장되므로 zero date 비교만으로 충분함.

## 수정

`(me_read_datetime = '' OR me_read_datetime = '0000-00-00 00:00:00')` → `me_read_datetime = '0000-00-00 00:00:00'`

## 맥락

쪽지 읽음 추적 전면 진단 중 발견 — 상세: 서버 `/home/damoang/docs/2026-06-05-memo-read-tracking-diagnosis.md`
- 2026-03-08(PHP 종료) 이후 전 시스템 쪽지 열람 기록 0건
- 후속 작업(별도): 프론트 헤더 쪽지 아이콘에 미읽음 배지 추가 (이 PR이 선행 조건)