### PR TITLE
feat(noti): 게시판 구독 단계화 + 인기글 트리거 — 자유게시판 알림 폭주 해소 (#12607)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5978,6 +5978,7 @@ func main() {
 		cronGroup.POST("/point-expiry-notify", cronHandler.PointExpiryNotify)
 		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
 		cronGroup.POST("/sync-visible-comment-counts", cronHandler.SyncVisibleCommentCounts)
+		cronGroup.POST("/popular-subscribe-notify", cronHandler.PopularSubscribeNotify)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo, writeAfterEventRepo)

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -192,3 +192,15 @@ func (h *Handler) SyncVisibleCommentCounts(c *gin.Context) {
 			typed.BoardsChecked, typed.BoardsSynced, typed.RowsUpdated, typed.Errors)
 	})
 }
+
+// PopularSubscribeNotify handles POST /api/internal/cron/popular-subscribe-notify
+// level=2(인기글만) 게시판 구독자에게 추천 임계값 도달 글을 1회 알림 (#12607).
+func (h *Handler) PopularSubscribeNotify(c *gin.Context) {
+	h.runCronTask(c, "popular-subscribe-notify", func() (interface{}, error) {
+		return runPopularSubscribeNotify(h.db)
+	}, func(result interface{}) {
+		typed := result.(*PopularSubscribeResult)
+		log.Printf("[Cron:popular-subscribe-notify] boards=%d posts_notified=%d notis=%d",
+			typed.Boards, typed.PostsNotified, typed.NotisCreated)
+	})
+}

--- a/internal/cron/popular_subscribe_notify.go
+++ b/internal/cron/popular_subscribe_notify.go
@@ -1,0 +1,126 @@
+package cron
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	"gorm.io/gorm"
+)
+
+// cronEnvInt reads a positive int env var, falling back to def.
+func cronEnvInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// PopularSubscribeResult contains the result of a popular-post subscribe notify run.
+type PopularSubscribeResult struct {
+	Boards        int    `json:"boards"`         // level=2 구독자 있는 보드 수
+	PostsNotified int    `json:"posts_notified"` // 이번 run 에 인기글로 통지된 글 수
+	NotisCreated  int    `json:"notis_created"`  // 생성된 알림 수
+	ExecutedAt    string `json:"executed_at"`
+}
+
+var boardSlugRe = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// runPopularSubscribeNotify sends a single "popular post" notification to level=2
+// (인기글만) board subscribers when a post crosses the recommend threshold (#12607).
+// 글 작성 시점엔 추천=0 이라 write 시 못 보내므로, 주기 cron 으로 임계값 도달 글을 잡아
+// 보드당 글당 1회만 알림(g5_board_subscribe_notified 로 중복 방지).
+func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
+	threshold := cronEnvInt("NOTI_POPULAR_THRESHOLD", 10)     // 추천글 기준과 정합되게 운영에서 조정
+	windowDays := cronEnvInt("NOTI_POPULAR_WINDOW_DAYS", 3)   // 최근 N일 내 글만 대상(오래된 글 재통지 방지)
+	maxPostsPerBoard := cronEnvInt("NOTI_POPULAR_MAX_POSTS", 200)
+	now := time.Now()
+	cutoff := now.AddDate(0, 0, -windowDays)
+
+	res := &PopularSubscribeResult{ExecutedAt: now.Format("2006-01-02 15:04:05")}
+
+	// 1) level=2 구독자가 있는 보드 목록
+	var boards []string
+	if err := db.Table("g5_board_subscribe").Distinct("bo_table").
+		Where("level = 2").Pluck("bo_table", &boards).Error; err != nil {
+		return res, err
+	}
+
+	type postRow struct {
+		WrID    int
+		Subject string
+		MbID    string
+		WrName  string
+	}
+
+	for _, board := range boards {
+		if !boardSlugRe.MatchString(board) {
+			continue // 동적 테이블명 인젝션 방지
+		}
+		res.Boards++
+
+		// 2) 임계값 도달 + 최근 + 미통지 글
+		var posts []postRow
+		q := fmt.Sprintf(
+			"SELECT w.wr_id AS wr_id, w.wr_subject AS subject, w.mb_id AS mb_id, w.wr_name AS wr_name "+
+				"FROM g5_write_%s w "+
+				"LEFT JOIN g5_board_subscribe_notified n ON n.bo_table = ? AND n.wr_id = w.wr_id "+
+				"WHERE w.wr_is_comment = 0 AND w.wr_good >= ? AND w.wr_datetime >= ? AND n.wr_id IS NULL "+
+				"ORDER BY w.wr_id LIMIT ?", board)
+		if err := db.Raw(q, board, threshold, cutoff, maxPostsPerBoard).Scan(&posts).Error; err != nil {
+			continue // 테이블 없음 등은 건너뜀
+		}
+		if len(posts) == 0 {
+			continue
+		}
+
+		// 3) 이 보드의 level=2 구독자 (noti_board_subscribe OFF 제외)
+		var subs []string
+		db.Table("g5_board_subscribe").Select("mb_id").
+			Where("bo_table = ? AND level = 2", board).Pluck("mb_id", &subs)
+		offSet := map[string]bool{}
+		if len(subs) > 0 {
+			var off []string
+			db.Table("g5_noti_preference").Select("mb_id").
+				Where("noti_board_subscribe = 0 AND mb_id IN ?", subs).Pluck("mb_id", &off)
+			for _, o := range off {
+				offSet[o] = true
+			}
+		}
+
+		for _, p := range posts {
+			authorName := p.WrName
+			if authorName == "" {
+				authorName = p.MbID
+			}
+			for _, sid := range subs {
+				if sid == p.MbID || offSet[sid] {
+					continue
+				}
+				noti := &gnurepo.Notification{
+					PhToCase: "subscribe", PhFromCase: "write", BoTable: board,
+					WrID: p.WrID, MbID: sid, RelMbID: p.MbID,
+					RelMbNick:  authorName,
+					RelMsg:     fmt.Sprintf("%s 게시판 인기글: %s", board, p.Subject),
+					RelURL:     fmt.Sprintf("/%s/%d", board, p.WrID),
+					PhReaded:   "N",
+					PhDatetime: now,
+					WrParent:   p.WrID,
+				}
+				if err := db.Create(noti).Error; err == nil {
+					res.NotisCreated++
+				}
+			}
+			// 통지 마킹 (구독자 0명이어도 마킹해 재스캔 방지)
+			db.Exec("INSERT IGNORE INTO g5_board_subscribe_notified (bo_table, wr_id) VALUES (?, ?)", board, p.WrID)
+			res.PostsNotified++
+		}
+	}
+
+	return res, nil
+}

