### PR TITLE
fix(mypage): 프로필 최근댓글 이용제한 근거 댓글 내용 가림

### DIFF
--- a/internal/handler/mypage_handler.go
+++ b/internal/handler/mypage_handler.go
@@ -264,6 +264,32 @@ func (h *MyPageHandler) GetMemberActivity(c *gin.Context) {
 		comments = make([]map[string]interface{}, 0)
 	}
 
+	// #12751: 이용제한 근거 댓글(g5_na_singo discipline)은 프로필 최근댓글에서도
+	// 내용을 가린다(링크는 유지). 게시글 상세와 동작을 통일.
+	if len(comments) > 0 {
+		idsByBoard := make(map[string][]int)
+		for _, cm := range comments {
+			board, _ := cm["bo_table"].(string)
+			wrID, _ := cm["wr_id"].(int)
+			if board != "" && wrID > 0 {
+				idsByBoard[board] = append(idsByBoard[board], wrID)
+			}
+		}
+		disciplined := make(map[string]map[int]bool, len(idsByBoard))
+		for board, ids := range idsByBoard {
+			if set, err := h.myPageRepo.FindDisciplinedCommentIDs(board, ids); err == nil {
+				disciplined[board] = set
+			}
+		}
+		for _, cm := range comments {
+			board, _ := cm["bo_table"].(string)
+			wrID, _ := cm["wr_id"].(int)
+			if set := disciplined[board]; set != nil && set[wrID] {
+				cm["preview"] = "[이용제한 댓글]"
+			}
+		}
+	}
+
 	resp := activityResponse{RecentPosts: posts, RecentComments: comments}
 
 	// 4. Store in Redis (60s TTL, non-blocking)

--- a/internal/repository/gnuboard/mypage_repo.go
+++ b/internal/repository/gnuboard/mypage_repo.go
@@ -22,6 +22,9 @@ type MyPageRepository interface {
 	GetBoardStats(mbID string) ([]gnuboard.BoardStat, error)
 	FindPublicPostsByMember(mbID string, limit int) ([]gnuboard.ActivityPost, error)
 	FindPublicCommentsByMember(mbID string, limit int) ([]gnuboard.ActivityComment, error)
+	// FindDisciplinedCommentIDs returns the set of wr_ids (within the given board)
+	// that are referenced as discipline evidence in g5_na_singo (#12751 masking).
+	FindDisciplinedCommentIDs(boardID string, wrIDs []int) (map[int]bool, error)
 	GetSearchableBoards() ([]searchableBoard, error)
 }
 
@@ -606,4 +609,26 @@ func (r *myPageRepository) FindPublicCommentsByMember(mbID string, limit int) ([
 		return nil, err
 	}
 	return comments, nil
+}
+
+// FindDisciplinedCommentIDs returns wr_ids (within boardID) that are referenced as
+// discipline evidence (g5_na_singo.discipline_log_id IS NOT NULL). Used to mask the
+// content of such comments in the member profile recent-comments list (#12751).
+func (r *myPageRepository) FindDisciplinedCommentIDs(boardID string, wrIDs []int) (map[int]bool, error) {
+	result := make(map[int]bool)
+	if boardID == "" || len(wrIDs) == 0 {
+		return result, nil
+	}
+	var ids []int
+	err := r.db.Raw(
+		"SELECT DISTINCT sg_id FROM g5_na_singo WHERE sg_table = ? AND sg_id IN ? AND discipline_log_id IS NOT NULL",
+		boardID, wrIDs,
+	).Scan(&ids).Error
+	if err != nil {
+		return result, err
+	}
+	for _, id := range ids {
+		result[id] = true
+	}
+	return result, nil
 }


### PR DESCRIPTION
## 문제 (버그게시판 #12751)
회원 프로필의 '최근 댓글' 목록에서, 이용제한 근거로 사용된 댓글 내용이 가림 없이 그대로 노출됩니다. 게시글 상세에서는 가려지는데 프로필 목록에는 미적용.

## 원인
최근댓글 조회(`FindPublicCommentsByMember`)는 **부모 글의 secret/lock만 필터**하고, 댓글 자체의 징계(g5_na_singo) 여부는 확인하지 않아 content가 그대로 반환됩니다.

## 수정 (제보자 의견 반영 — 블러 아님, 단순 치환)
- `mypage_repo.go`: `FindDisciplinedCommentIDs(board, wrIDs)` 추가 — `g5_na_singo WHERE sg_table=? AND sg_id IN ? AND discipline_log_id IS NOT NULL` (게시글 상세 댓글 API와 동일 판별).
- `mypage_handler.GetMemberActivity`: 최근댓글 wr_id를 보드별 배치 조회 → 징계 근거 댓글의 `preview`를 `[이용제한 댓글]`로 치환. **링크 유지**, 일반 댓글 무영향.
- secret 댓글은 기존 쿼리에서 이미 제외됨.

## 배포
- 새벽 4시 게이트, canary 검증(해당 프로필 최근댓글 가림 확인) 후 full.