### PR TITLE
feat(noti): 게시판 구독 요약 알림(level=3 다이제스트) (#12607 P1)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5979,6 +5979,7 @@ func main() {
 		cronGroup.POST("/auto-promote", cronHandler.AutoPromote)
 		cronGroup.POST("/sync-visible-comment-counts", cronHandler.SyncVisibleCommentCounts)
 		cronGroup.POST("/popular-subscribe-notify", cronHandler.PopularSubscribeNotify)
+		cronGroup.POST("/digest-subscribe-notify", cronHandler.DigestSubscribeNotify)
 		cronGroup.POST("/noti-cleanup", cronHandler.NotiCleanup)
 		cronGroup.POST("/auto-dismiss-reports", cronHandler.AutoDismissReports)
 

--- a/internal/cron/digest_subscribe_notify.go
+++ b/internal/cron/digest_subscribe_notify.go
@@ -1,0 +1,157 @@
+package cron
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	gnurepo "github.com/damoang/angple-backend/internal/repository/gnuboard"
+	"gorm.io/gorm"
+)
+
+// DigestSubscribeResult contains the result of a digest subscribe notify run.
+type DigestSubscribeResult struct {
+	Boards          int    `json:"boards"`           // level=3 구독자 있는 보드 수
+	Seeded          int    `json:"seeded"`           // 첫 run 커서 초기화(통지 0)된 보드 수
+	PostsSummarized int    `json:"posts_summarized"` // 이번 run 에 요약된 글 수
+	NotisCreated    int    `json:"notis_created"`    // 생성된 요약 알림 수
+	ExecutedAt      string `json:"executed_at"`
+}
+
+// runDigestSubscribeNotify sends one "digest" notification per level=3 (요약) board
+// subscriber, summarizing posts newer than the per-board cursor (#12607 P1).
+// 새 글마다 보내지 않고 cron 주기(예: 1일 1~2회)마다 모아서 1건으로 보낸다.
+// 커서(g5_board_subscribe_digest_cursor.last_wr_id)를 넘는 글만 묶고 run 끝에 커서를
+// 전진시켜 같은 글 중복 요약을 막는다. 커서가 없는 보드는 현재 MAX(wr_id)로 시드하고
+// 통지하지 않아(소급 폭발 방지), 신규 level=3 구독도 안전하게 다음 run 부터 요약된다.
+func runDigestSubscribeNotify(db *gorm.DB) (*DigestSubscribeResult, error) {
+	maxPreview := cronEnvInt("NOTI_DIGEST_PREVIEW", 3)    // 미리보기 제목 개수
+	maxPosts := cronEnvInt("NOTI_DIGEST_MAX_POSTS", 1000) // 보드당 1 run 집계 상한
+	now := time.Now()
+	res := &DigestSubscribeResult{ExecutedAt: now.Format("2006-01-02 15:04:05")}
+
+	// 1) level=3 구독자가 있는 보드
+	var boards []string
+	if err := db.Table("g5_board_subscribe").Distinct("bo_table").
+		Where("level = 3").Pluck("bo_table", &boards).Error; err != nil {
+		return res, err
+	}
+
+	type postRow struct {
+		WrID    int
+		Subject string
+	}
+
+	for _, board := range boards {
+		if !boardSlugRe.MatchString(board) {
+			continue // 동적 테이블명 인젝션 방지
+		}
+		res.Boards++
+
+		// 현재 커서
+		var cursor struct{ LastWrID int }
+		scan := db.Table("g5_board_subscribe_digest_cursor").
+			Select("last_wr_id AS last_wr_id").Where("bo_table = ?", board).Limit(1).Scan(&cursor)
+		hasCursor := scan.Error == nil && scan.RowsAffected > 0
+
+		// 보드 최대 wr_id (테이블 없음 등은 건너뜀)
+		var maxWr int
+		if err := db.Raw(fmt.Sprintf(
+			"SELECT COALESCE(MAX(wr_id),0) FROM g5_write_%s WHERE wr_is_comment=0", board)).
+			Scan(&maxWr).Error; err != nil {
+			continue
+		}
+
+		// 첫 run: 커서를 현재 MAX 로 시드만 하고 통지 0 (배포 이전 글 소급 폭발 방지)
+		if !hasCursor {
+			db.Exec("INSERT IGNORE INTO g5_board_subscribe_digest_cursor (bo_table, last_wr_id, updated_at) VALUES (?, ?, ?)",
+				board, maxWr, now)
+			res.Seeded++
+			continue
+		}
+
+		if maxWr <= cursor.LastWrID {
+			continue // 새 글 없음
+		}
+
+		// 2) cursor 초과 새 글
+		var posts []postRow
+		q := fmt.Sprintf(
+			"SELECT wr_id AS wr_id, wr_subject AS subject FROM g5_write_%s "+
+				"WHERE wr_is_comment=0 AND wr_id > ? ORDER BY wr_id LIMIT ?", board)
+		if err := db.Raw(q, cursor.LastWrID, maxPosts).Scan(&posts).Error; err != nil {
+			continue
+		}
+		if len(posts) == 0 {
+			db.Exec("UPDATE g5_board_subscribe_digest_cursor SET last_wr_id=?, updated_at=? WHERE bo_table=?",
+				maxWr, now, board)
+			continue
+		}
+
+		count := len(posts)
+		newCursor := posts[count-1].WrID
+
+		previews := make([]string, 0, maxPreview)
+		for i := 0; i < count && i < maxPreview; i++ {
+			previews = append(previews, posts[i].Subject)
+		}
+
+		// 게시판 한글명
+		boardName := board
+		db.Table("g5_board").Select("bo_subject").Where("bo_table = ?", board).Limit(1).Scan(&boardName)
+		if boardName == "" {
+			boardName = board
+		}
+
+		// 3) level=3 구독자 (noti_board_subscribe OFF 제외)
+		var subs []string
+		db.Table("g5_board_subscribe").Select("mb_id").
+			Where("bo_table = ? AND level = 3", board).Pluck("mb_id", &subs)
+		if len(subs) == 0 {
+			// 구독자 0이어도 커서는 전진 (다음 run 폭증 방지)
+			db.Exec("UPDATE g5_board_subscribe_digest_cursor SET last_wr_id=?, updated_at=? WHERE bo_table=?",
+				newCursor, now, board)
+			continue
+		}
+		offSet := map[string]bool{}
+		var off []string
+		db.Table("g5_noti_preference").Select("mb_id").
+			Where("noti_board_subscribe = 0 AND mb_id IN ?", subs).Pluck("mb_id", &off)
+		for _, o := range off {
+			offSet[o] = true
+		}
+
+		msg := fmt.Sprintf("%s 새 글 %d건: %s", boardName, count, strings.Join(previews, ", "))
+		if count > len(previews) {
+			msg += " 외"
+		}
+
+		for _, sid := range subs {
+			if offSet[sid] {
+				continue
+			}
+			noti := &gnurepo.Notification{
+				PhToCase:      "subscribe",
+				PhFromCase:    "digest",
+				BoTable:       board,
+				WrID:          newCursor,
+				MbID:          sid,
+				RelMsg:        msg,
+				RelURL:        fmt.Sprintf("/%s", board),
+				PhReaded:      "N",
+				PhDatetime:    now,
+				ParentSubject: boardName,
+				WrParent:      newCursor,
+			}
+			if err := db.Create(noti).Error; err == nil {
+				res.NotisCreated++
+			}
+		}
+		res.PostsSummarized += count
+
+		db.Exec("UPDATE g5_board_subscribe_digest_cursor SET last_wr_id=?, updated_at=? WHERE bo_table=?",
+			newCursor, now, board)
+	}
+
+	return res, nil
+}