--- a/internal/handler/noti_handler.go
+++ b/internal/handler/noti_handler.go
@@ -404,12 +404,25 @@ func (h *NotiHandler) MarkGroupAsRead(c *gin.Context) {
 
 // notiPreferenceResponse is the response for notification preferences
 type notiPreferenceResponse struct {
-	NotiComment   bool `json:"noti_comment"`
-	NotiReply     bool `json:"noti_reply"`
-	NotiMention   bool `json:"noti_mention"`
-	NotiLike      bool `json:"noti_like"`
-	NotiFollow    bool `json:"noti_follow"`
-	LikeThreshold int  `json:"like_threshold"`
+	NotiComment        bool `json:"noti_comment"`
+	NotiReply          bool `json:"noti_reply"`
+	NotiMention        bool `json:"noti_mention"`
+	NotiLike           bool `json:"noti_like"`
+	NotiFollow         bool `json:"noti_follow"`
+	NotiBoardSubscribe bool `json:"noti_board_subscribe"`
+	LikeThreshold      int  `json:"like_threshold"`
+}
+
+func toNotiPreferenceResponse(pref *gnurepo.NotiPreference) notiPreferenceResponse {
+	return notiPreferenceResponse{
+		NotiComment:        pref.NotiComment,
+		NotiReply:          pref.NotiReply,
+		NotiMention:        pref.NotiMention,
+		NotiLike:           pref.NotiLike,
+		NotiFollow:         pref.NotiFollow,
+		NotiBoardSubscribe: pref.NotiBoardSubscribe,
+		LikeThreshold:      pref.LikeThreshold,
+	}
 }
 
 // GetPreferences handles GET /api/v1/notifications/preferences
@@ -426,14 +439,7 @@ func (h *NotiHandler) GetPreferences(c *gin.Context) {
 		return
 	}
 
-	common.V2Success(c, notiPreferenceResponse{
-		NotiComment:   pref.NotiComment,
-		NotiReply:     pref.NotiReply,
-		NotiMention:   pref.NotiMention,
-		NotiLike:      pref.NotiLike,
-		NotiFollow:    pref.NotiFollow,
-		LikeThreshold: pref.LikeThreshold,
-	})
+	common.V2Success(c, toNotiPreferenceResponse(pref))
 }
 
 // UpdatePreferences handles PUT /api/v1/notifications/preferences
