### PR TITLE
fix: 쪽지 IsRead가 parseTime 환경에서 항상 true로 오판 — 미열람 표시·읽음 처리 전면 불능 수정

### DIFF
--- a/internal/domain/gnuboard/memo.go
+++ b/internal/domain/gnuboard/memo.go
@@ -1,6 +1,7 @@
 package gnuboard
 
 import (
+	"strings"
 	"time"
 )
 
@@ -22,7 +23,17 @@ func (G5Memo) TableName() string {
 	return "g5_memo"
 }
 
-// IsRead returns whether the memo has been read
+// IsRead returns whether the memo has been read.
+// me_read_datetime은 NOT NULL datetime 컬럼으로 미열람 시 zero date('0000-00-00 00:00:00')가
+// 저장된다. DSN이 parseTime=True라 zero date가 Go zero time 문자열("0001-01-01 ...")로
+// 스캔되므로, 두 형태 모두 미열람으로 판정해야 한다. (기존 코드는 raw 문자열만 비교해
+// 모든 쪽지를 읽음으로 오판 → 미열람 표시·읽음 처리가 전부 동작하지 않았음)
 func (m *G5Memo) IsRead() bool {
-	return m.MeReadDatetime != "" && m.MeReadDatetime != "0000-00-00 00:00:00"
+	if m.MeReadDatetime == "" {
+		return false
+	}
+	if strings.HasPrefix(m.MeReadDatetime, "0000-00-00") || strings.HasPrefix(m.MeReadDatetime, "0001-01-01") {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## 문제 (#12621 (a)의 원인 + 열람 기록 영구 누락)

`G5Memo.MeReadDatetime`은 **string** 타입인데 DSN이 `parseTime=True`라서, datetime 컬럼의 zero date(`0000-00-00 00:00:00`, 미열람)가 **Go zero time 문자열("0001-01-01 ...")로 스캔**됨. 기존 `IsRead()`는 raw 문자열(`''`, `'0000-00-00 00:00:00'`)만 비교하므로 **모든 쪽지를 '읽음'으로 오판**.

결과 (오늘 prod 실측):
- 쪽지함 목록에서 미열람 하이라이트 전멸 → 배지 카운트(SQL 기반, 정상)와 목록 표시 불일치 (#12621 (a))
- `GetMessage`의 읽음 처리 조건 `!memo.IsRead()`가 항상 false → **MarkAsRead 호출 자체가 스킵** → 상세 조회 27건 전부 200인데 열람 기록 0건

## 수정

`IsRead()`가 zero date의 두 표현(`0000-00-00`, `0001-01-01` 접두)을 모두 미열람으로 판정.

## 검증 방법 (배포 후)

```sql
SELECT COUNT(*) FROM g5_memo WHERE me_type='recv' AND me_read_datetime >= '2026-06-06';
-- 배포 후 쪽지 열람 시 0 → 증가해야 정상
```

## 연관
- #495 (unread-count MySQL 8 에러) 후속 — 같은 zero-date 계열
- 프론트 #12619(phantom 배지) 정리 작업은 이 PR 배포 후 진행 예정