### PR TITLE
fix(notification): 비공개 보드 글작성 시 팔로우·구독 알림 스킵

### DIFF
--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -345,6 +345,23 @@ func (w *WriteAfterWorker) handleAffiliateEvent(event gnudomain.WriteAfterEvent)
 }
 
 //nolint:gocyclo // Notification routing for post creation is branching-heavy business logic and stays explicit on purpose.
+// isPrivateBoard 는 일반 회원(기본 level 1)이 목록 또는 읽기를 할 수 없는 보드인지 판정한다.
+// bo_list_level 또는 bo_read_level 이 1 을 초과하면(=운영/숨김 보드) 비공개로 본다.
+// 조회 실패 시 false(기존 동작=알림 발송) 로 안전 폴백해 정상 보드 알림이 끊기지 않게 한다.
+func (w *WriteAfterWorker) isPrivateBoard(boTable string) bool {
+	var b struct {
+		ListLevel int `gorm:"column:bo_list_level"`
+		ReadLevel int `gorm:"column:bo_read_level"`
+	}
+	if err := w.db.Table("g5_board").
+		Select("bo_list_level, bo_read_level").
+		Where("bo_table = ?", boTable).
+		Scan(&b).Error; err != nil {
+		return false
+	}
+	return b.ListLevel > 1 || b.ReadLevel > 1
+}
+
 func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 	if w.cacheService != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -367,6 +384,14 @@ func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 	authorName := job.Author
 	if authorName == "" {
 		authorName = job.MemberID
+	}
+
+	// 비공개/숨김 보드(일반 회원이 목록 또는 읽기 불가)는 팔로우·구독 알림을 보내지 않는다.
+	// 접근 못 하는 회원에게 글 존재/링크가 노출되는 문제 방지(예: test, adm 등 운영 보드).
+	// 기준은 permission_checker 의 CanList/CanRead 와 동일 — 기본 회원(level 1)이
+	// list 또는 read 못 하면 비공개로 간주. 캐시 무효화·activity sync 는 위에서 이미 수행됨.
+	if w.isPrivateBoard(job.BoardSlug) {
+		return
 	}
 
 	var followerIDs []string

--- a/internal/worker/write_after_worker.go
+++ b/internal/worker/write_after_worker.go
@@ -344,7 +344,6 @@ func (w *WriteAfterWorker) handleAffiliateEvent(event gnudomain.WriteAfterEvent)
 	return nil
 }
 
-//nolint:gocyclo // Notification routing for post creation is branching-heavy business logic and stays explicit on purpose.
 // isPrivateBoard 는 일반 회원(기본 level 1)이 목록 또는 읽기를 할 수 없는 보드인지 판정한다.
 // bo_list_level 또는 bo_read_level 이 1 을 초과하면(=운영/숨김 보드) 비공개로 본다.
 // 조회 실패 시 false(기존 동작=알림 발송) 로 안전 폴백해 정상 보드 알림이 끊기지 않게 한다.
@@ -362,6 +361,7 @@ func (w *WriteAfterWorker) isPrivateBoard(boTable string) bool {
 	return b.ListLevel > 1 || b.ReadLevel > 1
 }
 
+//nolint:gocyclo // Notification routing for post creation is branching-heavy business logic and stays explicit on purpose.
 func (w *WriteAfterWorker) handlePostCreated(job PostCreatedJob) {
 	if w.cacheService != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
## 문제
운영자가 **비공개/숨김 보드**(예: `test`, `adm`)에 글을 써도, 글쓴이를 팔로우한 회원과 보드 구독자에게 새 글 알림이 발송됩니다. 해당 회원은 그 보드를 목록에서 보거나 읽을 수 없는데도 글의 존재·제목·링크가 알림으로 노출됩니다.

## 원인
`WriteAfterWorker.handlePostCreated` 가 팔로우(`g5_member_follow`)·구독(`g5_board_subscribe`) 알림을 생성할 때 **보드 공개여부를 전혀 확인하지 않습니다.**

## 변경
- `isPrivateBoard(boTable)` 추가: `bo_list_level > 1 OR bo_read_level > 1` 이면 비공개로 판정(기본 회원 level 1 이 목록 또는 읽기 불가). 기존 `permission_checker` 의 CanList/CanRead 와 동일 기준.
- `handlePostCreated` 에서 비공개 보드면 팔로우·구독 알림을 **스킵**(캐시 무효화·activity sync 는 그대로 수행). 조회 실패 시 false 폴백(기존 동작 유지).

## 분석 (판정 기준 근거)
- 전체 158 보드 중 `list_level>1 OR read_level>1` = **16개**: adm, advertiser, archive, governance, banners, logo, main, temp, test, promotion_archive, meet, nerv, monitoring, discord, promotion_my, angreport — 모두 운영/내부/시스템 보드로, 알림 대상에서 빠지는 게 맞습니다.
- `bo_use_search=0`(38개)은 검색 제외일 뿐 정상 열람 가능한 보드도 포함해 너무 넓어 **기준에서 제외**.
- 기준은 리뷰에서 조정 가능합니다(현재 list/read 둘 중 하나라도 제한이면 스킵).

## 검증
- `go build`/`go vet` 통과. 배포 후 test 보드 글 작성 시 팔로워에게 알림 미발송, 일반 보드는 정상 발송 확인 필요.