### PR TITLE
fix(xp): g5_na_xp 로그 xp_datetime 기록 (#12812 후속)

### DIFF
--- a/internal/repository/v2/exp_repo.go
+++ b/internal/repository/v2/exp_repo.go
@@ -244,6 +244,7 @@ func (r *expRepository) AddExp(mbID string, point int, content, relTable, relID,
 		// Insert exp log
 		log := &gnuboard.G5NaXP{
 			MbID:        mbID,
+			XpDatetime:  time.Now(),
 			XpPoint:     point,
 			XpContent:   content,
 			XpRelTable:  relTable,


### PR DESCRIPTION
## 배경
v1 XP 적립(#531) 운영 반영 후, `g5_na_xp` 로그 행의 `xp_datetime` 이 `0000-00-00` 으로 기록됨을 확인. AddExp 가 로그 struct 생성 시 시간을 세팅하지 않는 기존 결함(모든 Go AddExp 호출 공통, 신규 @write/@comment 호출로 표면화).

## 수정
`exp_repo.go` AddExp 의 g5_na_xp 로그 struct에 `XpDatetime: time.Now()` 추가 (AddPoint 의 PoDatetime 과 동일 패턴).
- `as_exp`/`as_level` 적립은 영향 없음 — 로그 행 타임스탬프만 정상화
- XP 내역 시간 정렬/표시 정상화
- 빌드 통과

## 검증
- canary → 글/댓글 1건 → g5_na_xp 신규 행의 xp_datetime 이 현재 시각(KST)으로 기록되는지 확인 → 4시/승인 운영