@@ -448,9 +454,10 @@ func (h *NotiHandler) UpdatePreferences(c *gin.Context) {
 		NotiComment   *bool `json:"noti_comment"`
 		NotiReply     *bool `json:"noti_reply"`
 		NotiMention   *bool `json:"noti_mention"`
-		NotiLike      *bool `json:"noti_like"`
-		NotiFollow    *bool `json:"noti_follow"`
-		LikeThreshold *int  `json:"like_threshold"`
+		NotiLike           *bool `json:"noti_like"`
+		NotiFollow         *bool `json:"noti_follow"`
+		NotiBoardSubscribe *bool `json:"noti_board_subscribe"`
+		LikeThreshold      *int  `json:"like_threshold"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		common.V2ErrorResponse(c, http.StatusBadRequest, "잘못된 요청", err)
@@ -478,6 +485,9 @@ func (h *NotiHandler) UpdatePreferences(c *gin.Context) {
 	if req.NotiFollow != nil {
 		pref.NotiFollow = *req.NotiFollow
 	}
+	if req.NotiBoardSubscribe != nil {
+		pref.NotiBoardSubscribe = *req.NotiBoardSubscribe
+	}
 	if req.LikeThreshold != nil {
 		if *req.LikeThreshold < 1 {
 			*req.LikeThreshold = 1
@@ -490,14 +500,7 @@ func (h *NotiHandler) UpdatePreferences(c *gin.Context) {
 		return
 	}
 
-	common.V2Success(c, notiPreferenceResponse{
-		NotiComment:   pref.NotiComment,
-		NotiReply:     pref.NotiReply,
-		NotiMention:   pref.NotiMention,
-		NotiLike:      pref.NotiLike,
-		NotiFollow:    pref.NotiFollow,
-		LikeThreshold: pref.LikeThreshold,
-	})
+	common.V2Success(c, toNotiPreferenceResponse(pref))
 }
 
 // DeleteGroup handles DELETE /api/v1/notifications/group

--- a/internal/repository/gnuboard/noti_preference.go
+++ b/internal/repository/gnuboard/noti_preference.go
@@ -14,8 +14,10 @@ type NotiPreference struct {
 	NotiMention   bool      `gorm:"column:noti_mention;default:1"`
 	NotiLike      bool      `gorm:"column:noti_like;default:1"`
 	NotiFollow    bool      `gorm:"column:noti_follow;default:1"`
-	LikeThreshold int       `gorm:"column:like_threshold;default:1"`
-	UpdatedAt     time.Time `gorm:"column:updated_at"`
+	// 게시판 구독('write' subscribe) 알림 — 회원 팔로우(NotiFollow)와 분리 (#12607)
+	NotiBoardSubscribe bool      `gorm:"column:noti_board_subscribe;default:1"`
+	LikeThreshold      int       `gorm:"column:like_threshold;default:1"`
+	UpdatedAt          time.Time `gorm:"column:updated_at"`
 }
 
 // TableName returns the g5_noti_preference table name
@@ -47,9 +49,10 @@ func (r *notiPreferenceRepository) Get(mbID string) (*NotiPreference, error) {
 				NotiComment:   true,
 				NotiReply:     true,
 				NotiMention:   true,
-				NotiLike:      true,
-				NotiFollow:    true,
-				LikeThreshold: 1,
+				NotiLike:           true,
+				NotiFollow:         true,
+				NotiBoardSubscribe: true,
+				LikeThreshold:      1,
 			}, nil
 		}
 		return nil, err
@@ -68,7 +71,8 @@ func (r *notiPreferenceRepository) Upsert(pref *NotiPreference) error {
 		"noti_reply":     pref.NotiReply,
 		"noti_mention":   pref.NotiMention,
 		"noti_like":      pref.NotiLike,
-		"noti_follow":    pref.NotiFollow,
-		"like_threshold": pref.LikeThreshold,
+		"noti_follow":          pref.NotiFollow,
+		"noti_board_subscribe": pref.NotiBoardSubscribe,
+		"like_threshold":       pref.LikeThreshold,
 	}).Error
 }

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -388,8 +388,10 @@ func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 		})
 	}
 
+	// level=1(전체)만 글 작성 시 알림. level=2(인기글만)는 추천 임계값 도달 시
+	// 인기글 트리거 cron 이 1회 알림 (#12607 — 자유게시판 등 폭주 방지).
 	var subscriberIDs []string
-	w.db.Table("g5_board_subscribe").Select("mb_id").Where("bo_table = ? AND mb_id != ?", job.BoardSlug, job.MemberID).Pluck("mb_id", &subscriberIDs)
+	w.db.Table("g5_board_subscribe").Select("mb_id").Where("bo_table = ? AND mb_id != ? AND level = 1", job.BoardSlug, job.MemberID).Pluck("mb_id", &subscriberIDs)
 	followerSet := make(map[string]bool, len(followerIDs))
 	for _, fid := range followerIDs {
 		followerSet[fid] = true
@@ -399,7 +401,7 @@ func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 			continue
 		}
 		pref, ok := w.mustGetNotiPreference(sid)
-		if !ok || !pref.NotiFollow {
+		if !ok || !pref.NotiBoardSubscribe {
 			continue
 		}
 		w.createNotification(&gnurepo.Notification{

--- a/migration/009_board_subscribe_levels.down.sql
+++ b/migration/009_board_subscribe_levels.down.sql
@@ -1,0 +1,4 @@
+-- rollback: 게시판 구독 단계화 (#12607)
+DROP TABLE IF EXISTS g5_board_subscribe_notified;
+ALTER TABLE g5_noti_preference DROP COLUMN noti_board_subscribe;
+ALTER TABLE g5_board_subscribe DROP COLUMN level;

--- a/migration/009_board_subscribe_levels.up.sql
+++ b/migration/009_board_subscribe_levels.up.sql
@@ -1,0 +1,21 @@
+-- 게시판 구독 알림 단계화 (#12607)
+-- level: 1=전체(모든 글, 1:1), 2=인기글만(추천 임계값 도달 시 1회)
+-- 자유게시판(free) 폭주(최근7일 subscribe 알림 38만건, 99%+) → 인기글만으로 전환.
+
+ALTER TABLE g5_board_subscribe
+  ADD COLUMN level TINYINT NOT NULL DEFAULT 1 AFTER bo_table;
+
+-- 게시판 구독 알림 토글을 회원 팔로우(noti_follow)와 분리
+ALTER TABLE g5_noti_preference
+  ADD COLUMN noti_board_subscribe TINYINT(1) NOT NULL DEFAULT 1 AFTER noti_follow;
+
+-- 인기글 알림 중복 방지 (인기 트리거 cron 이 글당 1회만 알림)
+CREATE TABLE IF NOT EXISTS g5_board_subscribe_notified (
+  bo_table    VARCHAR(20)  NOT NULL,
+  wr_id       INT          NOT NULL,
+  notified_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (bo_table, wr_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 기존 자유게시판 구독자 → 인기글만 (폭주 해소). 나머지 보드는 전체(1:1) 유지.
+UPDATE g5_board_subscribe SET level = 2 WHERE bo_table = 'free';


### PR DESCRIPTION
## 배경
게시판 구독이 **새 글마다 구독자 전원에 1:1 알림**(write_after_worker) → 자유게시판(free) 구독 시 폭주(최근7일 subscribe 알림 **38만건, 사이트 99%+**). g5_na_noti 760만 행 비대. deep-research: 주요 플랫폼 누구도 1:1 per-post 안 함(YouTube Personalized 기본 / Discourse watching·tracking·muted).

## 변경 (PR2 — 핵심)
- **migration 009**: `g5_board_subscribe.level`(1=전체/1:1, 2=인기글만) + `g5_noti_preference.noti_board_subscribe` + `g5_board_subscribe_notified`(인기글 중복통지 방지). **기존 자유게시판(free) 구독자 → level=2 마이그레이션**(폭주 해소). 나머지 보드는 level=1 유지.
- **write_after_worker**: subscribe 분기에서 `level=1`만 글 작성 시 알림, 게이트를 `noti_follow`→`noti_board_subscribe`로 분리.
- **인기글 트리거 cron** `POST /api/internal/cron/popular-subscribe-notify`: 최근 글 중 추천 임계값(`NOTI_POPULAR_THRESHOLD`, 추천글 기준과 정합) 도달 글을 `level=2` 구독자에게 **글당 1회** 알림(글 작성 시 추천=0 이라 write 시 불가 → cron). 동적 테이블명 slug 검증.
- noti_preference 모델 + GET/PUT `/api/v1/notifications/preferences` 에 `noti_board_subscribe` 추가.

정책: **자유게시판=인기글만, 그 외 전 게시판=전체/1:1 현행 유지**(글 적어 정상).

## 후속
- 프론트(별도 PR): 구독 버튼 단계 선택(전체/인기글만/끔) + 알림설정 토글.
- ops: `popular-subscribe-notify` 스케줄러(예: 5분) + na_noti 정리 cron(angple-backend#503) 등록.

## 검증
- go build/vet OK
- canary: free 일반글→알림X, 추천 임계값 글→1회만; 타 보드 level=1→전체 알림 유지; cron 중복 0; 사이트 일일 write 알림 급감.