--- a/internal/cron/handler.go
+++ b/internal/cron/handler.go
@@ -205,6 +205,18 @@ func (h *Handler) PopularSubscribeNotify(c *gin.Context) {
 	})
 }
 
+// DigestSubscribeNotify handles POST /api/internal/cron/digest-subscribe-notify
+// level=3(요약) 게시판 구독자에게 주기마다 새 글을 묶어 1건 알림 (#12607 P1).
+func (h *Handler) DigestSubscribeNotify(c *gin.Context) {
+	h.runCronTask(c, "digest-subscribe-notify", func() (interface{}, error) {
+		return runDigestSubscribeNotify(h.db)
+	}, func(result interface{}) {
+		typed := result.(*DigestSubscribeResult)
+		log.Printf("[Cron:digest-subscribe-notify] boards=%d seeded=%d posts=%d notis=%d",
+			typed.Boards, typed.Seeded, typed.PostsSummarized, typed.NotisCreated)
+	})
+}
+
 // NotiCleanup handles POST /api/internal/cron/noti-cleanup
 // Prunes g5_na_noti (read + old, then very old regardless) to curb table bloat (#12607).
 func (h *Handler) NotiCleanup(c *gin.Context) {

--- a/migration/011_board_subscribe_digest.down.sql
+++ b/migration/011_board_subscribe_digest.down.sql
@@ -1,0 +1,2 @@
+-- rollback: 다이제스트 커서 테이블 제거. level=3 구독자는 알림이 멈출 뿐 데이터 손상 없음.
+DROP TABLE IF EXISTS g5_board_subscribe_digest_cursor;

--- a/migration/011_board_subscribe_digest.up.sql
+++ b/migration/011_board_subscribe_digest.up.sql
@@ -1,0 +1,13 @@
+-- 게시판 구독 알림 다이제스트(요약, level=3) — #12607 P1
+-- level: 1=전체(글마다), 2=인기글만(추천 임계 1회), 3=요약(주기적으로 새 글 묶음 1건)
+-- level 컬럼은 009 에서 TINYINT 로 이미 존재 → 값(3)만 확장, DDL 불필요.
+
+-- 게시판별 마지막 다이제스트 커서. last_wr_id 초과 글만 다음 run 에 요약.
+-- 커서 행이 없는 보드는 digest cron 이 첫 run 에 "현재 MAX(wr_id) 로 초기화 + 통지 0"
+-- 으로 자가 시드한다(배포 시점 이전 글 소급 폭발 방지 — 010 preseed 와 동일 사상).
+CREATE TABLE IF NOT EXISTS g5_board_subscribe_digest_cursor (
+  bo_table    VARCHAR(20) NOT NULL,
+  last_wr_id  INT         NOT NULL DEFAULT 0,
+  updated_at  DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (bo_table)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## 배경
게시판 구독 알림 폭주(#12607) 후속 P1. 전체(level=1)/인기글만(level=2)에 이어 **요약(level=3)** 단계를 추가한다. 모범사례 연구(Discourse·GitHub·알림 시스템 설계론)에서 **다이제스트/배칭**이 폭주 해법의 정석이며, "끄기/인기글만"과 달리 **구독 의도(전체를 보고 싶다)를 보존**하면서 폭주만 제거한다. (설계 문서: `/home/damoang/docs/2026-06-13-subscription-notification-best-practices-and-digest-design.html`)

## 변경
- **migration 011**: `g5_board_subscribe_digest_cursor`(보드별 `last_wr_id` 커서) 생성. `level` 컬럼은 009 에서 이미 TINYINT → 값(3)만 확장(DDL 불필요).
- **`internal/cron/digest_subscribe_notify.go`**: level=3 구독 보드별로 커서 초과 새 글을 묶어 **구독자당 1건** 요약 알림(`"<게시판> 새 글 N건: 제목1, 제목2, 제목3 외"` → 게시판 목록 링크). run 끝에 커서 전진 → **중복 0**.
  - 커서 없는 보드: 현재 `MAX(wr_id)`로 시드 + 통지 0 → **배포 이전 글 소급 폭발 방지**(010 preseed 사상). 신규 level=3 구독도 다음 run 부터 안전.
  - 구독자 0이어도 커서 전진(다음 run 폭증 방지). `noti_board_subscribe=0` 제외. 동적 테이블명 `boardSlugRe` 검증.
- **handler + route**: `POST /api/internal/cron/digest-subscribe-notify` — 외부 cron(systemd/k8s) 호출. `popular-subscribe-notify` 패턴 재사용.

## 검증
- `go build ./internal/cron/... ./cmd/api/` OK, `go vet ./internal/cron/` OK, gofmt clean.
- 첫 run = 시드(통지 0) → 이후 run 부터 커서 초과 글만 요약(중복 0) 로직 검토 완료.

## 운영 (배포 후)
1. migration 011 적용. 2. 백엔드 배포. 3. cron 등록(예: 매일 08:00·20:00 KST → digest-subscribe-notify). 프론트 level=3 UI 는 별도 angple PR.