### PR TITLE
fix: 자동 미조치 기각을 sg_id(개별 댓글) 단위로 집계

### DIFF
--- a/internal/cron/auto_dismiss_reports.go
+++ b/internal/cron/auto_dismiss_reports.go
@@ -22,14 +22,14 @@ type AutoDismissResult struct {
 
 // runAutoDismissReports 자동 미처리(기각) 크론.
 //
-// 후보 판정 기준은 운영 화면(inbox)의 "dismiss_ready" 상태 정의와 100% 동일하다
-// (damoang-backend internal/repository/report_repo.go 의 카운트 서브쿼리 + buildStatusFilter "dismiss_ready" 참조).
-// 즉 화면에서 "만장일치 미조치"로 보이는 신고 == 이 크론이 기각하는 신고. 양쪽 기준을 일치시켜 드리프트를 방지한다.
+// 집계·처리 단위는 신고된 개별 댓글/글(sg_id)이다. 의견 저장과 수동 기각(GetAllByTableAndSgID,
+// WHERE sg_table=? AND sg_id=?)이 모두 sg_id 단위이므로 자동기각도 동일 단위로 맞춘다.
+// (과거 parent 단위 집계는, 한 글 아래 다른 댓글의 이용제한 의견이 무관한 댓글의 기각을 막는 버그가 있었다.)
 //
 //   - 의견 집계는 반드시 is_valid_reviewer = 1 (현재 유효한 담당자) 인 의견만, COUNT(DISTINCT reviewer_id) 로 센다.
 //     (탈퇴/해제된 옛 담당자의 표는 세지 않는다.)
-//   - 미조치(dismiss) 유효 담당자 N명(기본 2) 이상 AND 조치(action) 유효 담당자 0명.
-//   - 신고건(parent) 단위 집계: monitoring_checked=1 AND admin_approved=0 AND processed=0 AND hold=0
+//   - 같은 sg_id에 대해 미조치(dismiss) 유효 담당자 N명(기본 2) 이상 AND 조치(action) 유효 담당자 0명.
+//   - sg_id 단위 집계: monitoring_checked=1 AND admin_approved=0 AND processed=0 AND hold=0
 //     (이미 admin이 승인/처리했거나 보류한 건은 제외).
 //
 // singo_settings.auto_dismiss_enabled = 'true' 일 때만 동작한다(기본 비활성).
@@ -53,26 +53,27 @@ func runAutoDismissReports(db *gorm.DB) (*AutoDismissResult, error) {
 		result.MinOpinions = n
 	}
 
-	// 3. 후보 조회 — inbox "dismiss_ready" 정의와 동일 (report_repo.go 참조).
+	// 3. 후보 조회 — sg_id(개별 댓글) 단위.
 	//    유효 담당자(is_valid_reviewer=1)의 distinct 미조치 N명 이상 + distinct 조치 0명,
-	//    그리고 신고건 단위로 monitoring_checked=1, admin_approved=0, processed=0, hold=0.
+	//    그리고 sg_id 단위로 monitoring_checked=1, admin_approved=0, processed=0, hold=0.
 	type candidate struct {
 		Table  string `gorm:"column:sg_table"`
+		SGID   int    `gorm:"column:sg_id"`
 		Parent int    `gorm:"column:sg_parent"`
 	}
 	var candidates []candidate
 	if err := db.Raw(`
-		SELECT s.sg_table, s.sg_parent
+		SELECT s.sg_table, s.sg_id, s.sg_parent
 		FROM g5_na_singo s
 		LEFT JOIN (
-			SELECT o.sg_table, o.sg_parent,
+			SELECT o.sg_table, o.sg_id, o.sg_parent,
 				COUNT(DISTINCT CASE WHEN o.opinion_type = 'action' THEN o.reviewer_id END) AS action_count,
 				COUNT(DISTINCT CASE WHEN o.opinion_type = 'dismiss' THEN o.reviewer_id END) AS dismiss_count
 			FROM g5_na_singo_opinions o
 			WHERE o.is_valid_reviewer = 1
-			GROUP BY o.sg_table, o.sg_parent
-		) op ON s.sg_table = op.sg_table AND s.sg_parent = op.sg_parent
-		GROUP BY s.sg_table, s.sg_parent
+			GROUP BY o.sg_table, o.sg_id, o.sg_parent
+		) op ON s.sg_table = op.sg_table AND s.sg_id = op.sg_id AND s.sg_parent = op.sg_parent
+		GROUP BY s.sg_table, s.sg_id, s.sg_parent
 		HAVING MAX(s.monitoring_checked) = 1
 		   AND MAX(s.admin_approved) = 0
 		   AND MAX(s.processed) = 0
@@ -84,22 +85,18 @@ func runAutoDismissReports(db *gorm.DB) (*AutoDismissResult, error) {
 	}
 	result.CandidateCount = len(candidates)
 
-	// 4. 후보별 미처리 신고를 기각 처리 (처리자 system)
+	// 4. 후보 댓글(sg_id)별 미처리 신고를 기각 처리 (처리자 system).
+	//    범위는 수동 기각(GetAllByTableAndSgID)과 동일하게 sg_table + sg_id.
 	note := fmt.Sprintf("자동 미처리 (유효 담당자 만장일치 %d명)", result.MinOpinions)
 	for _, cand := range candidates {
-		// 이력 기록용 대표 sg_id (미처리 신고 중 하나)
-		var sgID int
-		db.Raw(`SELECT sg_id FROM g5_na_singo WHERE sg_table = ? AND sg_parent = ? AND processed = 0 ORDER BY id LIMIT 1`,
-			cand.Table, cand.Parent).Scan(&sgID)
-
 		// 기각 처리 — UpdateStatus(dismissed, "system")와 동일한 컬럼 세트
 		res := db.Exec(`
 			UPDATE g5_na_singo
 			SET processed = 1, admin_approved = 0, hold = 0,
 			    admin_datetime = NOW(), processed_datetime = NOW(),
 			    admin_users = 'system', version = version + 1
-			WHERE sg_table = ? AND sg_parent = ? AND processed = 0
-		`, cand.Table, cand.Parent)
+			WHERE sg_table = ? AND sg_id = ? AND processed = 0
+		`, cand.Table, cand.SGID)
 		if res.Error != nil {
 			result.Errors++
 			continue
@@ -109,14 +106,14 @@ func runAutoDismissReports(db *gorm.DB) (*AutoDismissResult, error) {
 			continue
 		}
 		result.DismissedRows += int(res.RowsAffected)
-		result.DismissedKeys = append(result.DismissedKeys, fmt.Sprintf("%s:%d", cand.Table, cand.Parent))
+		result.DismissedKeys = append(result.DismissedKeys, fmt.Sprintf("%s:%d", cand.Table, cand.SGID))
 
 		// 상태 변경 이력 (g5_singo_history)
 		if err := db.Exec(`
 			INSERT INTO g5_singo_history
 				(sg_table, sg_id, sg_parent, prev_status, new_status, admin_id, admin_note, created_at)
 			VALUES (?, ?, ?, 'monitoring', 'dismissed', 'system', ?, NOW())
-		`, cand.Table, sgID, cand.Parent, note).Error; err != nil {
+		`, cand.Table, cand.SGID, cand.Parent, note).Error; err != nil {
 			result.Errors++
 		}
 	}


### PR DESCRIPTION
## 배경

신고 처리의 실제 단위는 **댓글(sg_id)** 이다 — 의견 저장(`g5_na_singo_opinions`는 sg_id별)과 수동 기각(`GetAllByTableAndSgID`, `WHERE sg_table=? AND sg_id=?`)이 모두 sg_id 단위. 그런데 자동기각 크론은 **sg_parent(부모글) 단위**로 의견을 집계해, 한 글 아래 한 댓글의 이용제한 의견이 같은 글의 무관한 다른 댓글의 만장일치 미조치 기각까지 막았다.

**실증 사례**: `free` parent `6431073` 아래 신고 댓글 7개. 댓글 `6435333`은 담당자 2명 만장일치 미조치(유효 미조치 2, 조치 0)인데, 같은 글의 다른 댓글 `6431116`에 이용제한 의견이 1건 있다는 이유로 parent 집계상 `action=1`이 되어 `6435333`까지 기각에서 제외됐다.

라이브 측정: parent 단위 후보 0건 vs **sg_id 단위 후보 66건**(현재 누락).

## 변경 (`internal/cron/auto_dismiss_reports.go`)

- 후보 쿼리: `GROUP BY o.sg_table, o.sg_id, o.sg_parent` + JOIN도 `sg_id` 기준 (의견 카운트를 댓글 단위로)
- 기각 `UPDATE` 범위: `WHERE sg_table=? AND sg_id=? AND processed=0` (수동 기각 `GetAllByTableAndSgID`와 동일 범위)
- history: 후보 `sg_id` 직접 기록
- 조건 유지: `is_valid_reviewer=1` 인 distinct 미조치 N명(기본 2) 이상 AND distinct 조치 0명, 그리고 sg_id 단위 `monitoring_checked=1 / admin_approved=0 / processed=0 / hold=0`

## 검증

- `go build`, `go vet`, gofmt 통과
- 새 쿼리 라이브 실측: sg_id 후보 66건, 샘플 `6435333` 포함 / `6431116`(이용제한 있음) 제외 확인

> 활성화는 `singo_settings.auto_dismiss_enabled='true'`(현재 활성). 배포 후 수동 1회 트리거로 66건 처리 결과를 먼저 확인 예정.
> 별도 후속(PR): 인박스 목록 표시 카운트도 sg_id 단위로 정렬 (damoang-backend).