### PR TITLE
fix(comments): v1 댓글 작성 경로에 '댓글 비활성화' 강제 추가

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3102,6 +3102,18 @@ func main() {
 			phaseDurations["board_lookup"] = time.Since(phaseStart)
 			phaseStart = time.Now()
 
+			// 댓글 비활성화(읽기 전용) 글이면 작성 차단. admin 이 wr_option 에 comments_disabled 를
+			// 설정 → frontend UI/v2 핸들러는 막지만 v1 경로엔 강제가 누락돼 직접 호출 시 우회 가능했음.
+			{
+				var parentWrOption string
+				db.Table("g5_write_"+slug).Select("wr_option").
+					Where("wr_id = ? AND wr_is_comment = 0", postID).Scan(&parentWrOption)
+				if strings.Contains(parentWrOption, "comments_disabled") {
+					c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "본 게시물은 댓글이 비활성화되어 있습니다."})
+					return
+				}
+			}
+
 			// 요청 바디 파싱
 			var req struct {
 				Content  string `json:"content" binding:"required"`


### PR DESCRIPTION
## 문제
글별 **댓글 비활성화(읽기 전용)** — admin(level≥10)이 `wr_option` 에 `comments_disabled` 토큰 설정 — 가 **frontend UI**(폼/목록 숨김)와 **v2 댓글 핸들러**(handler.go:872, 403)에선 막히지만, **프론트가 실제 사용하는 v1 경로** `POST /api/v1/boards/:slug/posts/:id/comments`(main.go) 엔 강제가 누락. 따라서:
- UI는 댓글 폼을 숨기지만,
- **v1 API 를 직접 호출하면 비활성화된 글에도 댓글이 작성됨**(우회). 최고관리자가 읽기전용으로 막아도 서버에서 실제로 막히지 않음.

## 변경
v1 댓글 작성 핸들러의 board lookup 직후, 부모 글 `wr_option` 을 조회해 `comments_disabled` 포함 시 **403 "본 게시물은 댓글이 비활성화되어 있습니다."** 로 차단. v2 핸들러와 동일 정책·메시지.

```go
var parentWrOption string
db.Table("g5_write_"+slug).Select("wr_option").
    Where("wr_id = ? AND wr_is_comment = 0", postID).Scan(&parentWrOption)
if strings.Contains(parentWrOption, "comments_disabled") {
    c.JSON(http.StatusForbidden, gin.H{"success": false, "error": "본 게시물은 댓글이 비활성화되어 있습니다."}); return
}
```

## 검증
- `go build ./cmd/api/` OK, gofmt clean.
- 비활성화 아닌 글은 영향 없음(빈 wr_option → 통과). admin 설정 로직은 기존 그대로(변경 없음).

## 비고
- 4시 backend 배포 묶음 합류. 배포 후 비활성화 글에 v1 API 댓글 시도 → 403 확인 권장.