### PR TITLE
feat(singo): 제재 안내 쪽지에 기간·종료일 표시

### DIFF
--- a/internal/cron/report_process.go
+++ b/internal/cron/report_process.go
@@ -803,6 +803,7 @@ func buildMemoContent(targetMbID, targetNick string, disciplineDays int, discipl
 곧 다시 만나요! 🌈
 
 📝 쉬어가기 상세 내용
+• 기간: %s%s
 • 내 기록 확인: %s
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -818,11 +819,9 @@ func buildMemoContent(targetMbID, targetNick string, disciplineDays int, discipl
 
 🌟 함께 더 좋은 커뮤니티를 만들어가요!
    서로를 배려하는 마음, 그것이 다모앙의 힘입니다 💪`,
-		targetNick, targetNick, disciplineLink, profileLink)
+		targetNick, targetNick, penaltyDay, endDateStr, disciplineLink, profileLink)
 
-	// 실제 PHP 템플릿과의 호환성 유지 (사용하지 않는 플레이스홀더도 포함)
-	_ = penaltyDay
-	_ = endDateStr
+	// 미사용 플레이스홀더 (향후 템플릿 확장 대비)
 	_ = reasonList
 	_ = additionalInfo
 


### PR DESCRIPTION
## 변경
제재 안내 쪽지(`buildMemoContent`)가 기간·종료일을 계산만 하고 버려서, 회원이 쪽지만으로는 제재 기간/만료일을 알 수 없었습니다. 해당 정보를 쪽지 본문에 노출합니다.

## 상세
- `📝 쉬어가기 상세 내용`에 `• 기간: {기간}{ ~ 종료일}` 한 줄 추가
- 값은 `disciplineDays` 단일 출처에서 산출 → disciplinelog 기록·집행과 항상 일치 (별도 입력 없음)
- 영구는 `영구 ~`, 주의는 `주의(이용제한 없음)`로 표기

## 표시 예
`• 기간: 30일 ~ 2026-07-19 15:04:05`

## 배포
- 운영 반영은 정규 배포 윈도우(새벽 4시)에 진행 예정