### PR TITLE
feat(cron): g5_na_noti 정리 작업 — 알림 테이블 비대 완화 (#12607)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5979,6 +5979,7 @@ func main() {
 		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
 		cronGroup.POST("/sync-visible-comment-counts", cronHandler.SyncVisibleCommentCounts)
 		cronGroup.POST("/popular-subscribe-notify", cronHandler.PopularSubscribeNotify)
+		cronGroup.POST("/noti-cleanup", cronHandler.NotiCleanup)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo, writeAfterEventRepo)

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -204,3 +204,15 @@ func (h *Handler) PopularSubscribeNotify(c *gin.Context) {
 			typed.Boards, typed.PostsNotified, typed.NotisCreated)
 	})
 }
+
+// NotiCleanup handles POST /api/internal/cron/noti-cleanup
+// Prunes g5_na_noti (read + old, then very old regardless) to curb table bloat (#12607).
+func (h *Handler) NotiCleanup(c *gin.Context) {
+	h.runCronTask(c, "noti-cleanup", func() (interface{}, error) {
+		return runNotiCleanup(h.db)
+	}, func(result interface{}) {
+		typed := result.(*NotiCleanupResult)
+		log.Printf("[Cron:noti-cleanup] read_deleted=%d stale_deleted=%d batches=%d capped=%v",
+			typed.ReadDeleted, typed.StaleDeleted, typed.Batches, typed.Capped)
+	})
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -212,7 +212,7 @@ func (h *Handler) NotiCleanup(c *gin.Context) {
 		return runNotiCleanup(h.db)
 	}, func(result interface{}) {
 		typed := result.(*NotiCleanupResult)
-		log.Printf("[Cron:noti-cleanup] read_deleted=%d stale_deleted=%d batches=%d capped=%v",
-			typed.ReadDeleted, typed.StaleDeleted, typed.Batches, typed.Capped)
+		log.Printf("[Cron:noti-cleanup] deleted=%d batches=%d last_id=%d capped=%v",
+			typed.Deleted, typed.Batches, typed.LastID, typed.Capped)
 	})
 }

