### PR TITLE
feat(db): GORM dbresolver no-op 도입 (read/write 분리 인프라)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -65,6 +65,7 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	gormlogger "gorm.io/gorm/logger"
+	"gorm.io/plugin/dbresolver"
 )
 
 // @title           Angple Backend API
@@ -6110,6 +6111,33 @@ func initDB(cfg *config.Config) (*gorm.DB, error) {
 	if os.Getenv("OTEL_ENABLED") == "true" {
 		if pluginErr := db.Use(otelgorm.NewPlugin()); pluginErr != nil {
 			log.Printf("[WARN] otelgorm plugin registration failed: %v", pluginErr)
+		}
+	}
+
+	// dbresolver: read/write 분리 인프라.
+	// reader replica 가 별도로 설정되지 않은 경우(reader DSN == writer DSN)에는
+	// Register 를 호출하지 않아 replica 커넥션 풀조차 생성하지 않는다(완전 no-op).
+	// 2027 RDS 갱신 시 reader replica 추가에 대비한 사전 인프라.
+	readerDSN := cfg.Database.GetReaderDSN()
+	writerDSN := cfg.Database.GetDSN()
+	if readerDSN == writerDSN {
+		log.Printf("[INFO] dbresolver skipped: reader=writer (no-op)")
+	} else {
+		resolverLifetime := time.Duration(cfg.Database.ConnMaxLifetime) * time.Second
+		if resolverLifetime > 5*time.Minute {
+			resolverLifetime = 5 * time.Minute
+		}
+		resolver := dbresolver.Register(dbresolver.Config{
+			Replicas:          []gorm.Dialector{mysql.Open(readerDSN)},
+			TraceResolverMode: true,
+		}).
+			SetMaxIdleConns(cfg.Database.MaxIdleConns).
+			SetMaxOpenConns(cfg.Database.MaxOpenConns).
+			SetConnMaxLifetime(resolverLifetime)
+		if resolverErr := db.Use(resolver); resolverErr != nil {
+			log.Printf("[WARN] dbresolver registration failed (writer-only 로 계속): %v", resolverErr)
+		} else {
+			log.Printf("[INFO] dbresolver enabled: reader replica 활성")
 		}
 	}
 

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -8,7 +8,9 @@ server:
 
 database:
   host: ""  # DB_HOST 환경변수
+  reader_host: ""  # 비우면 writer(host) 재사용 — read/write 분리 미사용 (no-op)
   port: 3306
+  reader_port: 0   # 0이면 port 재사용
   user: ""  # DB_USER 환경변수
   password: ""  # DB_PASSWORD 환경변수
   dbname: angple_db

--- a/configs/config.docker.yaml
+++ b/configs/config.docker.yaml
@@ -8,7 +8,9 @@ server:
 
 database:
   host: mysql
+  reader_host: ""  # 비우면 writer(host) 재사용 — read/write 분리 미사용 (no-op)
   port: 3306
+  reader_port: 0   # 0이면 port 재사용
   user: ""        # → DB_USER (docker-compose environment:)
   password: ""    # → DB_PASSWORD (docker-compose environment:)
   dbname: ""      # → DB_NAME (docker-compose environment:)

--- a/configs/config.k3s.yaml
+++ b/configs/config.k3s.yaml
@@ -5,7 +5,9 @@ server:
 
 database:
   host: damoang-g5-prd.cluster-cduqes60oxt0.ap-northeast-2.rds.amazonaws.com
+  reader_host: ""  # 비우면 writer(host) 재사용 — read/write 분리 미사용 (no-op)
   port: 3306
+  reader_port: 0   # 0이면 port 재사용
   user: damoang
   password: ""  # Set via DB_PASSWORD env var
   dbname: damoang

--- a/configs/config.local.yaml
+++ b/configs/config.local.yaml
@@ -8,7 +8,9 @@ server:
 
 database:
   host: 127.0.0.1
+  reader_host: ""  # 비우면 writer(host) 재사용 — read/write 분리 미사용 (no-op)
   port: 3306
+  reader_port: 0   # 0이면 port 재사용
   user: ""        # → DB_USER (.env)
   password: ""    # → DB_PASSWORD (.env)
   dbname: ""      # → DB_NAME (.env)

--- a/configs/config.staging.yaml
+++ b/configs/config.staging.yaml
@@ -8,7 +8,9 @@ server:
 
 database:
   host: ""  # DB_HOST 환경변수
+  reader_host: ""  # 비우면 writer(host) 재사용 — read/write 분리 미사용 (no-op)
   port: 3306
+  reader_port: 0   # 0이면 port 재사용
   user: ""  # DB_USER 환경변수
   password: ""  # DB_PASSWORD 환경변수
   dbname: angple_db

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
+	gorm.io/plugin/dbresolver v1.6.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -327,3 +327,5 @@ gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
 gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 gorm.io/gorm v1.31.1 h1:7CA8FTFz/gRfgqgpeKIBcervUn3xSyPUmr6B2WXJ7kg=
 gorm.io/gorm v1.31.1/go.mod h1:XyQVbO2k6YkOis7C2437jSit3SsDK72s7n7rsSHd+Gs=
+gorm.io/plugin/dbresolver v1.6.2 h1:F4b85TenghUeITqe3+epPSUtHH7RIk3fXr5l83DF8Pc=
+gorm.io/plugin/dbresolver v1.6.2/go.mod h1:tctw63jdrOezFR9HmrKnPkmig3m5Edem9fdxk9bQSzM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,9 @@ type DatabaseConfig struct {
 	User            string `yaml:"user"`
 	Password        string `yaml:"password"`
 	DBName          string `yaml:"dbname"`
+	ReaderHost      string `yaml:"reader_host"` // 비어 있으면 writer(Host) 재사용 — read/write 분리 미사용
 	Port            int    `yaml:"port"`
+	ReaderPort      int    `yaml:"reader_port"` // 0이면 Port 재사용
 	MaxIdleConns    int    `yaml:"max_idle_conns"`
 	MaxOpenConns    int    `yaml:"max_open_conns"`
 	ConnMaxLifetime int    `yaml:"conn_max_lifetime"`
@@ -136,6 +138,13 @@ func overrideFromEnv(cfg *Config) {
 	}
 	if dbname := os.Getenv("DB_NAME"); dbname != "" {
 		cfg.Database.DBName = dbname
+	}
+	// Reader replica (선택) — 미설정 시 writer 재사용
+	if readerHost := os.Getenv("DB_READER_HOST"); readerHost != "" {
+		cfg.Database.ReaderHost = readerHost
+	}
+	if readerPort := os.Getenv("DB_READER_PORT"); readerPort != "" {
+		_, _ = fmt.Sscanf(readerPort, "%d", &cfg.Database.ReaderPort) //nolint:errcheck // 파싱 실패 시 기본값 유지
 	}
 
 	// Redis 설정
@@ -225,6 +234,26 @@ func (c *DatabaseConfig) GetDSN() string {
 		c.Password,
 		c.Host,
 		c.Port,
+		c.DBName,
+	)
+}
+
+// GetReaderDSN reader(replica) DSN 문자열 생성.
+// ReaderHost 가 비어 있으면 GetDSN() 을 그대로 반환한다(no-op = writer 재사용).
+// ReaderHost 가 설정된 경우에만 host/port 를 reader 로 치환하며, 포맷은 GetDSN() 과 동일하다.
+func (c *DatabaseConfig) GetReaderDSN() string {
+	if c.ReaderHost == "" {
+		return c.GetDSN()
+	}
+	port := c.ReaderPort
+	if port == 0 {
+		port = c.Port
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&loc=Asia%%2FSeoul&sql_mode=''&interpolateParams=true",
+		c.User,
+		c.Password,
+		c.ReaderHost,
+		port,
 		c.DBName,
 	)
 }


### PR DESCRIPTION
## 목적

2027년 RDS RI 갱신 시 reader replica 추가를 대비해 GORM `dbresolver` 기반 read/write 분리 인프라를 미리 깔아 둡니다. 이번 PR은 **인프라만 도입**하며 reader endpoint = writer endpoint 이므로 **동작 변화가 전혀 없습니다(no-op)**.

## 변경 사항

- `internal/config/config.go`
  - `DatabaseConfig` 에 `ReaderHost`(`reader_host`), `ReaderPort`(`reader_port`) 추가
  - `GetReaderDSN()` 추가: `ReaderHost` 가 비어 있으면 `GetDSN()` 을 그대로 반환(no-op), 설정된 경우에만 host/port 를 reader 로 치환 (DSN 포맷은 `GetDSN()` 과 동일)
  - `overrideFromEnv()` 에 `DB_READER_HOST`, `DB_READER_PORT` env override 추가
- `cmd/api/main.go` `initDB()`
  - otelgorm 등록 직후 dbresolver 블록 추가
  - `readerDSN == writerDSN` 이면 `dbresolver.Register` 를 **호출하지 않고** 로그만 출력 → replica 커넥션 풀조차 생성하지 않음
  - reader 가 다를 경우에만 `db.Use(dbresolver.Register(...))` 등록, 실패 시 warn 후 writer-only 로 계속
- `configs/config.*.yaml` 5종에 `reader_host: ""`, `reader_port: 0` 기본값 추가

## no-op 보장 근거

- 기본 설정에서 `ReaderHost` 가 비어 있으므로 `GetReaderDSN()` == `GetDSN()`
- 이 경우 `dbresolver.Register` 자체를 호출하지 않아 replica 풀 생성/연결이 없음 (pool 중복 없음)
- 핸들러/repository 의 기존 read/write 쿼리는 일절 변경하지 않음 (`Clauses(dbresolver.Read)` 미사용)

## 위험도

- **위험 0**: reader 미설정 환경에서는 코드 경로가 기존과 동일 (Register 미호출)

## 검증 결과

- `go build ./...` 통과
- `go vet ./internal/config/... ./cmd/api/...` 통과
- `GetReaderDSN()` no-op/reader 치환/`reader_port=0` fallback 단위 검증 통과 (임시 테스트, 미커밋)
- 변경 파일: config / main / yaml / go.mod·go.sum 만 — 핸들러·repository 무변경

## 향후 Phase 2

- reader replica endpoint 확보 후 `DB_READER_HOST`/`DB_READER_PORT` (또는 `reader_host`/`reader_port`) 설정만으로 자동 활성화
- 읽기 전용 쿼리에 `Clauses(dbresolver.Read)` 점진 적용 (별도 PR)
