### PR TITLE
feat: 만장일치 미처리 신고 자동 기각 크론 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5980,6 +5980,7 @@ func main() {
 		cronGroup.POST("/sync-visible-comment-counts", cronHandler.SyncVisibleCommentCounts)
 		cronGroup.POST("/popular-subscribe-notify", cronHandler.PopularSubscribeNotify)
 		cronGroup.POST("/noti-cleanup", cronHandler.NotiCleanup)
+		cronGroup.POST("/auto-dismiss-reports", cronHandler.AutoDismissReports)
 
 		// Start delete worker for delayed deletion processing
 		deleteWorker := worker.NewDeleteWorker(db, gnuWriteRepo, scheduledDeleteRepo, writeAfterEventRepo)

--- a/internal/cron/auto_dismiss_reports.go
+++ b/internal/cron/auto_dismiss_reports.go
@@ -1,0 +1,106 @@
+package cron
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// AutoDismissResult contains the result of the auto-dismiss cron run.
+type AutoDismissResult struct {
+	Enabled        bool     `json:"enabled"`
+	MinOpinions    int      `json:"min_opinions"`
+	CandidateCount int      `json:"candidate_count"`
+	DismissedRows  int      `json:"dismissed_rows"`
+	DismissedKeys  []string `json:"dismissed_keys"`
+	Errors         int      `json:"errors"`
+	ExecutedAt     string   `json:"executed_at"`
+}
+
+// runAutoDismissReports 자동 미처리(기각) 크론.
+// 만장일치 조건: 같은 콘텐츠(sg_table, sg_parent)에 서로 다른 담당자의 "미처리(dismiss)"
+// 의견이 N명(기본 2) 이상이고 "조치(action)" 의견이 0건이면, 미처리 신고를 처리자 'system'으로 자동 기각한다.
+// singo_settings.auto_dismiss_enabled = 'true' 일 때만 동작한다(기본 비활성).
+func runAutoDismissReports(db *gorm.DB) (*AutoDismissResult, error) {
+	now := time.Now()
+	result := &AutoDismissResult{MinOpinions: 2, ExecutedAt: now.Format("2006-01-02 15:04:05")}
+
+	// 1. 활성화 여부 확인 — 설정이 'true'가 아니면 아무 것도 하지 않음
+	var enabled string
+	db.Raw("SELECT `value` FROM singo_settings WHERE `key` = ?", "auto_dismiss_enabled").Scan(&enabled)
+	if strings.TrimSpace(enabled) != "true" {
+		result.Enabled = false
+		return result, nil
+	}
+	result.Enabled = true
+
+	// 2. 최소 미처리 인원 (기본 2, 설정으로 조정 가능)
+	var minStr string
+	db.Raw("SELECT `value` FROM singo_settings WHERE `key` = ?", "auto_dismiss_min_opinions").Scan(&minStr)
+	if n, err := strconv.Atoi(strings.TrimSpace(minStr)); err == nil && n > 0 {
+		result.MinOpinions = n
+	}
+
+	// 3. 후보 조회 — 미처리 신고가 남아 있고, distinct 미처리 의견 N명 이상 + 조치 의견 0건
+	type candidate struct {
+		Table  string `gorm:"column:sg_table"`
+		Parent int    `gorm:"column:sg_parent"`
+	}
+	var candidates []candidate
+	if err := db.Raw(`
+		SELECT o.sg_table, o.sg_parent
+		FROM g5_na_singo_opinions o
+		WHERE EXISTS (
+			SELECT 1 FROM g5_na_singo s
+			WHERE s.sg_table = o.sg_table AND s.sg_parent = o.sg_parent AND s.processed = 0
+		)
+		GROUP BY o.sg_table, o.sg_parent
+		HAVING COUNT(DISTINCT CASE WHEN o.opinion_type = 'dismiss' THEN o.reviewer_id END) >= ?
+		   AND SUM(CASE WHEN o.opinion_type = 'action' THEN 1 ELSE 0 END) = 0
+	`, result.MinOpinions).Scan(&candidates).Error; err != nil {
+		return result, err
+	}
+	result.CandidateCount = len(candidates)
+
+	// 4. 후보별 미처리 신고를 기각 처리 (처리자 system)
+	note := fmt.Sprintf("자동 미처리 (만장일치 %d명)", result.MinOpinions)
+	for _, cand := range candidates {
+		// 이력 기록용 대표 sg_id (미처리 신고 중 하나)
+		var sgID int
+		db.Raw(`SELECT sg_id FROM g5_na_singo WHERE sg_table = ? AND sg_parent = ? AND processed = 0 ORDER BY id LIMIT 1`,
+			cand.Table, cand.Parent).Scan(&sgID)
+
+		// 기각 처리 — UpdateStatus(dismissed, "system")와 동일한 컬럼 세트
+		res := db.Exec(`
+			UPDATE g5_na_singo
+			SET processed = 1, admin_approved = 0, hold = 0,
+			    admin_datetime = NOW(), processed_datetime = NOW(),
+			    admin_users = 'system', version = version + 1
+			WHERE sg_table = ? AND sg_parent = ? AND processed = 0
+		`, cand.Table, cand.Parent)
+		if res.Error != nil {
+			result.Errors++
+			continue
+		}
+		if res.RowsAffected == 0 {
+			// 이미 처리됨 — 이력 남기지 않음
+			continue
+		}
+		result.DismissedRows += int(res.RowsAffected)
+		result.DismissedKeys = append(result.DismissedKeys, fmt.Sprintf("%s:%d", cand.Table, cand.Parent))
+
+		// 상태 변경 이력 (g5_singo_history)
+		if err := db.Exec(`
+			INSERT INTO g5_singo_history
+				(sg_table, sg_id, sg_parent, prev_status, new_status, admin_id, admin_note, created_at)
+			VALUES (?, ?, ?, 'monitoring', 'dismissed', 'system', ?, NOW())
+		`, cand.Table, sgID, cand.Parent, note).Error; err != nil {
+			result.Errors++
+		}
+	}
+
+	return result, nil
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -216,3 +216,16 @@ func (h *Handler) NotiCleanup(c *gin.Context) {
 			typed.Deleted, typed.Batches, typed.LastID, typed.Capped)
 	})
 }
