### PR TITLE
feat(disciplinelog): 읽기 API에 회원 공개 사유(member_reason) 노출

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -34,6 +34,7 @@ type singoRow struct {
 	AdminDisciplineDays    int       `gorm:"column:admin_discipline_days"`
 	AdminDisciplineType    string    `gorm:"column:admin_discipline_type"`
 	AdminDisciplineDetail  *string   `gorm:"column:admin_discipline_detail"`
+	AdminMemberReason      *string   `gorm:"column:admin_member_reason"`
 	TargetTitle            *string   `gorm:"column:target_title"`
 	AdminDatetime          time.Time `gorm:"column:admin_datetime"`
 }
@@ -49,6 +50,7 @@ type singoReportGroup struct {
 	AggDays     int            // 최댓값(가장 무거운 제재, permanentDays=영구 형태)
 	AggType     string         // 합집합 제재 유형(원본 토큰 "level,access")
 	AggDetail   string         // 항목 메모 합침(기록/소명용)
+	MemberReason string        // 회원 공개 사유(대상 단위 단일값, 첫 비어있지 않은 값)
 	ReportCount int            // 콘텐츠 단위 수
 	// URL 대표(첫 항목)
 	SgTable  string
@@ -77,6 +79,7 @@ type disciplineData struct {
 	PenaltyType     []string       `json:"penalty_type"`
 	SgTypes         []int          `json:"sg_types"`
 	Content         string         `json:"content,omitempty"`
+	MemberReason    string         `json:"member_reason,omitempty"` // 회원 공개 사유 (운영자 입력 시에만)
 	ReportedItems   []reportedItem `json:"reported_items"`
 	IsBulk          bool           `json:"is_bulk"`
 	ReportedURL     string         `json:"reported_url,omitempty"`
@@ -98,7 +101,7 @@ func runProcessApprovedReports(db *gorm.DB) (*ProcessReportsResult, error) {
 	if err := db.Raw(`
 		SELECT target_mb_id, sg_table, sg_id, sg_parent,
 			admin_discipline_reasons, admin_discipline_days,
-			admin_discipline_type, admin_discipline_detail,
+			admin_discipline_type, admin_discipline_detail, admin_member_reason,
 			target_title, admin_datetime
 		FROM g5_na_singo
 		WHERE admin_approved = 1 AND processed = 0
@@ -151,6 +154,10 @@ func groupApprovedRows(rows []singoRow) []*singoReportGroup {
 		}
 		if g.TargetTitle == nil && r.TargetTitle != nil && *r.TargetTitle != "" {
 			g.TargetTitle = r.TargetTitle
+		}
+		// 회원 공개 사유: 대상 단위 단일값 — 첫 비어있지 않은 값 채택(메모처럼 합치지 않음)
+		if g.MemberReason == "" && r.AdminMemberReason != nil && *r.AdminMemberReason != "" {
+			g.MemberReason = *r.AdminMemberReason
 		}
 
 		cKey := fmt.Sprintf("%s/%d/%d", r.SgTable, r.SgID, r.SgParent)
@@ -295,6 +302,7 @@ func processReportGroup(db *gorm.DB, group *singoReportGroup, now time.Time) err
 			var err error
 			wrID, err = createDisciplineLogPost(tx, targetMbID, targetNick, sgTypesArray,
 				group.AggDays, group.AggType, disciplineDetail,
+				group.MemberReason,
 				group.SgTable, group.SgID, group.SgParent, group.ReportCount,
 				items, isBulk, now)
 			if err != nil {
@@ -523,6 +531,7 @@ func createDisciplineLogPost(
 	sgTypes []int,
 	disciplineDays int,
 	disciplineType, disciplineDetail string,
+	memberReason string,
 	sgTable string, sgID, sgParent, reportCount int,
 	items []reportedItem,
 	isBulk bool,
@@ -563,6 +572,7 @@ func createDisciplineLogPost(
 		PenaltyType:     penaltyType,
 		SgTypes:         sgTypes,
 		Content:         stripTags(disciplineDetail),
+		MemberReason:    memberReason,
 		ReportedItems:   items,
 		IsBulk:          isBulk,
 		ReportedURL:     reportedPath,

--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -42,16 +42,16 @@ type singoRow struct {
 // singoReportGroup은 (피신고자, 처리일) 단위 묶음 → disciplinelog 글 1개.
 // Items는 콘텐츠 단위(sg_id)별 제재 메타데이터를 각자 보유하고, Agg* 는 글 레벨 집계값.
 type singoReportGroup struct {
-	TargetMbID  string
-	DateKey     string
-	TargetTitle *string
-	Items       []reportedItem // 콘텐츠 단위별(항목별 사유/일수/유형/메모 포함)
-	AggReasons  []int          // 합집합 사유 코드
-	AggDays     int            // 최댓값(가장 무거운 제재, permanentDays=영구 형태)
-	AggType     string         // 합집합 제재 유형(원본 토큰 "level,access")
-	AggDetail   string         // 항목 메모 합침(기록/소명용)
-	MemberReason string        // 회원 공개 사유(대상 단위 단일값, 첫 비어있지 않은 값)
-	ReportCount int            // 콘텐츠 단위 수
+	TargetMbID   string
+	DateKey      string
+	TargetTitle  *string
+	Items        []reportedItem // 콘텐츠 단위별(항목별 사유/일수/유형/메모 포함)
+	AggReasons   []int          // 합집합 사유 코드
+	AggDays      int            // 최댓값(가장 무거운 제재, permanentDays=영구 형태)
+	AggType      string         // 합집합 제재 유형(원본 토큰 "level,access")
+	AggDetail    string         // 항목 메모 합침(기록/소명용)
+	MemberReason string         // 회원 공개 사유(대상 단위 단일값, 첫 비어있지 않은 값)
+	ReportCount  int            // 콘텐츠 단위 수
 	// URL 대표(첫 항목)
 	SgTable  string
 	SgID     int

--- a/internal/handler/v2/discipline_log_handler.go
+++ b/internal/handler/v2/discipline_log_handler.go
@@ -35,6 +35,7 @@ type DisciplineLogContent struct {
 	SgTypes         []int          `json:"sg_types"`
 	ReportedItems   []ReportedItem `json:"reported_items,omitempty"`
 	Content         string         `json:"content,omitempty"`
+	MemberReason    string         `json:"member_reason,omitempty"` // 회원 공개 사유 (운영자 입력 시 상세에 노출)
 }
 
 // ReportedItem represents a reported post or comment.
@@ -139,6 +140,7 @@ type DisciplineLogDetail struct {
 	ViolationTypes  []ViolationType `json:"violation_types"`
 	ReportedItems   []ReportedItem  `json:"reported_items,omitempty"`
 	Memo            string          `json:"memo,omitempty"`
+	MemberReason    string          `json:"member_reason,omitempty"` // 회원 공개 사유 (운영자 입력 시에만 노출)
 	CreatedBy       string          `json:"created_by"`
 	CreatedAt       string          `json:"created_at"`
 	ClaimPostID     *int            `json:"claim_post_id,omitempty"`
@@ -404,6 +406,7 @@ func (h *DisciplineLogHandler) GetDetail(c *gin.Context) {
 		PenaltyDateTo:   penaltyDateTo,
 		ViolationTypes:  violations,
 		ReportedItems:   reportedItems,
+		MemberReason:    data.MemberReason,
 		CreatedBy:       post.MbID,
 		CreatedAt:       post.WrDatetime.Format("2006-01-02 15:04:05"),
 	}


### PR DESCRIPTION
## 개요
disciplinelog 읽기 API 노출 + 크론 처리 시 `member_reason` 기록.

## 변경
- 읽기 API(`GET /api/v1/discipline-logs/:id`): `wr_content.member_reason` → 응답 노출
- 크론(`report_process.go`): `g5_na_singo.admin_member_reason`을 대상 단위 단일값으로 채택 → `wr_content.member_reason` 기록 (메모처럼 합치지 않음)

## 마이그레이션
damoang-backend#108의 `admin_member_reason` 컬럼 필요 — **운영 RDS에 이미 적용 완료**.

## 연관
쓰기 damoang-backend#108 · 화면 angple#1640 · 입력 damoang-ops#90

## 검증
`go build ./internal/cron/`, `./internal/handler/v2/` 통과