--- a/internal/cron/noti_cleanup.go
+++ b/internal/cron/noti_cleanup.go
@@ -10,21 +10,26 @@ import (
 
 // NotiCleanupResult contains the result of a notification cleanup run.
 type NotiCleanupResult struct {
-	ReadDeleted  int64  `json:"read_deleted"`  // 읽음 + readOlderThanDays 경과
-	StaleDeleted int64  `json:"stale_deleted"` // 읽음 무관 + allOlderThanDays 경과
-	Batches      int    `json:"batches"`
-	Capped       bool   `json:"capped"` // maxBatches 도달로 중단 (다음 run 에서 계속)
-	ExecutedAt   string `json:"executed_at"`
+	Deleted    int64  `json:"deleted"` // 이번 run 에 삭제된 행 수
+	Batches    int    `json:"batches"`
+	LastID     int64  `json:"last_id"` // 이번 run 이 도달한 ph_id 워터마크
+	Capped     bool   `json:"capped"`  // maxBatches 도달로 중단 (다음 run 에서 계속)
+	ExecutedAt string `json:"executed_at"`
 }
 
 // runNotiCleanup prunes g5_na_noti to curb table bloat (#12607: 760만 행).
-// 읽은 알림은 readOlderThanDays, 읽지 않은 오래된 알림은 allOlderThanDays 후 삭제한다.
-// 락/슬로우쿼리 방지를 위해 batchSize 단위 DELETE 를 반복하며, maxBatches 로 1회 실행량을 제한한다.
+// 삭제 대상: ① 읽은 알림 중 readOlderThanDays 경과, ② 읽음 무관 allOlderThanDays 경과.
+//
+// g5_na_noti 에는 ph_datetime/ph_readed 선두 인덱스가 없어 조건 기반 LIMIT DELETE 는
+// 매 배치마다 760만 행 풀스캔을 유발한다. 이를 피하려 PRIMARY KEY(ph_id, auto_increment)
+// 오름차순 윈도우로 walk 하며 [cursor, cursor+window) 범위만 PK 인덱스로 스캔/삭제한다.
+// 오래된 행일수록 ph_id 가 작아 앞쪽 윈도우에서 먼저 지워지고, 삭제분만큼 다음 run 의
+// MIN(ph_id) 가 올라가 진행된다. maxBatches 로 1회 실행량(락/부하)을 제한한다.
 func runNotiCleanup(db *gorm.DB) (*NotiCleanupResult, error) {
 	readOlderThanDays := envInt("NOTI_CLEANUP_READ_DAYS", 30)
 	allOlderThanDays := envInt("NOTI_CLEANUP_ALL_DAYS", 90)
-	batchSize := envInt("NOTI_CLEANUP_BATCH", 5000)
-	maxBatches := envInt("NOTI_CLEANUP_MAX_BATCHES", 200) // 5000*200 = 1M rows/run 안전 상한
+	window := int64(envInt("NOTI_CLEANUP_BATCH", 5000)) // ph_id 윈도우 폭 (PK 범위 스캔)
+	maxBatches := envInt("NOTI_CLEANUP_MAX_BATCHES", 200)
 
 	now := time.Now()
 	readCutoff := now.AddDate(0, 0, -readOlderThanDays).Format("2006-01-02 15:04:05")
@@ -32,41 +37,35 @@ func runNotiCleanup(db *gorm.DB) (*NotiCleanupResult, error) {
 
 	res := &NotiCleanupResult{ExecutedAt: now.Format("2006-01-02 15:04:05")}
 
-	deleteLoop := func(where string, args ...interface{}) (int64, error) {
-		var total int64
-		for res.Batches < maxBatches {
-			q := append([]interface{}{}, args...)
-			r := db.Exec("DELETE FROM g5_na_noti WHERE "+where+" LIMIT ?", append(q, batchSize)...)
-			if r.Error != nil {
-				return total, r.Error
-			}
-			res.Batches++
-			total += r.RowsAffected
-			if r.RowsAffected < int64(batchSize) {
-				return total, nil // 더 지울 것 없음
-			}
-			if res.Batches >= maxBatches {
-				res.Capped = true
-				return total, nil
-			}
-		}
-		return total, nil
+	// 테이블 ph_id 범위 (한 번만 조회)
+	var bounds struct {
+		MinID int64
+		MaxID int64
 	}
-
-	// 1) 읽은 알림 중 readCutoff 이전
-	read, err := deleteLoop("ph_readed = 'Y' AND ph_datetime < ?", readCutoff)
-	if err != nil {
+	if err := db.Raw("SELECT COALESCE(MIN(ph_id),0) AS min_id, COALESCE(MAX(ph_id),0) AS max_id FROM g5_na_noti").
+		Scan(&bounds).Error; err != nil {
 		return res, err
 	}
-	res.ReadDeleted = read
+	if bounds.MaxID == 0 {
+		return res, nil // 빈 테이블
+	}
 
-	// 2) 읽음 무관 allCutoff 이전 (오래된 미읽음 포함)
-	if !res.Capped {
-		stale, err := deleteLoop("ph_datetime < ?", allCutoff)
-		if err != nil {
-			return res, err
+	// 한 윈도우 내에서 두 조건을 OR 로 한 번에 삭제(범위 재주행 방지).
+	const where = "ph_id >= ? AND ph_id < ? AND ((ph_readed = 'Y' AND ph_datetime < ?) OR ph_datetime < ?)"
+
+	for cursor := bounds.MinID; cursor <= bounds.MaxID; cursor += window {
+		if res.Batches >= maxBatches {
+			res.Capped = true
+			break
 		}
-		res.StaleDeleted = stale
+		hi := cursor + window // [cursor, hi)
+		r := db.Exec("DELETE FROM g5_na_noti WHERE "+where, cursor, hi, readCutoff, allCutoff)
+		if r.Error != nil {
+			return res, r.Error
+		}
+		res.Batches++
+		res.Deleted += r.RowsAffected
+		res.LastID = hi
 	}
 
 	return res, nil

--- a/internal/cron/noti_cleanup.go
+++ b/internal/cron/noti_cleanup.go
@@ -1,0 +1,82 @@
+package cron
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// NotiCleanupResult contains the result of a notification cleanup run.
+type NotiCleanupResult struct {
+	ReadDeleted  int64  `json:"read_deleted"`  // 읽음 + readOlderThanDays 경과
+	StaleDeleted int64  `json:"stale_deleted"` // 읽음 무관 + allOlderThanDays 경과
+	Batches      int    `json:"batches"`
+	Capped       bool   `json:"capped"` // maxBatches 도달로 중단 (다음 run 에서 계속)
+	ExecutedAt   string `json:"executed_at"`
+}
+
+// runNotiCleanup prunes g5_na_noti to curb table bloat (#12607: 760만 행).
+// 읽은 알림은 readOlderThanDays, 읽지 않은 오래된 알림은 allOlderThanDays 후 삭제한다.
+// 락/슬로우쿼리 방지를 위해 batchSize 단위 DELETE 를 반복하며, maxBatches 로 1회 실행량을 제한한다.
+func runNotiCleanup(db *gorm.DB) (*NotiCleanupResult, error) {
+	readOlderThanDays := envInt("NOTI_CLEANUP_READ_DAYS", 30)
+	allOlderThanDays := envInt("NOTI_CLEANUP_ALL_DAYS", 90)
+	batchSize := envInt("NOTI_CLEANUP_BATCH", 5000)
+	maxBatches := envInt("NOTI_CLEANUP_MAX_BATCHES", 200) // 5000*200 = 1M rows/run 안전 상한
+
+	now := time.Now()
+	readCutoff := now.AddDate(0, 0, -readOlderThanDays).Format("2006-01-02 15:04:05")
+	allCutoff := now.AddDate(0, 0, -allOlderThanDays).Format("2006-01-02 15:04:05")
+
+	res := &NotiCleanupResult{ExecutedAt: now.Format("2006-01-02 15:04:05")}
+
+	deleteLoop := func(where string, args ...interface{}) (int64, error) {
+		var total int64
+		for res.Batches < maxBatches {
+			q := append([]interface{}{}, args...)
+			r := db.Exec("DELETE FROM g5_na_noti WHERE "+where+" LIMIT ?", append(q, batchSize)...)
+			if r.Error != nil {
+				return total, r.Error
+			}
+			res.Batches++
+			total += r.RowsAffected
+			if r.RowsAffected < int64(batchSize) {
+				return total, nil // 더 지울 것 없음
+			}
+			if res.Batches >= maxBatches {
+				res.Capped = true
+				return total, nil
+			}
+		}
+		return total, nil
+	}
+
+	// 1) 읽은 알림 중 readCutoff 이전
+	read, err := deleteLoop("ph_readed = 'Y' AND ph_datetime < ?", readCutoff)
+	if err != nil {
+		return res, err
+	}
+	res.ReadDeleted = read
+
+	// 2) 읽음 무관 allCutoff 이전 (오래된 미읽음 포함)
+	if !res.Capped {
+		stale, err := deleteLoop("ph_datetime < ?", allCutoff)
+		if err != nil {
+			return res, err
+		}
+		res.StaleDeleted = stale
+	}
+
+	return res, nil
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}

--- a/internal/cron/popular_subscribe_notify.go
+++ b/internal/cron/popular_subscribe_notify.go
@@ -36,8 +36,8 @@ var boardSlugRe = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 // 글 작성 시점엔 추천=0 이라 write 시 못 보내므로, 주기 cron 으로 임계값 도달 글을 잡아
 // 보드당 글당 1회만 알림(g5_board_subscribe_notified 로 중복 방지).
 func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
-	threshold := cronEnvInt("NOTI_POPULAR_THRESHOLD", 10)     // 추천글 기준과 정합되게 운영에서 조정
-	windowDays := cronEnvInt("NOTI_POPULAR_WINDOW_DAYS", 3)   // 최근 N일 내 글만 대상(오래된 글 재통지 방지)
+	threshold := cronEnvInt("NOTI_POPULAR_THRESHOLD", 10)   // 추천글 기준과 정합되게 운영에서 조정
+	windowDays := cronEnvInt("NOTI_POPULAR_WINDOW_DAYS", 3) // 최근 N일 내 글만 대상(오래된 글 재통지 방지)
 	maxPostsPerBoard := cronEnvInt("NOTI_POPULAR_MAX_POSTS", 200)
 	now := time.Now()
 	cutoff := now.AddDate(0, 0, -windowDays)

--- a/internal/handler/noti_handler.go
+++ b/internal/handler/noti_handler.go
@@ -451,9 +451,9 @@ func (h *NotiHandler) UpdatePreferences(c *gin.Context) {
 	}
 
 	var req struct {
-		NotiComment   *bool `json:"noti_comment"`
-		NotiReply     *bool `json:"noti_reply"`
-		NotiMention   *bool `json:"noti_mention"`
+		NotiComment        *bool `json:"noti_comment"`
+		NotiReply          *bool `json:"noti_reply"`
+		NotiMention        *bool `json:"noti_mention"`
 		NotiLike           *bool `json:"noti_like"`
 		NotiFollow         *bool `json:"noti_follow"`
 		NotiBoardSubscribe *bool `json:"noti_board_subscribe"`

--- a/internal/repository/gnuboard/noti_preference.go
+++ b/internal/repository/gnuboard/noti_preference.go
@@ -8,12 +8,12 @@ import (
 
 // NotiPreference represents a row in g5_noti_preference table
 type NotiPreference struct {
-	MbID          string    `gorm:"column:mb_id;primaryKey"`
-	NotiComment   bool      `gorm:"column:noti_comment;default:1"`
-	NotiReply     bool      `gorm:"column:noti_reply;default:1"`
-	NotiMention   bool      `gorm:"column:noti_mention;default:1"`
-	NotiLike      bool      `gorm:"column:noti_like;default:1"`
-	NotiFollow    bool      `gorm:"column:noti_follow;default:1"`
+	MbID        string `gorm:"column:mb_id;primaryKey"`
+	NotiComment bool   `gorm:"column:noti_comment;default:1"`
+	NotiReply   bool   `gorm:"column:noti_reply;default:1"`
+	NotiMention bool   `gorm:"column:noti_mention;default:1"`
+	NotiLike    bool   `gorm:"column:noti_like;default:1"`
+	NotiFollow  bool   `gorm:"column:noti_follow;default:1"`
 	// 게시판 구독('write' subscribe) 알림 — 회원 팔로우(NotiFollow)와 분리 (#12607)
 	NotiBoardSubscribe bool      `gorm:"column:noti_board_subscribe;default:1"`
 	LikeThreshold      int       `gorm:"column:like_threshold;default:1"`
@@ -45,10 +45,10 @@ func (r *notiPreferenceRepository) Get(mbID string) (*NotiPreference, error) {
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return &NotiPreference{
-				MbID:          mbID,
-				NotiComment:   true,
-				NotiReply:     true,
-				NotiMention:   true,
+				MbID:               mbID,
+				NotiComment:        true,
+				NotiReply:          true,
+				NotiMention:        true,
 				NotiLike:           true,
 				NotiFollow:         true,
 				NotiBoardSubscribe: true,
@@ -67,10 +67,10 @@ func (r *notiPreferenceRepository) Upsert(pref *NotiPreference) error {
 		return r.db.Create(pref).Error
 	}
 	return r.db.Model(&NotiPreference{}).Where("mb_id = ?", pref.MbID).Updates(map[string]interface{}{
-		"noti_comment":   pref.NotiComment,
-		"noti_reply":     pref.NotiReply,
-		"noti_mention":   pref.NotiMention,
-		"noti_like":      pref.NotiLike,
+		"noti_comment":         pref.NotiComment,
+		"noti_reply":           pref.NotiReply,
+		"noti_mention":         pref.NotiMention,
+		"noti_like":            pref.NotiLike,
 		"noti_follow":          pref.NotiFollow,
 		"noti_board_subscribe": pref.NotiBoardSubscribe,
 		"like_threshold":       pref.LikeThreshold,


### PR DESCRIPTION
## 배경
버그 #12607 조사 중 사이트 전역 알림 과부하 발견. 게시판 구독이 새 글마다 구독자 전원에게 1:1 알림을 보내 `g5_na_noti` 가 **760만 행**까지 비대(write 알림 매일 ~5만건).

## 변경
`internal/cron/noti_cleanup.go` + `POST /api/internal/cron/noti-cleanup` 추가:
- 읽은 알림(`ph_readed='Y'`) **30일** 경과 삭제 → 이후 읽음 무관 **90일** 경과 삭제
- 배치 DELETE(`LIMIT` 루프) + 1회 `maxBatches` 상한으로 락/슬로우쿼리 최소화
- 보존기간/배치크기/상한 = env(`NOTI_CLEANUP_READ_DAYS`·`_ALL_DAYS`·`_BATCH`·`_MAX_BATCHES`)

이건 알림 개편(#12607)의 **PR1(즉효·독립)**. 후속 PR에서 게시판 구독 단계화(자유게시판=인기글만) + 인기글 트리거로 생성량 자체를 줄임.

## 후속(ops)
스케줄러(systemd timer)에 `/api/internal/cron/noti-cleanup` 주기 호출 등록 필요(예: 매일 새벽).

## 검증
- go build/vet OK
- 적용 후: `SELECT COUNT(*) FROM g5_na_noti` 감소 + 슬로우쿼리/락 없음 확인