+
+// AutoDismissReports handles POST /api/internal/cron/auto-dismiss-reports
+// 만장일치 미처리(2명 이상 dismiss + action 0건) 신고를 처리자 'system'으로 자동 기각.
+// singo_settings.auto_dismiss_enabled = 'true' 일 때만 동작.
+func (h *Handler) AutoDismissReports(c *gin.Context) {
+	h.runCronTask(c, "auto-dismiss-reports", func() (interface{}, error) {
+		return runAutoDismissReports(h.db)
+	}, func(result interface{}) {
+		typed := result.(*AutoDismissResult)
+		log.Printf("[Cron:auto-dismiss-reports] enabled=%v min=%d candidates=%d dismissed=%d errors=%d",
+			typed.Enabled, typed.MinOpinions, typed.CandidateCount, typed.DismissedRows, typed.Errors)
+	})
+}


### PR DESCRIPTION
## 개요

신고 담당자가 여러 명일 때, 같은 신고건에 **서로 다른 담당자의 미처리(dismiss) 의견이 2명 이상이고 조치(action) 의견이 0건**(만장일치)이면 미처리 신고를 처리자 `system`으로 자동 기각하는 시간별 크론을 추가합니다.

## 동작 방식

- 신규 엔드포인트: `POST /api/internal/cron/auto-dismiss-reports`
- `singo_settings.auto_dismiss_enabled = 'true'` 일 때만 동작 (**기본 비활성** — 배포만으로는 아무 동작 안 함)
- `auto_dismiss_min_opinions` (기본 2)로 최소 미처리 인원 조정
- 후보: 미처리 신고가 남아있고 distinct 미처리 의견 N명 이상 + 조치 의견 0건
- 처리: 수동 기각과 동일 컬럼 세트 (`processed=1, admin_approved=0, hold=0, admin_datetime/processed_datetime=NOW(), admin_users='system', version+1`)
- 이력: `g5_singo_history`에 `monitoring→dismissed` 기록, 이미 처리된 건은 RowsAffected=0으로 멱등 skip

## 변경 파일

- `internal/cron/auto_dismiss_reports.go` (신규): `runAutoDismissReports`
- `internal/cron/handler.go`: `AutoDismissReports` 핸들러
- `cmd/api/main.go`: cronGroup 라우트 등록

## 활성화(별도 운영 단계)

PR 머지/배포 후 아래 2단계를 거쳐야 실제 동작:
1. `singo_settings` 행 추가: `auto_dismiss_enabled='true'`, `auto_dismiss_min_opinions='2'`
2. crontab 1줄 추가: `0 * * * * curl -s -X POST "http://127.0.0.1:8091/api/internal/cron/auto-dismiss-reports?secret=angple_cron_2024"`

## 검증

- `go build ./...`, `go vet ./internal/cron/`, gofmt 통과