### PR TITLE
fix(noti): 인기글 cron 백필 폭주 방지 + 중복 통지 race 수정 (#12607)

### DIFF
--- a/internal/cron/popular_subscribe_notify.go
+++ b/internal/cron/popular_subscribe_notify.go
@@ -79,6 +79,13 @@ func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
 			continue
 		}
 
+		// 게시판 한글명 (없으면 slug)
+		boardName := board
+		db.Table("g5_board").Select("bo_subject").Where("bo_table = ?", board).Limit(1).Scan(&boardName)
+		if boardName == "" {
+			boardName = board
+		}
+
 		// 3) 이 보드의 level=2 구독자 (noti_board_subscribe OFF 제외)
 		var subs []string
 		db.Table("g5_board_subscribe").Select("mb_id").
@@ -94,6 +101,15 @@ func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
 		}
 
 		for _, p := range posts {
+			// claim: 통지 전에 먼저 마킹(원자적 INSERT IGNORE)해 동시 cron 실행 시
+			// 같은 글 중복 통지를 막는다. 이미 선점됐으면(RowsAffected==0) skip.
+			// 구독자 0명이어도 마킹돼 재스캔되지 않는다.
+			claim := db.Exec("INSERT IGNORE INTO g5_board_subscribe_notified (bo_table, wr_id) VALUES (?, ?)", board, p.WrID)
+			if claim.Error != nil || claim.RowsAffected == 0 {
+				continue
+			}
+			res.PostsNotified++
+
 			authorName := p.WrName
 			if authorName == "" {
 				authorName = p.MbID
@@ -106,7 +122,7 @@ func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
 					PhToCase: "subscribe", PhFromCase: "write", BoTable: board,
 					WrID: p.WrID, MbID: sid, RelMbID: p.MbID,
 					RelMbNick:  authorName,
-					RelMsg:     fmt.Sprintf("%s 게시판 인기글: %s", board, p.Subject),
+					RelMsg:     fmt.Sprintf("%s 게시판 인기글: %s", boardName, p.Subject),
 					RelURL:     fmt.Sprintf("/%s/%d", board, p.WrID),
 					PhReaded:   "N",
 					PhDatetime: now,
@@ -116,9 +132,6 @@ func runPopularSubscribeNotify(db *gorm.DB) (*PopularSubscribeResult, error) {
 					res.NotisCreated++
 				}
 			}
-			// 통지 마킹 (구독자 0명이어도 마킹해 재스캔 방지)
-			db.Exec("INSERT IGNORE INTO g5_board_subscribe_notified (bo_table, wr_id) VALUES (?, ?)", board, p.WrID)
-			res.PostsNotified++
 		}
 	}
 

--- a/migration/010_preseed_popular_notified.down.sql
+++ b/migration/010_preseed_popular_notified.down.sql
@@ -1,0 +1,4 @@
+-- 선마킹 데이터 제거. g5_board_subscribe_notified 는 통지 중복방지용 상태 테이블이라
+-- (사용자 가치 없음) free 마커 전체 삭제해도 무해(최악: 재통지 가능).
+-- 단, 009.down 이 테이블 자체를 DROP 하므로 보통은 그쪽에서 정리됨.
+DELETE FROM g5_board_subscribe_notified WHERE bo_table = 'free';

--- a/migration/010_preseed_popular_notified.up.sql
+++ b/migration/010_preseed_popular_notified.up.sql
@@ -1,0 +1,11 @@
+-- #12607: 인기글 트리거 cron 첫 실행 시 기존 인기글 소급 통지(백필 폭주) 방지.
+-- 실측: free 최근 7일 wr_good>=10 글 2,346건 × level=2 구독자 130명 ≈ 30만 알림이
+-- cron 첫 run 에 한 번에 발사될 위험. 배포 시점 이전 free 글을 '통지 완료'로 선마킹해,
+-- cron 이 배포 이후 신규로 임계값을 넘긴 글만 통지하도록 한다.
+-- cron 기본 window=3일이며 30일 버퍼로 선마킹(window 확대 대비). free 외 보드는
+-- 현재 level=2 구독자가 없어(자유게시판만 인기글만 정책) 대상 아님.
+INSERT IGNORE INTO g5_board_subscribe_notified (bo_table, wr_id)
+SELECT 'free', wr_id
+FROM g5_write_free
+WHERE wr_is_comment = 0
+  AND wr_datetime >= DATE_SUB(NOW(), INTERVAL 30 DAY);


### PR DESCRIPTION
## 배경
#504(머지됨)의 인기글 트리거 cron을 독립 점검한 결과 **배포 차단급 결함**을 발견. 크론 스케줄러 등록(활성화) 전 반드시 선반영.

## 결함 & 수정
- **P0 — 첫 실행 백필 폭주**: cron이 `window`(기본 3일) 내 `wr_good>=threshold` 미통지 글을 전부 신규로 간주. 실측 free 최근7일 인기글 **2,346건 × level=2 구독자 130명 ≈ 30만 알림**이 첫 run에 발사 → 폭주 방지 기능이 폭주 유발.
  → **migration 010**: 배포 시점 이전 free 글(30일 버퍼)을 `g5_board_subscribe_notified`에 선마킹. cron은 배포 이후 신규 임계값 도달 글만 통지.
- **P1 — 중복 통지 race**: 통지 후 마킹 순서 → 동시 cron 실행 시 같은 글 양쪽 통지. **claim 패턴**(원자적 INSERT IGNORE 선마킹, RowsAffected==0이면 skip)으로 전환.
- 알림 메시지 게시판명 slug → 한글명(`bo_subject`).

## 배포 순서 (중요)
migration 009 → **migration 010** → 백엔드 코드 → 그 후에만 cron 스케줄러 등록.

## 검증
- build/vet OK
- canary: cron 첫 run 에 기존 인기글 통지 0건, 배포 후 신규 임계값 글만 1회 통지, 동시 실행 중복 0.