### PR TITLE
feat(xp): v1 글/댓글 경험치(XP) 적립 추가 (#12812 후속)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3044,6 +3044,26 @@ func main() {
 				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoWritePoint, "글쓰기", tableName, fmt.Sprintf("%d", post.WrID), "@write", pc) //nolint:errcheck
 			}
 
+			// 경험치(XP) 적립 — v2 핸들러와 동일 정책(전역 xpConfig, 기본 글 100).
+			// 비동기·panic 격리. 레벨업 토스트는 프론트가 as_level 변화로 처리하므로 서버 noti 생략.
+			if v2ExpRepo != nil {
+				xpMbID, xpTable, xpWrID := mbID, tableName, post.WrID
+				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("[xp] write XP panic for %s: %v", xpMbID, r)
+						}
+					}()
+					xpConfig, err := v2ExpRepo.GetXPConfig()
+					if err != nil || xpConfig == nil || !xpConfig.WriteEnabled || xpConfig.WriteXP <= 0 {
+						return
+					}
+					if _, err := v2ExpRepo.AddExp(xpMbID, xpConfig.WriteXP, "글쓰기", xpTable, fmt.Sprintf("%d", xpWrID), "@write"); err != nil {
+						log.Printf("[xp] write XP grant failed for %s: %v", xpMbID, err)
+					}
+				}()
+			}
+
 			// 첨부파일 레코드 생성 (g5_board_file)
 			if len(req.Files) > 0 {
 				var boardFiles []gnuboard.G5BoardFile
@@ -3341,6 +3361,26 @@ func main() {
 					pc, _ = pointConfigRepo.GetPointConfig()
 				}
 				_ = gnuPointWriteRepo.AddPoint(mbID, board.BoCommentPoint, "댓글작성", fmt.Sprintf("g5_write_%s", slug), fmt.Sprintf("%d", comment.WrID), "@comment", pc) //nolint:errcheck
+			}
+
+			// 경험치(XP) 적립 — v2 핸들러와 동일 정책(전역 xpConfig, 기본 댓글 50).
+			// 비동기·panic 격리. 레벨업 토스트는 프론트가 as_level 변화로 처리하므로 서버 noti 생략.
+			if v2ExpRepo != nil {
+				xpMbID, xpTable, xpWrID := mbID, fmt.Sprintf("g5_write_%s", slug), comment.WrID
+				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("[xp] comment XP panic for %s: %v", xpMbID, r)
+						}
+					}()
+					xpConfig, err := v2ExpRepo.GetXPConfig()
+					if err != nil || xpConfig == nil || !xpConfig.CommentEnabled || xpConfig.CommentXP <= 0 {
+						return
+					}
+					if _, err := v2ExpRepo.AddExp(xpMbID, xpConfig.CommentXP, "댓글작성", xpTable, fmt.Sprintf("%d", xpWrID), "@comment"); err != nil {
+						log.Printf("[xp] comment XP grant failed for %s: %v", xpMbID, err)
+					}
+				}()
 			}
 
 			// Admin sees full IP, others see masked


### PR DESCRIPTION
## 배경 (#12812)
글·댓글 작성 시 경험치(XP)가 쌓이지 않는다는 제보. 라이브 쓰기 경로(v1)에는 **XP 적립 호출이 아예 없습니다**(v2 핸들러에만 존재하나 v2 경로는 미사용/死). 로그인 XP만 동작하던 이유.

> 포인트는 선행 PR #530(컬럼 매핑 정정)으로 이미 운영 복구됨. 본 PR은 XP를 추가합니다.

## 수정
`cmd/api/main.go` v1 post/comment 핸들러의 포인트 적립 직후에 XP 적립을 추가:
- v2와 동일 정책: 전역 `xpConfig`(기본 글 100 / 댓글 50), `WriteEnabled`/`CommentEnabled` 게이트
- 비동기(goroutine) + panic 격리 → 글쓰기 응답/트랜잭션에 영향 없음
- `@write`/`@comment` 액션으로 `g5_na_xp` 기록 + `as_level` 재계산
- 레벨업 토스트는 프론트가 `as_level` 변화로 처리하므로 서버 noti 생략(스코프 최소화)
- 전체 빌드 통과

## 검증
- canary → 글/댓글 1건 작성 → `g5_na_xp` 에 @write/@comment 행 + `as_level` 갱신 확인 → 4시/승인 운영
- 소급 없음(배포 시점 이후부터)