### PR TITLE
feat: 쪽지 전체 읽음 처리 API (POST /api/v1/messages/read-all)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5392,6 +5392,7 @@ func main() {
 		v1Messages := router.Group("/api/v1/messages", middleware.JWTAuth(jwtManager))
 		v1Messages.GET("", v1MsgHandler.GetMessages)
 		v1Messages.GET("/unread-count", v1MsgHandler.GetUnreadCount)
+		v1Messages.POST("/read-all", v1MsgHandler.ReadAllMessages)
 		v1Messages.GET("/:id", v1MsgHandler.GetMessage)
 		v1Messages.POST("", banCheck, v1MsgHandler.SendMessage)
 		v1Messages.DELETE("/:id", v1MsgHandler.DeleteMessage)

--- a/internal/handler/message_handler.go
+++ b/internal/handler/message_handler.go
@@ -296,3 +296,20 @@ func (h *V1MessageHandler) GetUnreadCount(c *gin.Context) {
 	}
 	common.V2Success(c, gin.H{"count": count})
 }
+
+// ReadAllMessages handles POST /api/v1/messages/read-all
+// 받은 쪽지 전체를 읽음 처리한다 ('모두 읽음' 버튼).
+func (h *V1MessageHandler) ReadAllMessages(c *gin.Context) {
+	mbID := h.getMbID(c)
+	if mbID == "" {
+		common.V2ErrorResponse(c, http.StatusUnauthorized, "인증이 필요합니다", nil)
+		return
+	}
+
+	updated, err := h.memoRepo.MarkAllAsRead(mbID)
+	if err != nil {
+		common.V2ErrorResponse(c, http.StatusInternalServerError, "쪽지 일괄 읽음 처리 실패", err)
+		return
+	}
+	common.V2Success(c, gin.H{"updated": updated})
+}

--- a/internal/repository/gnuboard/memo_repo.go
+++ b/internal/repository/gnuboard/memo_repo.go
@@ -13,6 +13,7 @@ type MemoRepository interface {
 	FindSent(mbID string, page, limit int) ([]*gnuboard.G5Memo, int64, error)
 	FindByID(meID int, mbID string) (*gnuboard.G5Memo, error)
 	MarkAsRead(meID int) error
+	MarkAllAsRead(mbID string) (int64, error)
 	Delete(meID int, mbID string) error
 	Send(senderID, receiverID, content string) (*gnuboard.G5Memo, error)
 	CountUnread(mbID string) (int64, error)
@@ -79,6 +80,17 @@ func (r *memoRepository) MarkAsRead(meID int) error {
 	now := time.Now().Format("2006-01-02 15:04:05")
 	return r.db.Model(&gnuboard.G5Memo{}).Where("me_id = ?", meID).
 		Update("me_read_datetime", now).Error
+}
+
+// MarkAllAsRead marks every unread received memo for the user as read.
+// 미열람 = zero date(0000-00-00 00:00:00) — CountUnread 와 동일한 판정 기준을 사용한다.
+// Returns the number of memos updated.
+func (r *memoRepository) MarkAllAsRead(mbID string) (int64, error) {
+	now := time.Now().Format("2006-01-02 15:04:05")
+	result := r.db.Model(&gnuboard.G5Memo{}).
+		Where("me_recv_mb_id = ? AND me_type = 'recv' AND me_read_datetime = '0000-00-00 00:00:00'", mbID).
+		Update("me_read_datetime", now)
+	return result.RowsAffected, result.Error
 }
 
 // Delete deletes a memo for the user


### PR DESCRIPTION
## 요약
받은 쪽지함 '모두 읽음' 버튼용 백엔드 엔드포인트. (쪽지 배지 도입 후 미열람 누적 해소책 — 운영 공지 약속 사항)

## 변경
- `MemoRepository.MarkAllAsRead(mbID)`: 미열람(zero date) 수신 쪽지 일괄 읽음 처리, RowsAffected 반환 — CountUnread 와 동일 판정 기준
- `V1MessageHandler.ReadAllMessages`: POST /api/v1/messages/read-all → `{updated: n}`
- 라우트 등록 (JWTAuth 그룹 내)

## 검증
- go build 통과, gofmt clean
- 프론트 연동 PR 별도 (angple 레포, '모두 읽음' 버튼)