### PR TITLE
fix(sanitize): src 없는/비허용 iframe 제거 — 글 수정 시 본문 사라짐 (#12686)

### DIFF
--- a/internal/common/sanitize.go
+++ b/internal/common/sanitize.go
@@ -135,20 +135,28 @@ func SanitizeMessage(text string) string {
 	return strictPolicy.Sanitize(text)
 }
 
-// iframeRegex는 iframe 태그를 매칭하는 정규식
-var iframeRegex = regexp.MustCompile(`(?i)<iframe\s[^>]*src="([^"]*)"[^>]*>[\s\S]*?</iframe>`)
+// iframeAnyRegex는 src 유무와 무관하게 모든 iframe 태그를 매칭한다.
+var iframeAnyRegex = regexp.MustCompile(`(?i)<iframe\b[^>]*>[\s\S]*?</iframe>`)
 
-// removeDisallowedIframes는 허용 도메인이 아닌 iframe을 제거한다.
+// iframeSrcAttrRegex는 iframe의 src 속성값을 추출한다(없으면 미매칭).
+var iframeSrcAttrRegex = regexp.MustCompile(`(?i)\bsrc\s*=\s*"([^"]*)"`)
+
+// emptyYoutubeWrapperRegex는 iframe이 제거돼 빈 껍데기만 남은
+// tiptap youtube 래퍼(<div data-youtube-video>)를 매칭한다.
+var emptyYoutubeWrapperRegex = regexp.MustCompile(`(?i)<div\b[^>]*\bdata-youtube-video\b[^>]*>\s*</div>`)
+
+// removeDisallowedIframes는 허용 도메인 src를 가진 iframe만 남기고 나머지를 제거한다.
+// #12686: 기존에는 src="..."가 있어야만 매칭돼, src가 누락된 깨진 iframe
+// (예: tiptap youtube 노드가 src=null로 직렬화된 경우)이 무방비로 통과·저장됐다.
+// 그 깨진 노드는 수정 진입 시 에디터 본문을 비우는 원인이 된다. 이제 src가 없거나
+// 허용 도메인이 아닌 iframe은 모두 제거하고, 비게 된 youtube 래퍼도 정리한다.
 func removeDisallowedIframes(html string) string {
-	return iframeRegex.ReplaceAllStringFunc(html, func(match string) string {
-		submatch := iframeRegex.FindStringSubmatch(match)
-		if len(submatch) < 2 {
-			return ""
+	html = iframeAnyRegex.ReplaceAllStringFunc(html, func(match string) string {
+		m := iframeSrcAttrRegex.FindStringSubmatch(match)
+		if len(m) < 2 || !allowedIframeSrcRegex.MatchString(m[1]) {
+			return "" // src 없음 또는 비허용 도메인 → 제거
 		}
-		src := submatch[1]
-		if allowedIframeSrcRegex.MatchString(src) {
-			return match
-		}
-		return ""
+		return match
 	})
+	return emptyYoutubeWrapperRegex.ReplaceAllString(html, "")
 }

--- a/internal/common/sanitize_test.go
+++ b/internal/common/sanitize_test.go
@@ -65,6 +65,33 @@ func TestSanitizePostContent_NonYoutubeIframeRemoved(t *testing.T) {
 	}
 }
 
+// #12686: src가 누락된 깨진 iframe(과 빈 youtube 래퍼)은 제거하고 본문은 보존한다.
+func TestSanitizePostContent_SrclessYoutubeIframeRemoved(t *testing.T) {
+	input := `<div data-youtube-video=""><iframe class="tiptap-youtube" width="640" height="480" allowfullscreen="true"></iframe></div><p>본문 텍스트</p>`
+	result := SanitizePostContent(input)
+	if strings.Contains(result, "<iframe") {
+		t.Errorf("src-less iframe not removed: %s", result)
+	}
+	if strings.Contains(result, "data-youtube-video") {
+		t.Errorf("empty youtube wrapper not cleaned: %s", result)
+	}
+	if !strings.Contains(result, "본문 텍스트") {
+		t.Errorf("body text must be preserved: %s", result)
+	}
+}
+
+// src가 있는 정상 youtube iframe은 깨진 케이스 처리 후에도 보존되어야 한다(회귀 방지).
+func TestSanitizePostContent_ValidYoutubeStillPreservedAfterSrclessFix(t *testing.T) {
+	input := `<div data-youtube-video=""><iframe src="https://www.youtube.com/embed/abc123" width="640" height="480"></iframe></div><p>설명</p>`
+	result := SanitizePostContent(input)
+	if !strings.Contains(result, "youtube.com/embed/abc123") {
+		t.Errorf("valid youtube iframe should be preserved: %s", result)
+	}
+	if !strings.Contains(result, "설명") {
+		t.Errorf("body text must be preserved: %s", result)
+	}
+}
+
 func TestSanitizePostContent_DangerousCSSRemoved(t *testing.T) {
 	input := `<div style="position: fixed; z-index: 9999; top: 0; left: 0; width: 100vw;">overlay</div>`
 	result := SanitizePostContent(input)


### PR DESCRIPTION
## 배경 (#12686)
모바일에서 유튜브 임베드가 있는 글을 **수정** 진입하면 본문이 통째로 안 보이는 버그. 근원 조사 결과:
- DB 저장본의 youtube iframe 에 **src 만 누락**(나머지 tiptap 속성은 존재): `<div data-youtube-video><iframe class="tiptap-youtube" width height allowfullscreen ...(no src)></iframe></div>`
- 원인 ①: `removeDisallowedIframes` 의 정규식이 `src="..."` 가 **있어야만** 매칭 → src 없는 깨진 iframe 을 검증 못 해 **무방비 통과·저장**.
- 원인 ②(프론트, 별도 PR): tiptap youtube renderHTML 이 src=null 이면 src 없는 iframe 을 emit. 그 깨진 노드가 수정 진입 시 setContent 파싱을 깨 본문 blank.

## 변경 (백엔드)
- iframe 매칭을 src 유무와 무관하게 바꾼 뒤, **src 가 없거나 허용 도메인이 아니면 제거**. 비게 된 youtube 래퍼(`div[data-youtube-video]`)도 정리.
- 정상 youtube/twitter/vimeo 등 허용 iframe 은 그대로 보존.
- 효과: 앞으로 깨진 임베드가 저장되지 않음 → 향후 수정 진입 blank 방지.

## 검증
- 기존 sanitize 테스트 전부 통과(회귀 없음) + 신규 2건(src-less 제거+본문 보존 / 정상 youtube 보존).
- go build/vet OK.

## 후속
- 프론트(별도 PR): 기존에 이미 저장된 깨진 글의 수정 blank 를 위해, 수정 로드 시 깨진 youtube 노드를 setContent 전에 제거(canary+모바일 확인).