### PR TITLE
fix(ipprotect): 신고(sg_ip) 경로에 IP Protection 적용

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4735,7 +4735,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/report - Report a post
-		v1Boards.POST("/:slug/posts/:id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -4792,8 +4792,8 @@ func main() {
 				return
 			}
 
-			// 신고자 IP
-			sgIP := c.ClientIP()
+			// 신고자 IP (IP Protection 적용 — 지정 멤버/관리자는 치환 IP 기록)
+			sgIP := middleware.GetClientIP(c)
 
 			// 사유별 1행씩 INSERT (nariya 호환: sg_type = reason code)
 			now := time.Now()
@@ -4819,7 +4819,7 @@ func main() {
 		})
 
 		// POST /api/v1/boards/:slug/posts/:id/comments/:comment_id/report - Report a comment
-		v1Boards.POST("/:slug/posts/:id/comments/:comment_id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), func(c *gin.Context) {
+		v1Boards.POST("/:slug/posts/:id/comments/:comment_id/report", middleware.JWTAuth(jwtManager), middleware.BanCheck(db), middleware.IPProtection(ipProtectCfg), func(c *gin.Context) {
 			slug := c.Param("slug")
 			postID, err := strconv.Atoi(c.Param("id"))
 			if err != nil {
@@ -4884,8 +4884,8 @@ func main() {
 				return
 			}
 
-			// 신고자 IP
-			sgIP := c.ClientIP()
+			// 신고자 IP (IP Protection 적용 — 지정 멤버/관리자는 치환 IP 기록)
+			sgIP := middleware.GetClientIP(c)
 			now := time.Now()
 
 			// 사유별 1행씩 INSERT (nariya 호환)


### PR DESCRIPTION
## 배경
IP Protection 플러그인(KG_IPPROTECT_LIST/ADMIN_IP)은 글·댓글 작성, 추천·리액션 경로에 적용되나, **신고(report) 경로는 누락**이었음. 신고 핸들러가 `IPProtection` 미들웨어 없이 `sgIP := c.ClientIP()` 로 실제 IP 를 `g5_na_singo.sg_ip` 에 기록 → 지정 보호 멤버(예: google_7d27080e)·super admin 도 **신고 시 실IP가 남음**.

## 변경 (글/댓글 작성 경로와 동일 패턴)
- `POST /:slug/posts/:id/report` + `.../comments/:comment_id/report` 라우트에 `middleware.IPProtection(ipProtectCfg)` 추가 (protected_ip 컨텍스트 주입).
- `sgIP := c.ClientIP()` → `middleware.GetClientIP(c)` (2곳) — 지정 멤버/관리자는 치환 IP, 그 외 실IP 그대로.

## 검증
- `go build ./cmd/api/` OK, gofmt clean.
- 무영향: 비지정 멤버는 GetClientIP 가 c.ClientIP() 로 폴백 → 동작 동일.

## 비고
- 배너 클릭로그(banner_handler.go:53)도 c.ClientIP() 사용하나 분석용 + v2 method 핸들러라 이번 범위서 제외(선택 후속).
- 4시 배포 묶음(backend) 합류.