### PR TITLE
chore(lint): goconst + prealloc 정리 — golangci-lint 0 issues

### DIFF
--- a/cmd/ad-free-setup/main.go
+++ b/cmd/ad-free-setup/main.go
@@ -238,9 +238,9 @@ func main() {
 		os.Exit(5)
 	}
 
-	colNames := []string{}
-	placeholders := []string{}
-	args := []any{}
+	colNames := make([]string, 0, len(insertVals))
+	placeholders := make([]string, 0, len(insertVals))
+	args := make([]any, 0, len(insertVals))
 	for k, v := range insertVals {
 		colNames = append(colNames, "`"+k+"`")
 		if v == "__NOW__" {

--- a/internal/repository/v2/point_config_repo.go
+++ b/internal/repository/v2/point_config_repo.go
@@ -17,6 +17,9 @@ var (
 
 const pointConfigCacheTTL = 30 * time.Second
 
+// nullJSON 은 site_settings.settings_json 이 비어있음을 나타내는 리터럴 "null" 문자열.
+const nullJSON = "null"
+
 // PointConfigRepository handles point configuration data access
 type PointConfigRepository interface {
 	// GetPointConfig returns the current point configuration (cached 30s)
@@ -68,7 +71,7 @@ func (r *pointConfigRepository) getPointConfigFromDB() (*PointConfig, error) {
 		return DefaultPointConfig(), nil
 	}
 
-	if row.SettingsJSON == nil || *row.SettingsJSON == "" || *row.SettingsJSON == "null" {
+	if row.SettingsJSON == nil || *row.SettingsJSON == "" || *row.SettingsJSON == nullJSON {
 		return DefaultPointConfig(), nil
 	}
 
@@ -103,7 +106,7 @@ func (r *pointConfigRepository) UpdatePointConfig(config *PointConfig) error {
 
 	// Parse existing JSON to preserve other fields
 	existing := make(map[string]interface{})
-	if err == nil && row.SettingsJSON != nil && *row.SettingsJSON != "" && *row.SettingsJSON != "null" {
+	if err == nil && row.SettingsJSON != nil && *row.SettingsJSON != "" && *row.SettingsJSON != nullJSON {
 		if unmarshalErr := json.Unmarshal([]byte(*row.SettingsJSON), &existing); unmarshalErr != nil {
 			existing = make(map[string]interface{})
 		}


### PR DESCRIPTION
## 배경
golangci-lint(v2.11.2, CI와 동일 버전) 전체 실행 시 기존 코드에서 2건 지적. CI는 `only-new-issues`라 PR을 막지 않아 누적돼 있던 항목.

## 변경
- `internal/repository/v2/point_config_repo.go`: 리터럴 `"null"` 4회 반복 → `const nullJSON` 추출 (goconst)
- `cmd/ad-free-setup/main.go`: `colNames`/`placeholders`/`args` 슬라이스를 `len(insertVals)` 용량으로 미리 할당 (prealloc)

동작 변화 없음. golangci-lint 재실행 시 **0 issues** 확인. build/vet/gofmt -s 통과.